### PR TITLE
Introduce and migrate to a plugin configuration mechanism.

### DIFF
--- a/common/junit-platform-native/build.gradle
+++ b/common/junit-platform-native/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: junit_jupiter_version
     testImplementation(platform('org.junit:junit-bom:' + junit_jupiter_version))
     testImplementation('org.junit.jupiter:junit-jupiter')
+    testImplementation('org.junit.vintage:junit-vintage-engine')
 }
 
 apply from: "gradle/native-image-testing.gradle"

--- a/common/junit-platform-native/gradle/native-image-testing.gradle
+++ b/common/junit-platform-native/gradle/native-image-testing.gradle
@@ -37,13 +37,13 @@ afterEvaluate {
                 "-cp", classpath,
                 "--no-fallback",
                 "--features=org.graalvm.junit.platform.JUnitPlatformFeature",
-                "-H:Name=native-image-tests.bin",
-                "-H:Class=org.graalvm.junit.platform.NativeImageJUnitLauncher"
+                "-H:Name=native-image-tests",
+                "-H:Class=org.graalvm.junit.platform.NativeImageJUnitLauncher",
         ]
         if (project.hasProperty("agent")) {
             if (!new File("${buildDir}/agentOutput/").exists()) {
                 throw new GradleException("Agent output missing when -Pagent is set.\n" +
-                        "You need to run `./gradlew -Pagent test` first.")
+                        "You need to run `gradle -Pagent test` first.")
             }
 
             args << "-H:ConfigurationFileDirectories=${buildDir}/agentOutput"
@@ -59,5 +59,5 @@ afterEvaluate {
 tasks.register("nativeTest", Exec) {
     dependsOn nativeTestBuild
     workingDir = "${buildDir}"
-    executable = "./native-image-tests.bin"
+    executable = "${buildDir}/native-image-tests"
 }

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/JUnitPlatformFeature.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/JUnitPlatformFeature.java
@@ -40,10 +40,10 @@
  */
 package org.graalvm.junit.platform;
 
+import org.graalvm.junit.platform.config.core.PluginConfigProvider;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
-import org.graalvm.nativeimage.hosted.RuntimeReflection;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.support.descriptor.ClassSource;
@@ -60,58 +60,29 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("unused")
 public final class JUnitPlatformFeature implements Feature {
 
-    final boolean debug = System.getProperty("debug") != null;
+    public final boolean debug = System.getProperty("debug") != null;
+
+    private static final NativeImageConfigurationImpl nativeImageConfigImpl = new NativeImageConfigurationImpl();
+    private final ServiceLoader<PluginConfigProvider> extensionConfigProviders = ServiceLoader.load(PluginConfigProvider.class);
 
     @Override
     public void duringSetup(DuringSetupAccess access) {
-        try {
-            RuntimeReflection.register(org.junit.platform.commons.annotation.Testable.class.getMethods());
-            RuntimeReflection.register(Class.forName("org.junit.jupiter.params.ParameterizedTestExtension").getDeclaredMethods());
-            RuntimeReflection.registerForReflectiveInstantiation(Class.forName("org.junit.jupiter.params.ParameterizedTestExtension"));
-            RuntimeReflection.register(Class.forName("org.junit.jupiter.params.provider.CsvArgumentsProvider").getMethods());
-            RuntimeReflection.register(Class.forName("org.junit.jupiter.params.provider.CsvArgumentsProvider").getDeclaredMethods());
-            RuntimeReflection.registerForReflectiveInstantiation(Class.forName("org.junit.jupiter.params.provider.CsvArgumentsProvider"));
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Missing some JUnit Platform classes for runtime reflection configuration. \n" +
-                    "Check if JUnit Platform is on your classpath or if that version is supported. \n" +
-                    "Original error: " + e);
-        }
+        forEachProvider(p -> p.onLoad(nativeImageConfigImpl));
     }
 
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.vintage.engine.support.UniqueIdReader");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.vintage.engine.support.UniqueIdStringifier");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.platform.launcher.core.InternalTestPlan");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.platform.commons.util.StringUtils");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.platform.launcher.core.TestExecutionListenerRegistry");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.platform.commons.logging.LoggerFactory$DelegatingLogger");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.platform.launcher.core.EngineDiscoveryOrchestrator");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.platform.launcher.core.LauncherConfigurationParameters");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.platform.commons.logging.LoggerFactory");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.jupiter.engine.config.EnumConfigurationParameterConverter");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.jupiter.engine.descriptor.ClassTestDescriptor");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.platform.engine.UniqueIdFormat");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.jupiter.engine.descriptor.JupiterTestDescriptor");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.jupiter.engine.descriptor.MethodBasedTestDescriptor");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.platform.commons.util.ReflectionUtils");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.jupiter.engine.execution.ConditionEvaluator");
-        RuntimeClassInitialization.initializeAtBuildTime("org.junit.jupiter.engine.execution.ExecutableInvoker");
         RuntimeClassInitialization.initializeAtBuildTime(NativeImageJUnitLauncher.class);
 
         Launcher launcher = LauncherFactory.create();
