### PR TITLE
Maven plugin changes

### DIFF
--- a/.github/workflows/native-maven-plugin.yml
+++ b/.github/workflows/native-maven-plugin.yml
@@ -45,7 +45,7 @@ jobs:
             echo "JVM run"
             mvn compile exec:java@java
             echo "Native run"
-            mvn -DskipTests package exec:exec@native
+            mvn -Pnative -DskipTests package exec:exec@native
           popd
       - name: Plugin test (test native)
         run: |
@@ -53,5 +53,5 @@ jobs:
             echo "JVM run"
             mvn test
             echo "Native run"
-            mvn package
+            mvn -Pnative test
           popd

--- a/common/scripts/testAll.sh
+++ b/common/scripts/testAll.sh
@@ -9,5 +9,5 @@ popd
 
 pushd examples/maven
 mvn compile exec:java@java
-mvn test package exec:exec@native
+mvn -Pnative test package exec:exec@native
 popd

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -32,6 +32,42 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>test-native</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skip>false</skip>
+                            <imageName>${imageName}</imageName>
+                            <buildArgs>--no-fallback</buildArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
@@ -77,40 +113,12 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${project.build.directory}/native/${imageName}</executable>
-                            <workingDirectory>${project.build.directory}/native</workingDirectory>
+                            <executable>${project.build.directory}/${imageName}</executable>
+                            <workingDirectory>${project.build.directory}</workingDirectory>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.graalvm.buildtools</groupId>
-                <artifactId>native-maven-plugin</artifactId>
-                <version>${native.maven.plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>build</id>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                        <phase>package</phase>
-                    </execution>
-                    <execution>
-                        <id>test</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <phase>test</phase>
-                    </execution>
-                </executions>
-                <configuration>
-                    <skip>false</skip>
-                    <imageName>${imageName}</imageName>
-                    <buildArgs>--no-fallback</buildArgs>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
 

--- a/native-maven-plugin/README.md
+++ b/native-maven-plugin/README.md
@@ -9,35 +9,45 @@ Maven plugin for GraalVM Native Image building
 > More information is available [here](../common/docs/GRAALVM_SETUP.md).
 
 
-Add `native-maven-plugin` into the `<plugins>` section of the `pom.xml` file:
+Add the following profile to your `pom.xml` file:
 
 ```xml
-<plugin>
-    <groupId>org.graalvm.buildtools</groupId>
-    <artifactId>native-maven-plugin</artifactId>
-    <version>${current_plugin_version}</version>
-    <executions>
-        <execution>
-            <id>build</id>
-            <goals>
-                <goal>build</goal>
-            </goals>
-            <phase>package</phase>
-        </execution>
-        <execution>
-            <id>test</id>
-            <goals>
-                <goal>test</goal>
-            </goals>
-            <phase>test</phase>
-        </execution>
-    </executions>
-    <configuration>
-        <!-- ... -->
-    </configuration>
-</plugin>
+    <profiles>
+        <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>test-native</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <!-- ... -->
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 ```
-You can then build a native executable directly with Maven using the `mvn package` command without running the `native-image` command as a separate step.
+
+You can then build a native executable directly with Maven using the `mvn -Pnative package` command without running the `native-image` command as a separate step.
 
 *You can also take a look at example project [here](../examples/maven).*
 
@@ -58,7 +68,7 @@ In order to use the recommended test listener mode, you need to add following de
 
 The plugin figures out which JAR files it needs to pass to the native image and
 what the executable main class should be. If the heuristics fails with the `no main manifest attribute, in target/<name>.jar` error, the main class should be
-specified in the `<configuration>` node of the plugin. When `mvn package` completes, an executable is ready for use, generated in the _target_ directory of the project.
+specified in the `<configuration>` node of the plugin. When `mvn -Pnative package` completes, an executable is ready for use, generated in the _target_ directory of the project. Additionally, running `mvn -Pnative test` will also build and run native tests.
 
 ### Maven Plugin Customization
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildMojo.java
@@ -78,7 +78,7 @@ public class NativeBuildMojo extends AbstractNativeMojo {
     @Parameter(defaultValue = "${plugin}", readonly = true) // Maven 3 only
     private PluginDescriptor plugin;
 
-    @Parameter(defaultValue = "${project.build.directory}/" + Utils.NATIVE_IMAGE_OUTPUT_FOLDER, property = "outputDir", required = true)//
+    @Parameter(defaultValue = "${project.build.directory}", property = "outputDir", required = true)//
     private File outputDirectory;
 
     @Parameter(property = "mainClass")
@@ -171,9 +171,7 @@ public class NativeBuildMojo extends AbstractNativeMojo {
     }
 
     private Path getWorkingDirectory() {
-        if (!outputDirectory.exists()) {
-            outputDirectory.mkdirs();
-        }
+        outputDirectory.mkdirs();
         return outputDirectory.toPath();
     }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -81,7 +81,7 @@ public class NativeTestMojo extends AbstractNativeMojo {
         }
 
         String classpath = getClassPath();
-        Path targetFolder = new File(project.getBuild().getDirectory()).toPath().resolve(Utils.NATIVE_IMAGE_OUTPUT_FOLDER);
+        Path targetFolder = new File(project.getBuild().getDirectory()).toPath();
         targetFolder.toFile().mkdirs();
 
         logger.info("====================");


### PR DESCRIPTION
Document Maven native profile (closes #36)
Use test-native and build-native execution ids (closes #37)
Maven plugin : move back the application executable to target (closes #38)