### PR TITLE
Change maven readme/example to use buildArgs with individual tags for each option

### DIFF
--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -60,7 +60,9 @@
                         <configuration>
                             <skip>false</skip>
                             <imageName>${imageName}</imageName>
-                            <buildArgs>--no-fallback</buildArgs>
+                            <buildArgs>
+                                <buildArg>--no-fallback</buildArg>
+                            </buildArgs>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/native-maven-plugin/README.md
+++ b/native-maven-plugin/README.md
@@ -92,7 +92,7 @@ It is also possible to customize the plugin within a
     <imageName>executable-name</imageName>
     <mainClass>com.test.classname</mainClass>
     <buildArgs>
-        --no-fallback
+        <buildArg>--no-fallback</buildArg>
     </buildArgs>
     <skip>false</skip>
 </configuration>


### PR DESCRIPTION
Prevents maven xml parser from breaking native-image arguments with commas (fix for #67).