@@ -136,7 +107,7 @@ public final class JUnitPlatformFeature implements Feature {
 
         // Run a a junit launcher to discover tests and register classes for reflection
         if (debug) {
-            classpath.forEach(path -> System.out.println("[Debug] Found classpath: " + path));
+            classpath.forEach(path -> debug("Found classpath: " + path));
         }
         return DiscoverySelectors.selectClasspathRoots(new HashSet<>(classpath));
 
@@ -163,16 +134,28 @@ public final class JUnitPlatformFeature implements Feature {
     }
 
     private void registerTestClassForReflection(Class<?> clazz) {
-        if (debug) {
-            System.out.println("[Debug] Registering test class for reflection: " + clazz.getName());
+        debug("Registering test class for reflection: %s", clazz.getName());
+        nativeImageConfigImpl.registerAllClassMembersForReflection(clazz);
+        forEachProvider(p -> p.onTestClassRegistered(clazz, nativeImageConfigImpl));
+        Class<?> superClass = clazz.getSuperclass();
+        if (superClass != null && superClass != Object.class) {
+            registerTestClassForReflection(superClass);
         }
-        RuntimeReflection.register(clazz.getDeclaredConstructors());
+    }
 
-        for (Field field : clazz.getDeclaredFields()) {
-            RuntimeReflection.register(field);
+    private void forEachProvider(Consumer<PluginConfigProvider> consumer) {
+        for (PluginConfigProvider provider : extensionConfigProviders) {
+            consumer.accept(provider);
         }
-        for (Method method : clazz.getDeclaredMethods()) {
-            RuntimeReflection.register(method);
+    }
+
+    public static void debug(String format, Object... args) {
+        if (debug()) {
+            System.out.printf("[Debug] " + format + "%n", args);
         }
+    }
+
+    public static boolean debug() {
+        return ImageSingletons.lookup(JUnitPlatformFeature.class).debug;
     }
 }

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/NativeImageConfigurationImpl.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/NativeImageConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -40,46 +40,45 @@
  */
 package org.graalvm.junit.platform;
 
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.TestPlan;
-import org.junit.platform.reporting.legacy.LegacyReportingUtils;
+import org.graalvm.junit.platform.config.core.NativeImageConfiguration;
+import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
-import java.io.PrintWriter;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
 
-@SuppressWarnings("unused")
-public class PrintTestExecutionListener implements TestExecutionListener {
+class NativeImageConfigurationImpl implements NativeImageConfiguration {
 
-    TestPlan testPlan;
-    final PrintWriter out;
-
-    public PrintTestExecutionListener() {
-        out = new PrintWriter(System.out);
-    }
-
-    public PrintTestExecutionListener(PrintWriter out) {
-        this.out = out;
+    @Override
+    public void registerForReflection(Class<?>... classes) {
+        RuntimeReflection.register(classes);
     }
 
     @Override
-    public void testPlanExecutionStarted(TestPlan testPlan) {
-        this.testPlan = testPlan;
+    public void registerForReflection(Executable... methods) {
+        RuntimeReflection.register(methods);
     }
 
     @Override
-    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-        printTest(testIdentifier, "SKIPPED: " + reason);
+    public void registerForReflection(Field... fields) {
+        RuntimeReflection.register(fields);
     }
 
     @Override
-    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-        printTest(testIdentifier, testExecutionResult.getStatus().name());
-    }
-
-    private void printTest(TestIdentifier testIdentifier, String status) {
-        if (testIdentifier.getParentId().isPresent() && !testIdentifier.isContainer()) {
-            out.println(LegacyReportingUtils.getClassName(testPlan, testIdentifier) + " > " + testIdentifier.getDisplayName() + " " + status + "\n");
+    public void initializeAtBuildTime(String... classNames) {
+        for (String className : classNames) {
+            Class<?> clazz;
+            try {
+                clazz = Class.forName(className);
+                initializeAtBuildTime(clazz);
+            } catch (ClassNotFoundException e) {
+                JUnitPlatformFeature.debug("[Native Image Configuration] Failed to register class for build time initialization: %s Reason: %s", className, e);
+            }
         }
+    }
+
+    @Override
+    public void initializeAtBuildTime(Class<?>... classes) {
+        RuntimeClassInitialization.initializeAtBuildTime(classes);
     }
 }

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/UniqueIdTrackingTestExecutionListener.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/UniqueIdTrackingTestExecutionListener.java
@@ -58,7 +58,7 @@ import java.util.List;
  * that were executed and generates a file (currently hard coded to
  * {@code ./build/test_ids.txt} with Gradle or {@code ./target/test_ids.txt} with Maven)
  * that contains test IDs which can be passed to custom launcher to select exactly those test classes.
- *
+ * <p>
  * This file should be replaced with org.junit.platform.launcher.listeners.UniqueIdTrackingListener,
  * once junit-platform-launcher version 1.8 gets released.
  *
@@ -72,7 +72,16 @@ public class UniqueIdTrackingTestExecutionListener implements TestExecutionListe
     private final List<String> uniqueIds = new ArrayList<>();
 
     @Override
+    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+        addTest(testIdentifier);
+    }
+
+    @Override
     public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+        addTest(testIdentifier);
+    }
+
+    private void addTest(TestIdentifier testIdentifier) {
         if (testIdentifier.isTest()) {
             this.uniqueIds.add(testIdentifier.getUniqueId());
         }

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/core/NativeImageConfiguration.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/core/NativeImageConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,48 +38,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.graalvm.junit.platform;
+package org.graalvm.junit.platform.config.core;
 
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.TestPlan;
-import org.junit.platform.reporting.legacy.LegacyReportingUtils;
+import org.graalvm.junit.platform.JUnitPlatformFeature;
 
-import java.io.PrintWriter;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
 
-@SuppressWarnings("unused")
-public class PrintTestExecutionListener implements TestExecutionListener {
+public interface NativeImageConfiguration {
 
-    TestPlan testPlan;
-    final PrintWriter out;
+    void registerForReflection(Class<?>... classes);
 
-    public PrintTestExecutionListener() {
-        out = new PrintWriter(System.out);
-    }
+    void registerForReflection(Executable... methods);
 
-    public PrintTestExecutionListener(PrintWriter out) {
-        this.out = out;
-    }
+    void registerForReflection(Field... fields);
 
-    @Override
-    public void testPlanExecutionStarted(TestPlan testPlan) {
-        this.testPlan = testPlan;
-    }
-
-    @Override
-    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-        printTest(testIdentifier, "SKIPPED: " + reason);
-    }
-
-    @Override
-    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-        printTest(testIdentifier, testExecutionResult.getStatus().name());
-    }
-
-    private void printTest(TestIdentifier testIdentifier, String status) {
-        if (testIdentifier.getParentId().isPresent() && !testIdentifier.isContainer()) {
-            out.println(LegacyReportingUtils.getClassName(testPlan, testIdentifier) + " > " + testIdentifier.getDisplayName() + " " + status + "\n");
+    default void registerAllClassMembersForReflection(Class<?>... classes) {
+        for (Class<?> clazz : classes) {
+            JUnitPlatformFeature.debug("[Native Image Configuration] Registering for reflection: %s", clazz.getName());
+            registerForReflection(clazz);
+            registerForReflection(clazz.getDeclaredConstructors());
+            registerForReflection(clazz.getDeclaredMethods());
+            registerForReflection(clazz.getDeclaredFields());
         }
     }
+
+    void initializeAtBuildTime(String... classNames);
+
+    void initializeAtBuildTime(Class<?>... classes);
 }

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/core/PluginConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/core/PluginConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,48 +38,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.graalvm.junit.platform;
+package org.graalvm.junit.platform.config.core;
 
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.TestPlan;
-import org.junit.platform.reporting.legacy.LegacyReportingUtils;
+public interface PluginConfigProvider {
 
-import java.io.PrintWriter;
+    void onLoad(NativeImageConfiguration config);
 
-@SuppressWarnings("unused")
-public class PrintTestExecutionListener implements TestExecutionListener {
+    void onTestClassRegistered(Class<?> testClass, NativeImageConfiguration registry);
 
-    TestPlan testPlan;
-    final PrintWriter out;
-
-    public PrintTestExecutionListener() {
-        out = new PrintWriter(System.out);
-    }
-
-    public PrintTestExecutionListener(PrintWriter out) {
-        this.out = out;
-    }
-
-    @Override
-    public void testPlanExecutionStarted(TestPlan testPlan) {
-        this.testPlan = testPlan;
-    }
-
-    @Override
-    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-        printTest(testIdentifier, "SKIPPED: " + reason);
-    }
-
-    @Override
-    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-        printTest(testIdentifier, testExecutionResult.getStatus().name());
-    }
-
-    private void printTest(TestIdentifier testIdentifier, String status) {
-        if (testIdentifier.getParentId().isPresent() && !testIdentifier.isContainer()) {
-            out.println(LegacyReportingUtils.getClassName(testPlan, testIdentifier) + " > " + testIdentifier.getDisplayName() + " " + status + "\n");
-        }
-    }
 }

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.junit.platform.config.jupiter;
+
+import org.graalvm.junit.platform.config.core.NativeImageConfiguration;
+import org.graalvm.junit.platform.config.core.PluginConfigProvider;
+import org.graalvm.junit.platform.config.util.AnnotationUtils;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.IndicativeSentencesGeneration;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.aggregator.AggregateWith;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.graalvm.junit.platform.JUnitPlatformFeature.debug;
+
+public class JupiterConfigProvider implements PluginConfigProvider {
+
+    @Override
+    public void onLoad(NativeImageConfiguration config) {
+        String[] buildTimeInitializedClasses = new String[]{
+                "org.junit.jupiter.engine.config.EnumConfigurationParameterConverter",
+                "org.junit.jupiter.engine.descriptor.ClassTestDescriptor",
+                "org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor",
+                "org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor",
+                "org.junit.jupiter.engine.descriptor.JupiterTestDescriptor",
+                "org.junit.jupiter.engine.descriptor.JupiterTestDescriptor$1",
+                "org.junit.jupiter.engine.descriptor.MethodBasedTestDescriptor",
+                "org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor",
+                "org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor",
+                "org.junit.jupiter.engine.execution.ConditionEvaluator",
+                "org.junit.jupiter.engine.execution.ExecutableInvoker"
+        };
+        for (String className : buildTimeInitializedClasses) {
+            config.initializeAtBuildTime(className);
+        }
+    }
+
+    @Override
+    public void onTestClassRegistered(Class<?> testClass, NativeImageConfiguration registry) {
+        AnnotationUtils.registerClassesFromAnnotationForReflection(testClass, registry, ArgumentsSource.class, ArgumentsSource::value);
+        AnnotationUtils.registerClassesFromAnnotationForReflection(testClass, registry, ExtendWith.class, ExtendWith::value);
+        AnnotationUtils.forEachAnnotatedMethod(testClass, EnumSource.class, (m, annotation) -> handleEnumSource(m, annotation, registry));
+        handleTestOrderer(testClass, registry);
+        AnnotationUtils.registerClassesFromAnnotationForReflection(testClass, registry, DisplayNameGeneration.class, DisplayNameGeneration::value);
+        AnnotationUtils.registerClassesFromAnnotationForReflection(testClass, registry, IndicativeSentencesGeneration.class, IndicativeSentencesGeneration::generator);
+        AnnotationUtils.forEachAnnotatedMethodParameter(testClass, ConvertWith.class, annotation -> registry.registerAllClassMembersForReflection(annotation.value()));
+        AnnotationUtils.forEachAnnotatedMethodParameter(testClass, AggregateWith.class, annotation -> registry.registerAllClassMembersForReflection(annotation.value()));
+        AnnotationUtils.registerClassesFromAnnotationForReflection(testClass, registry, MethodSource.class, JupiterConfigProvider::handleMethodSource);
+        AnnotationUtils.registerClassesFromAnnotationForReflection(testClass, registry, EnabledIf.class, JupiterConfigProvider::handleEnabledIf);
+        AnnotationUtils.registerClassesFromAnnotationForReflection(testClass, registry, DisabledIf.class, JupiterConfigProvider::handleDisabledIf);
+    }
+
+    private static Class<?>[] handleMethodSource(MethodSource annotation) {
+        return handleMethodReference(annotation.value());
+    }
+
+    private static Class<?>[] handleEnabledIf(EnabledIf annotation) {
+        return handleMethodReference(annotation.value());
+    }
+
+    private static Class<?>[] handleDisabledIf(DisabledIf annotation) {
+        return handleMethodReference(annotation.value());
+    }
+
+    private static Class<?>[] handleMethodReference(String... methodNames) {
+        List<Class<?>> classList = new ArrayList<>();
+        for (String methodName : methodNames) {
+            String[] parts = methodName.split("#");
+            /*
+             * If the method used as an argument source resides in a different class than the test class, it must be specified
+             * by the fully qualified class name, followed by a # and the method name
+             */
+            debug("Found method reference: %s", methodName);
+            if (parts.length == 2) {
+                String className = parts[0];
+                debug("Processing method reference from another class: %s", className);
+                try {
+                    classList.add(Class.forName(className));
+                } catch (ClassNotFoundException e) {
+                    debug("Failed to register method reference for reflection: %s Reason: %s", className, e);
+                }
+            } else {
+                debug("Skipping method reference as it originates in the same class as the test: %s", methodName);
+            }
+        }
+        return classList.toArray(new Class<?>[0]);
+    }
+
+    public static void handleEnumSource(Method method, EnumSource source, NativeImageConfiguration registry) {
+        registry.registerAllClassMembersForReflection(source.value());
+        if (method.getParameterCount() > 0) {
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            /* EnumSource annotated methods without an enum in the annotation value must have the enum as the first parameter. */
+            Class<?> enumParameterType = parameterTypes[0];
+            if (enumParameterType.isEnum()) {
+                debug("Registering method enum parameter for reflection. Method: %s Parameter: %s", method, parameterTypes[0]);
+                registry.registerAllClassMembersForReflection(enumParameterType);
+            } else {
+                debug("First parameter of method not an enum - skipping. Method: %s", method);
+            }
+        } else {
+            debug("Method doesn't have at least 1 parameter - skipping enum registration. Method: %s", method);
+        }
+    }
+
+    private static void handleTestOrderer(Class<?> testClass, NativeImageConfiguration registry) {
+        Optional<TestMethodOrder> annotation = AnnotationSupport.findAnnotation(testClass, TestMethodOrder.class);
+        if (annotation.isPresent()) {
+            TestMethodOrder testMethodOrder = annotation.get();
+            Class<?> clazz = testMethodOrder.value();
+            registry.initializeAtBuildTime(clazz);
+        }
+    }
+
+}

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/platform/PlatformConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/platform/PlatformConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,48 +38,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.graalvm.junit.platform;
+package org.graalvm.junit.platform.config.platform;
 
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.TestPlan;
-import org.junit.platform.reporting.legacy.LegacyReportingUtils;
+import org.graalvm.junit.platform.config.core.PluginConfigProvider;
+import org.graalvm.junit.platform.config.core.NativeImageConfiguration;
 
-import java.io.PrintWriter;
-
-@SuppressWarnings("unused")
-public class PrintTestExecutionListener implements TestExecutionListener {
-
-    TestPlan testPlan;
-    final PrintWriter out;
-
-    public PrintTestExecutionListener() {
-        out = new PrintWriter(System.out);
-    }
-
-    public PrintTestExecutionListener(PrintWriter out) {
-        this.out = out;
-    }
+public class PlatformConfigProvider implements PluginConfigProvider {
 
     @Override
-    public void testPlanExecutionStarted(TestPlan testPlan) {
-        this.testPlan = testPlan;
-    }
-
-    @Override
-    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-        printTest(testIdentifier, "SKIPPED: " + reason);
-    }
-
-    @Override
-    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-        printTest(testIdentifier, testExecutionResult.getStatus().name());
-    }
-
-    private void printTest(TestIdentifier testIdentifier, String status) {
-        if (testIdentifier.getParentId().isPresent() && !testIdentifier.isContainer()) {
-            out.println(LegacyReportingUtils.getClassName(testPlan, testIdentifier) + " > " + testIdentifier.getDisplayName() + " " + status + "\n");
+    public void onLoad(NativeImageConfiguration config) {
+        String[] buildTimeInitializedClasses = new String[]{
+                "org.junit.platform.launcher.core.InternalTestPlan",
+                "org.junit.platform.commons.util.StringUtils",
+                "org.junit.platform.launcher.core.TestExecutionListenerRegistry",
+                "org.junit.platform.commons.logging.LoggerFactory$DelegatingLogger",
+                "org.junit.platform.launcher.core.EngineDiscoveryOrchestrator",
+                "org.junit.platform.launcher.core.LauncherConfigurationParameters",
+                "org.junit.platform.commons.logging.LoggerFactory",
+                "org.junit.platform.engine.UniqueIdFormat",
+                "org.junit.platform.commons.util.ReflectionUtils"
+        };
+        for (String className : buildTimeInitializedClasses) {
+            config.initializeAtBuildTime(className);
         }
+
+        try {
+            /* Verify if the core JUnit Platform test class is available on the classpath */
+            Class.forName("org.junit.platform.commons.annotation.Testable");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Missing some JUnit Platform classes for runtime reflection configuration. \n" +
+                    "Check if JUnit Platform is on your classpath or if that version is supported. \n" +
+                    "Original error: " + e);
+        }
+    }
+
+    @Override
+    public void onTestClassRegistered(Class<?> testClass, NativeImageConfiguration registry) {
     }
 }

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/util/AnnotationUtils.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/util/AnnotationUtils.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.junit.platform.config.util;
+
+import org.graalvm.junit.platform.config.core.NativeImageConfiguration;
+import org.graalvm.util.GuardedAnnotationAccess;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Repeatable;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class AnnotationUtils {
+
+    public static <A extends Annotation> void forEachAnnotationOnClassMembers(Class<?> clazz, Class<A> annotationType, Consumer<A> consumer) {
+        for (A annotation : getAnnotations(clazz, annotationType)) {
+            consumer.accept(annotation);
+        }
+
+        forEachMethod(clazz, method -> {
+            for (A annotation : getAnnotations(method, annotationType)) {
+                consumer.accept(annotation);
+            }
+        });
+    }
+
+    public static <A extends Annotation> void forEachAnnotatedMethod(Class<?> clazz, Class<A> annotationType, BiConsumer<Method, A> consumer) {
+        forEachMethod(clazz, method -> {
+            for (A annotation : getAnnotations(method, annotationType)) {
+                consumer.accept(method, annotation);
+            }
+        });
+    }
+
+    public static <A extends Annotation> void forEachAnnotatedMethodParameter(Class<?> clazz, Class<A> annotationType, Consumer<A> consumer) {
+        forEachMethod(clazz, method -> {
+            for (Parameter parameter : method.getParameters()) {
+                for (A annotation: getAnnotations(parameter, annotationType)) {
+                    consumer.accept(annotation);
+                }
+            }
+        });
+    }
+
+    private static void forEachMethod(Class<?> clazz, Consumer<Method> consumer) {
+        for (Method method : clazz.getDeclaredMethods()) {
+            consumer.accept(method);
+        }
+    }
+
+    private static <A extends Annotation> List<A> getAnnotations(AnnotatedElement element, Class<A> annotation) {
+        if (GuardedAnnotationAccess.getAnnotation(annotation, Repeatable.class) != null) {
+            return AnnotationSupport.findRepeatableAnnotations(element, annotation);
+        } else {
+            Optional<A> optionalAnnotation = AnnotationSupport.findAnnotation(element, annotation);
+            List<A> annotationList = new ArrayList<>();
+            optionalAnnotation.ifPresent(annotationList::add);
+            return annotationList;
+        }
+
+    }
+
+    public interface ClassProvider<T extends Annotation> extends Function<T, Class<?>> {
+    }
+
+    public interface ClassArrayProvider<T extends Annotation> extends Function<T, Class<?>[]> {
+    }
+
+    public static <T extends Annotation> void registerClassesFromAnnotationForReflection(Class<?> testClass, NativeImageConfiguration config, Class<T> annotation, ClassArrayProvider<T> classProvider) {
+        forEachAnnotationOnClassMembers(testClass, annotation, a -> {
+            Class<?>[] reflectivelyAccessedClasses = classProvider.apply(a);
+            config.registerAllClassMembersForReflection(reflectivelyAccessedClasses);
+        });
+    }
+
+    public static <T extends Annotation> void registerClassesFromAnnotationForReflection(Class<?> testClass, NativeImageConfiguration config, Class<T> annotation, ClassProvider<T> classProvider) {
+        forEachAnnotationOnClassMembers(testClass, annotation, a -> {
+            Class<?> reflectivelyAccessedClass = classProvider.apply(a);
+            config.registerAllClassMembersForReflection(reflectivelyAccessedClass);
+        });
+    }
+}

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/vintage/VintageConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/vintage/VintageConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,48 +38,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.graalvm.junit.platform;
+package org.graalvm.junit.platform.config.vintage;
 
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.TestPlan;
-import org.junit.platform.reporting.legacy.LegacyReportingUtils;
+import org.graalvm.junit.platform.config.core.NativeImageConfiguration;
+import org.graalvm.junit.platform.config.core.PluginConfigProvider;
 
-import java.io.PrintWriter;
-
-@SuppressWarnings("unused")
-public class PrintTestExecutionListener implements TestExecutionListener {
-
-    TestPlan testPlan;
-    final PrintWriter out;
-
-    public PrintTestExecutionListener() {
-        out = new PrintWriter(System.out);
-    }
-
-    public PrintTestExecutionListener(PrintWriter out) {
-        this.out = out;
-    }
+public class VintageConfigProvider implements PluginConfigProvider {
 
     @Override
-    public void testPlanExecutionStarted(TestPlan testPlan) {
-        this.testPlan = testPlan;
-    }
-
-    @Override
-    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-        printTest(testIdentifier, "SKIPPED: " + reason);
-    }
-
-    @Override
-    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-        printTest(testIdentifier, testExecutionResult.getStatus().name());
-    }
-
-    private void printTest(TestIdentifier testIdentifier, String status) {
-        if (testIdentifier.getParentId().isPresent() && !testIdentifier.isContainer()) {
-            out.println(LegacyReportingUtils.getClassName(testPlan, testIdentifier) + " > " + testIdentifier.getDisplayName() + " " + status + "\n");
+    public void onLoad(NativeImageConfiguration config) {
+        String[] buildTimeInitializedClasses = new String[]{
+                "org.junit.vintage.engine.descriptor.RunnerTestDescriptor",
+                "org.junit.vintage.engine.support.UniqueIdReader",
+                "org.junit.vintage.engine.support.UniqueIdStringifier",
+                "org.junit.runner.Description",
+                "org.junit.runners.BlockJUnit4ClassRunner",
+                "org.junit.runners.JUnit4",
+                /* Workaround until we can register serializable classes from a native-image feature */
+                "org.junit.runner.Result"
+        };
+        for (String className : buildTimeInitializedClasses) {
+            config.initializeAtBuildTime(className);
         }
+    }
+
+    @Override
+    public void onTestClassRegistered(Class<?> testClass, NativeImageConfiguration registry) {
     }
 }

--- a/common/junit-platform-native/src/main/resources/META-INF/services/org.graalvm.junit.platform.config.core.PluginConfigProvider
+++ b/common/junit-platform-native/src/main/resources/META-INF/services/org.graalvm.junit.platform.config.core.PluginConfigProvider
@@ -1,0 +1,3 @@
+org.graalvm.junit.platform.config.jupiter.JupiterConfigProvider
+org.graalvm.junit.platform.config.platform.PlatformConfigProvider
+org.graalvm.junit.platform.config.vintage.VintageConfigProvider

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/AggregateWithTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/AggregateWithTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.junit.jupiter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.AggregateWith;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.aggregator.ArgumentsAggregationException;
+import org.junit.jupiter.params.aggregator.ArgumentsAggregator;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.Objects;
+
+public class AggregateWithTests {
+
+    @ParameterizedTest(name = "Test basic aggregation")
+    @CsvSource({
+            "0,    1,   1",
+    })
+    public void testAggregateWith(@AggregateWith(AdditionTestArgumentsAggregator.class) AggregatedArgs test) {
+        Assertions.assertEquals(new AggregatedArgs(0, 1, 1), test);
+    }
+
+    @ParameterizedTest(name = "Test aggregation with two parameters")
+    @CsvSource({
+            "0,    1,   1,   1,    2,   3",
+    })
+    public void testAggregateWith(@AggregateWith(AdditionTestArgumentsAggregator.class) AggregatedArgs testOne, @AggregateWith(AdditionTestArgumentsAggregator.class) AggregatedArgs testTwo) {
+        Assertions.assertEquals(new AggregatedArgs(0, 1, 1), testOne);
+        Assertions.assertEquals(new AggregatedArgs(1, 2, 3), testTwo);
+    }
+
+}
+
+class AdditionTestArgumentsAggregator implements ArgumentsAggregator {
+
+    @Override
+    public Object aggregateArguments(ArgumentsAccessor accessor, ParameterContext context) throws ArgumentsAggregationException {
+        int offset = context.getIndex() * 3;
+        int a = accessor.getInteger(offset);
+        int b = accessor.getInteger(offset + 1);
+        int result = accessor.getInteger(offset + 2);
+        return new AggregatedArgs(a, b, result);
+    }
+}
+
+class AggregatedArgs {
+
+    public final int a;
+    public final int b;
+    public final int result;
+
+    AggregatedArgs(int a, int b, int result) {
+        this.a = a;
+        this.b = b;
+        this.result = result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AggregatedArgs that = (AggregatedArgs) o;
+        return a == that.a && b == that.b && result == that.result;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(a, b, result);
+    }
+}

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/BasicTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/BasicTests.java
@@ -38,48 +38,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.graalvm.junit.platform;
+package org.graalvm.junit.jupiter;
 
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.TestPlan;
-import org.junit.platform.reporting.legacy.LegacyReportingUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
-import java.io.PrintWriter;
+class BasicTests {
 
-@SuppressWarnings("unused")
-public class PrintTestExecutionListener implements TestExecutionListener {
-
-    TestPlan testPlan;
-    final PrintWriter out;
-
-    public PrintTestExecutionListener() {
-        out = new PrintWriter(System.out);
+    BasicTests(TestInfo info) {
+        System.out.println("Running test: " + info.getDisplayName());
     }
 
-    public PrintTestExecutionListener(PrintWriter out) {
-        this.out = out;
+    @Test
+    @DisplayName("Basic test one")
+    void addsTwoNumbers(TestInfo testInfo) {
+        Assertions.assertEquals("Basic test one", testInfo.getDisplayName());
     }
 
-    @Override
-    public void testPlanExecutionStarted(TestPlan testPlan) {
-        this.testPlan = testPlan;
+    @Test
+    @DisplayName("Basic test two")
+    void addsTwoNumbers2(TestInfo testInfo) {
+        Assertions.assertEquals("Basic test two", testInfo.getDisplayName());
     }
 
-    @Override
-    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-        printTest(testIdentifier, "SKIPPED: " + reason);
-    }
-
-    @Override
-    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-        printTest(testIdentifier, testExecutionResult.getStatus().name());
-    }
-
-    private void printTest(TestIdentifier testIdentifier, String status) {
-        if (testIdentifier.getParentId().isPresent() && !testIdentifier.isContainer()) {
-            out.println(LegacyReportingUtils.getClassName(testPlan, testIdentifier) + " > " + testIdentifier.getDisplayName() + " " + status + "\n");
-        }
-    }
 }

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/ConvertWithTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/ConvertWithTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,48 +38,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.graalvm.junit.platform;
+package org.graalvm.junit.jupiter;
 
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.TestPlan;
-import org.junit.platform.reporting.legacy.LegacyReportingUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ArgumentConversionException;
+import org.junit.jupiter.params.converter.ArgumentConverter;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.provider.CsvSource;
 
-import java.io.PrintWriter;
+public class ConvertWithTests {
 
-@SuppressWarnings("unused")
-public class PrintTestExecutionListener implements TestExecutionListener {
-
-    TestPlan testPlan;
-    final PrintWriter out;
-
-    public PrintTestExecutionListener() {
-        out = new PrintWriter(System.out);
+    @ParameterizedTest(name = "Test conversion")
+    @CsvSource({
+            "0.50,   1.30,   1.132",
+    })
+    public void testConverters(@ConvertWith(IntArgumentConverter.class) int a, @ConvertWith(IntArgumentConverter.class) int b, @ConvertWith(IntArgumentConverter.class) int c) {
+        Assertions.assertEquals(0, a);
+        Assertions.assertEquals(1, b);
+        Assertions.assertEquals(1, c);
     }
 
-    public PrintTestExecutionListener(PrintWriter out) {
-        this.out = out;
-    }
+}
+
+class IntArgumentConverter implements ArgumentConverter {
 
     @Override
-    public void testPlanExecutionStarted(TestPlan testPlan) {
-        this.testPlan = testPlan;
-    }
-
-    @Override
-    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-        printTest(testIdentifier, "SKIPPED: " + reason);
-    }
-
-    @Override
-    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-        printTest(testIdentifier, testExecutionResult.getStatus().name());
-    }
-
-    private void printTest(TestIdentifier testIdentifier, String status) {
-        if (testIdentifier.getParentId().isPresent() && !testIdentifier.isContainer()) {
-            out.println(LegacyReportingUtils.getClassName(testPlan, testIdentifier) + " > " + testIdentifier.getDisplayName() + " " + status + "\n");
-        }
+    public Object convert(Object source, ParameterContext context) throws ArgumentConversionException {
+        return (int) Math.floor(Double.parseDouble((String) source));
     }
 }

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/CsvSourceTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/CsvSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,77 +38,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.example.project;
+package org.graalvm.junit.jupiter;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-class CalculatorTests {
+import java.util.ArrayList;
+import java.util.List;
 
-    CalculatorTests(TestInfo info) {
-        System.out.println("Running test: " + info.getDisplayName());
-    }
+public class CsvSourceTests {
 
-    @Test
-    @DisplayName("1 + 1 = 2")
-    void addsTwoNumbers() {
-        Calculator calculator = new Calculator();
-        assertEquals(2, calculator.add(1, 1), "1 + 1 should equal 2");
-    }
-
-    @Test
-    @DisplayName("1 + 2 = 3")
-    void addsTwoNumbers2() {
-        Calculator calculator = new Calculator();
-        assertEquals(3, calculator.add(1, 2), "1 + 2 should equal 3");
-    }
+    private static final List<int[]> actualArgs = new ArrayList<>();
 
     @ParameterizedTest(name = "{0} + {1} = {2}")
     @CsvSource({
             "0,    1,   1",
             "1,    2,   3",
-            "49,  51, 100",
-            "1,  100, 101"
     })
     void add(int first, int second, int expectedResult) {
-        Calculator calculator = new Calculator();
-        assertEquals(expectedResult, calculator.add(first, second),
-                () -> first + " + " + second + " should equal " + expectedResult);
+        actualArgs.add(new int[]{first, second, expectedResult});
     }
 
-    @Nested
-    class NestedTest {
-
-        NestedTest(TestInfo info) {
-            System.out.println("Running nested test: " + info.getDisplayName());
-        }
-
-        @Test
-        @DisplayName("3 + 2 = 5, from a nested test class")
-        void addsTwoNumbersButNested() {
-            Calculator calculator = new Calculator();
-            assertEquals(5, calculator.add(3, 2));
-        }
-
-        @Nested
-        class NestedNestedTest {
-
-            NestedNestedTest(TestInfo info) {
-                System.out.println("Running nested nested test: " + info.getDisplayName());
-            }
-
-            @Test
-            @DisplayName("3 + 2 = 5, from a nested nested test class")
-            void addsTwoNumbersButNested() {
-                Calculator calculator = new Calculator();
-                assertEquals(5, calculator.add(3, 2));
-            }
-        }
+    @AfterAll
+    public static void verifyArguments() {
+        Assertions.assertEquals(2, actualArgs.size());
+        Assertions.assertArrayEquals(new int[]{0, 1, 1}, actualArgs.get(0));
+        Assertions.assertArrayEquals(new int[]{1, 2, 3}, actualArgs.get(1));
     }
+
 }

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/DisplayNameGenerationTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/DisplayNameGenerationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,48 +38,53 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.graalvm.junit.platform;
+package org.graalvm.junit.jupiter;
 
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.TestPlan;
-import org.junit.platform.reporting.legacy.LegacyReportingUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.IndicativeSentencesGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
-import java.io.PrintWriter;
+public class DisplayNameGenerationTests {
 
-@SuppressWarnings("unused")
-public class PrintTestExecutionListener implements TestExecutionListener {
 
-    TestPlan testPlan;
-    final PrintWriter out;
+    @DisplayNameGeneration(DisplayNameGenerator.Standard.class)
+    public static class StandardGenerator {
 
-    public PrintTestExecutionListener() {
-        out = new PrintWriter(System.out);
-    }
-
-    public PrintTestExecutionListener(PrintWriter out) {
-        this.out = out;
-    }
-
-    @Override
-    public void testPlanExecutionStarted(TestPlan testPlan) {
-        this.testPlan = testPlan;
-    }
-
-    @Override
-    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-        printTest(testIdentifier, "SKIPPED: " + reason);
-    }
-
-    @Override
-    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-        printTest(testIdentifier, testExecutionResult.getStatus().name());
-    }
-
-    private void printTest(TestIdentifier testIdentifier, String status) {
-        if (testIdentifier.getParentId().isPresent() && !testIdentifier.isContainer()) {
-            out.println(LegacyReportingUtils.getClassName(testPlan, testIdentifier) + " > " + testIdentifier.getDisplayName() + " " + status + "\n");
+        @Test
+        public void testOne(TestInfo info) {
+            Assertions.assertEquals("testOne(TestInfo)", info.getDisplayName());
         }
     }
+
+    @DisplayNameGeneration(DisplayNameGenerator.Simple.class)
+    public static class SimpleGenerator {
+
+        @Test
+        public void testOne(TestInfo info) {
+            Assertions.assertEquals("testOne (TestInfo)", info.getDisplayName());
+        }
+    }
+
+    // Checkstyle: stop
+    @IndicativeSentencesGeneration(generator = DisplayNameGenerator.ReplaceUnderscores.class)
+    public static class IndicativeSentencesGenerator {
+
+        @Test
+        public void test_one(TestInfo info) {
+            Assertions.assertEquals("DisplayNameGenerationTests$IndicativeSentencesGenerator, test one (TestInfo)", info.getDisplayName());
+        }
+    }
+
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    public static class ReplaceUnderscoresGenerator {
+
+        @Test
+        public void test_one(TestInfo info) {
+            Assertions.assertEquals("test one (TestInfo)", info.getDisplayName());
+        }
+    }
+    // Checkstyle: resume
 }

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/EnabledIfDisabledIfTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/EnabledIfDisabledIfTests.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.junit.jupiter;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+public class EnabledIfDisabledIfTests {
+
+    public static final String SHOULD_NOT_RUN_ERROR = "If this ran, something went wrong.";
+
+    public static class EnabledIfTests {
+
+        @EnabledIf("shouldRun")
+        public static class ShouldNeverRun {
+
+            @Test
+            public void testShouldNeverRun() {
+                Assertions.fail(SHOULD_NOT_RUN_ERROR);
+            }
+
+            @SuppressWarnings("unused")
+            public static boolean shouldRun() {
+                return false;
+            }
+        }
+
+        public static class Mixed {
+
+            private static boolean methodExecuted = false;
+
+            @Test
+            @EnabledIf("run")
+            public void testShouldRun() {
+                methodExecuted = true;
+            }
+
+            @Test
+            @EnabledIf("doNotRun")
+            public void testShouldNotRun() {
+                Assertions.fail(SHOULD_NOT_RUN_ERROR);
+            }
+
+            @AfterAll
+            public static void afterAll() {
+                Assertions.assertTrue(methodExecuted);
+            }
+
+            @SuppressWarnings("unused")
+            public boolean doNotRun() {
+                return false;
+            }
+
+            @SuppressWarnings("unused")
+            public boolean run() {
+                return true;
+            }
+        }
+
+
+        public static class ExternalCondition {
+            private static boolean methodExecuted;
+
+            @Test
+            @EnabledIf("org.graalvm.junit.jupiter.EnabledIfExternalConditions#run")
+            public void testShouldRun() {
+                methodExecuted = true;
+            }
+
+            @AfterAll
+            public static void afterAll() {
+                Assertions.assertTrue(methodExecuted);
+            }
+
+            @Test
+            @EnabledIf("org.graalvm.junit.jupiter.EnabledIfExternalConditions#doNotRun")
+            public void testShouldNotRun() {
+                Assertions.fail(SHOULD_NOT_RUN_ERROR);
+            }
+        }
+    }
+
+    public static class DisabledIfTests {
+
+        @DisabledIf("shouldRun")
+        public static class ShouldNeverRun {
+
+            @Test
+            public void testShouldNeverRun() {
+                Assertions.fail(SHOULD_NOT_RUN_ERROR);
+            }
+
+            @SuppressWarnings("unused")
+            public static boolean shouldRun() {
+                return true;
+            }
+        }
+
+        public static class Mixed {
+            private static boolean methodExecuted;
+
+            @Test
+            @DisabledIf("run")
+            public void testShouldRun() {
+                methodExecuted = true;
+            }
+
+            @AfterAll
+            public static void afterAll() {
+                Assertions.assertTrue(methodExecuted);
+            }
+
+            @Test
+            @DisabledIf("doNotRun")
+            public void testShouldNotRun() {
+                Assertions.fail(SHOULD_NOT_RUN_ERROR);
+            }
+
+            @SuppressWarnings("unused")
+            public boolean doNotRun() {
+                return true;
+            }
+
+            @SuppressWarnings("unused")
+            public boolean run() {
+                return false;
+            }
+        }
+
+
+        public static class ExternalCondition {
+
+            @Test
+            @DisabledIf("org.graalvm.junit.jupiter.DisabledIfExternalConditions#run")
+            public void testShouldRun() {
+            }
+
+            @Test
+            @DisabledIf("org.graalvm.junit.jupiter.DisabledIfExternalConditions#doNotRun")
+            public void testShouldNotRun() {
+                Assertions.fail(SHOULD_NOT_RUN_ERROR);
+            }
+        }
+    }
+}
+
+@SuppressWarnings("unused")
+class EnabledIfExternalConditions {
+
+    public static boolean doNotRun() {
+        return false;
+    }
+
+    public static boolean run() {
+        return true;
+    }
+}
+
+@SuppressWarnings("unused")
+class DisabledIfExternalConditions {
+
+    public static boolean doNotRun() {
+        return true;
+    }
+
+    public static boolean run() {
+        return false;
+    }
+}

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/EnumSourceTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/EnumSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,12 +38,57 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.example.project;
+package org.graalvm.junit.jupiter;
 
-public class Calculator {
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
-    public int add(int a, int b) {
-        return a + b;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class EnumSourceTests {
+
+    enum Color {
+        RED,
+        GREEN
+    }
+
+    enum Day {
+        MONDAY,
+        TUESDAY
+    }
+
+    public static class EnumSourceWithoutArgumentsTest {
+        private static final Set<Color> colors = new HashSet<>();
+
+        @ParameterizedTest
+        @EnumSource
+        public void testEnumSourceWithoutArguments(Color color) {
+            colors.add(color);
+        }
+
+        @AfterAll
+        public static void afterAll() {
+            Assertions.assertTrue(colors.containsAll(Arrays.asList(Color.RED, Color.GREEN)));
+        }
+    }
+
+    public static class EnumSourceWithArgumentsTest {
+        private static final Set<Day> days = new HashSet<>();
+
+        @ParameterizedTest
+        @EnumSource(value = Day.class)
+        public void testEnumSourceWithArguments(Day day) {
+            days.add(day);
+        }
+
+        @AfterAll
+        public static void afterAll() {
+            Assertions.assertTrue(days.containsAll(Arrays.asList(Day.MONDAY, Day.TUESDAY)));
+        }
     }
 
 }

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/MethodSourceTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/MethodSourceTests.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.junit.jupiter;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class MethodSourceTests {
+
+    public abstract static class ArgumentTestBase {
+        private static final List<int[]> actualArgs = new ArrayList<>();
+        protected static final List<int[]> expectedArgs = new ArrayList<>();
+
+        @BeforeAll
+        public static void setup() {
+            actualArgs.clear();
+        }
+
+        @AfterAll
+        public static void afterAll() {
+            Assertions.assertEquals(expectedArgs.size(), actualArgs.size());
+            for (int i = 0; i < expectedArgs.size(); ++i) {
+                Assertions.assertArrayEquals(expectedArgs.get(i), actualArgs.get(i));
+            }
+        }
+
+        protected static void addExpectedArgs(int a, int b) {
+            expectedArgs.add(new int[]{a, b});
+        }
+
+        protected static void traceArgs(int a, int b) {
+            actualArgs.add(new int[]{a, b});
+        }
+    }
+
+    public static class EmptyMethodSourceTests extends ArgumentTestBase {
+
+        @BeforeAll
+        public static void setup() {
+            addExpectedArgs(1, 5);
+            addExpectedArgs(7, 12);
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        public void testEmptyMethodSource(int a, int b) {
+            traceArgs(a, b);
+        }
+
+        public static Stream<Arguments> testEmptyMethodSource() {
+            return Stream.of(
+                    Arguments.of(1, 5),
+                    Arguments.of(7, 12)
+            );
+        }
+    }
+
+    public static class SameClassMethodSourceTests extends ArgumentTestBase {
+
+        @BeforeAll
+        public static void setup() {
+            addExpectedArgs(31, 32);
+            addExpectedArgs(1, 3);
+        }
+
+        @ParameterizedTest
+        @MethodSource("getTestInputs")
+        public void testSameClassMethodSource(int a, int b) {
+            traceArgs(a, b);
+        }
+
+        private static Stream<Arguments> getTestInputs() {
+            return Stream.of(
+                    Arguments.of(31, 32),
+                    Arguments.of(1, 3)
+            );
+        }
+    }
+
+    public static class OtherClassMethodSourceTests extends ArgumentTestBase {
+
+        @BeforeAll
+        public static void setup() {
+            addExpectedArgs(33, 35);
+            addExpectedArgs(99, 1);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.graalvm.junit.jupiter.MethodSourceProvider#getInputs")
+        public void testOtherClassMethodSource(int a, int b) {
+            traceArgs(a, b);
+        }
+    }
+
+    public static class CombinedMethodSourceTests extends ArgumentTestBase {
+
+        @BeforeAll
+        public static void setup() {
+            addExpectedArgs(33, 35);
+            addExpectedArgs(99, 1);
+            addExpectedArgs(31, 32);
+            addExpectedArgs(1, 3);
+        }
+
+        @ParameterizedTest
+        @MethodSource({"org.graalvm.junit.jupiter.MethodSourceProvider#getInputs", "getTestInputs"})
+        public void combinedTests(int a, int b) {
+            traceArgs(a, b);
+        }
+
+        private static Stream<Arguments> getTestInputs() {
+            return Stream.of(
+                    Arguments.of(31, 32),
+                    Arguments.of(1, 3)
+            );
+        }
+    }
+}
+
+class MethodSourceProvider {
+
+    public static Stream<Arguments> getInputs() {
+        return Stream.of(
+                Arguments.of(33, 35),
+                Arguments.of(99, 1)
+        );
+    }
+
+}

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/NestedTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/NestedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,48 +38,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.graalvm.junit.platform;
+package org.graalvm.junit.jupiter;
 
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.TestPlan;
-import org.junit.platform.reporting.legacy.LegacyReportingUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
-import java.io.PrintWriter;
 
-@SuppressWarnings("unused")
-public class PrintTestExecutionListener implements TestExecutionListener {
+public class NestedTests {
 
-    TestPlan testPlan;
-    final PrintWriter out;
+    @Nested
+    class NestedTest {
 
-    public PrintTestExecutionListener() {
-        out = new PrintWriter(System.out);
-    }
+        NestedTest(TestInfo info) {
+            System.out.println("Running nested test: " + info.getDisplayName());
+        }
 
-    public PrintTestExecutionListener(PrintWriter out) {
-        this.out = out;
-    }
+        @Test
+        @DisplayName("Test in a nested test class")
+        void addsTwoNumbersButNested() {
+        }
 
-    @Override
-    public void testPlanExecutionStarted(TestPlan testPlan) {
-        this.testPlan = testPlan;
-    }
+        @Nested
+        class NestedNestedTest {
 
-    @Override
-    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-        printTest(testIdentifier, "SKIPPED: " + reason);
-    }
+            NestedNestedTest(TestInfo info) {
+                System.out.println("Running nested nested test: " + info.getDisplayName());
+            }
 
-    @Override
-    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-        printTest(testIdentifier, testExecutionResult.getStatus().name());
-    }
-
-    private void printTest(TestIdentifier testIdentifier, String status) {
-        if (testIdentifier.getParentId().isPresent() && !testIdentifier.isContainer()) {
-            out.println(LegacyReportingUtils.getClassName(testPlan, testIdentifier) + " > " + testIdentifier.getDisplayName() + " " + status + "\n");
+            @Test
+            @DisplayName("Test in a nested nested test class")
+            void addsTwoNumbersButNested() {
+            }
         }
     }
+
 }

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/TestMethodOrderTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/TestMethodOrderTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.junit.jupiter;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+public class TestMethodOrderTests {
+
+    public static class MethodOrderTests {
+
+        private static final List<String> executedMethods = new ArrayList<>();
+
+        @BeforeAll
+        public static void beforeTests() {
+            executedMethods.clear();
+        }
+
+        @BeforeEach
+        public void beforeEach(TestInfo info) {
+            executedMethods.add(info.getTestMethod().get().getName());
+        }
+
+        @AfterAll
+        public static void afterTests() {
+            List<String> expectedMethods = Arrays.asList("testOne", "testTwo");
+            Assertions.assertEquals(expectedMethods, executedMethods);
+        }
+
+    }
+
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    public static class ArgumentOrderer extends MethodOrderTests {
+
+        @Test
+        @Order(2)
+        public void testTwo() {
+        }
+
+        @Test
+        @Order(1)
+        public void testOne() {
+        }
+    }
+
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    public static class DisplayNameOrderer extends MethodOrderTests {
+
+        @Test
+        @DisplayName("B - I must be second")
+        public void testTwo() {
+        }
+
+        @Test
+        @DisplayName("A - I must be first")
+        public void testOne() {
+        }
+    }
+
+    @TestMethodOrder(MethodOrderer.MethodName.class)
+    public static class MethodNameOrderer extends MethodOrderTests {
+
+        @Test
+        public void testOne() {
+        }
+
+        @Test
+        public void testTwo() {
+        }
+    }
+
+    @TestMethodOrder(MethodOrderer.Random.class)
+    public static class RandomOrderer {
+
+        @Test
+        public void testOne() {
+        }
+
+        @Test
+        public void testTwo() {
+        }
+    }
+}

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/vintage/BasicTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/vintage/BasicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,48 +38,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.graalvm.junit.platform;
+package org.graalvm.junit.vintage;
 
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.TestPlan;
-import org.junit.platform.reporting.legacy.LegacyReportingUtils;
+import org.junit.Assert;
+import org.junit.Test;
 
-import java.io.PrintWriter;
+public class BasicTests {
 
-@SuppressWarnings("unused")
-public class PrintTestExecutionListener implements TestExecutionListener {
-
-    TestPlan testPlan;
-    final PrintWriter out;
-
-    public PrintTestExecutionListener() {
-        out = new PrintWriter(System.out);
-    }
-
-    public PrintTestExecutionListener(PrintWriter out) {
-        this.out = out;
-    }
-
-    @Override
-    public void testPlanExecutionStarted(TestPlan testPlan) {
-        this.testPlan = testPlan;
-    }
-
-    @Override
-    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-        printTest(testIdentifier, "SKIPPED: " + reason);
-    }
-
-    @Override
-    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-        printTest(testIdentifier, testExecutionResult.getStatus().name());
-    }
-
-    private void printTest(TestIdentifier testIdentifier, String status) {
-        if (testIdentifier.getParentId().isPresent() && !testIdentifier.isContainer()) {
-            out.println(LegacyReportingUtils.getClassName(testPlan, testIdentifier) + " > " + testIdentifier.getDisplayName() + " " + status + "\n");
-        }
+    @Test
+    public void test() {
+        System.out.println("Hello, World! This is JUnit 4 test.");
+        Assert.assertEquals("This shouldn't fail", 42, 42);
     }
 }


### PR DESCRIPTION
This PR introduces a plugin configuration mechanism to separate plugin configuration from the JUnit feature. The core of this mechanism is the `PluginConfigProvider` service. The service currently implements 2 callbacks:
 - onLoad() - triggered when the `JUnitPlatformFeature` is loaded
 - onTestClassRegistered() - triggered when a test class is registered for inclusion in the image.

The provider receives a `NativeImageConfiguration` object that allows registering classes for reflection and build time initialization, removing the dependency to Native Image classes.

Currently, three such providers are implemented:
 - JUnit Platform
 - JUnit Jupiter
 - JUnit Vintage

All plugin-specific configuration has been moved from the feature to their respective provider.

Closes #54
Closes #51 
Closes #50 