### PR TITLE
Fix service not being registered on native image task

### DIFF
--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/TestNativeBuildTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/TestNativeBuildTask.java
@@ -40,9 +40,8 @@
  */
 package org.graalvm.buildtools.gradle.tasks;
 
-import org.graalvm.buildtools.gradle.GradleUtils;
-import org.graalvm.buildtools.gradle.NativeImageService;
 import org.graalvm.buildtools.Utils;
+import org.graalvm.buildtools.gradle.GradleUtils;
 import org.graalvm.buildtools.gradle.dsl.JUnitPlatformOptions;
 import org.graalvm.buildtools.gradle.internal.GraalVMLogger;
 import org.gradle.api.Project;
@@ -115,8 +114,10 @@ public abstract class TestNativeBuildTask extends AbstractExecTask<TestNativeBui
     }
 
     // This property provides access to the service instance
+    // It should be Property<NativeImageService> but because of a bug in Gradle
+    // we have to use a more generic type, see https://github.com/gradle/gradle/issues/17559
     @Internal
-    public abstract Property<NativeImageService> getServer();
+    public abstract Property<Object> getServer();
 
     @Override
     @SuppressWarnings("ConstantConditions")


### PR DESCRIPTION
This works around a bug in Gradle which prevents the service provider from
being registered on the native image tasks.

See https://github.com/gradle/gradle/issues/17559