### PR TITLE
Skip Maven native testing when there is no test

### DIFF
--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -53,7 +53,10 @@ import org.graalvm.buildtools.VersionInfo;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -77,6 +80,9 @@ public class NativeTestMojo extends AbstractNativeMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (skipTests) {
             logger.info("Tests are skipped.");
+            return;
+        }
+        if (!hasTests()) {
             return;
         }
 
@@ -103,6 +109,18 @@ public class NativeTestMojo extends AbstractNativeMojo {
         buildImage(classpath, targetFolder);
 
         runTests(targetFolder);
+    }
+
+    private boolean hasTests() {
+        Path testOutputPath = Paths.get(project.getBuild().getTestOutputDirectory());
+        if (Files.exists(testOutputPath) && Files.isDirectory(testOutputPath)) {
+            try (DirectoryStream<Path> directory = Files.newDirectoryStream(testOutputPath)) {
+                return directory.iterator().hasNext();
+            } catch (IOException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+        return false;
     }
 
     private void buildImage(String classpath, Path targetFolder) throws MojoExecutionException {


### PR DESCRIPTION
Please wait for @aclement validation before merging this PR.

Validated with the `maven` example and the repro provided in #81.
I did not implement logging because this is what Surefire does for regular tests, and it kind of make sense with Maven regular output where the name of the project and of the plugin are already displayed.

Closes #81