### PR TITLE
[Gradle plugin] Javadoc and other NativeImageOptions fixes

### DIFF
--- a/examples/gradle/build.gradle
+++ b/examples/gradle/build.gradle
@@ -40,6 +40,6 @@ nativeBuild {
 }
 
 nativeTest {
-	agent = false
-	persistConfig = false
+  agent = false
+  persistConfig = false
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/JUnitPlatformOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/JUnitPlatformOptions.java
@@ -76,7 +76,7 @@ public class JUnitPlatformOptions extends NativeImageOptions {
 
     @Override
     public void configure(Project project) {
-        args("--features=org.graalvm.junit.platform.JUnitPlatformFeature");
+        buildArgs("--features=org.graalvm.junit.platform.JUnitPlatformFeature");
         super.configure(project, SourceSet.TEST_SOURCE_SET_NAME);
     }
 }


### PR DESCRIPTION
Add/clarify Javadoc in the NativeImageOptions class wherever needed.
Add `@deprecated` tag to options that are there only for compatibilty with older Gradle plugins.
Use only recommended options internally in order to be consistent.

Closes following issues:
Fixes User native-image arguments should override plugin arguments in the gradle plugin #64
Fixes Wrong error message when agent output is missing (Gradle plugin) #65
Fixes systemProperties javadoc is not clear enough (Gradle plugin) #66

