### PR TITLE
Fix identification of the GraalVM executable

### DIFF
--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -190,7 +190,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
             logger.lifecycle("Args are: " + args);
         }
         JavaInstallationMetadata metadata = options.getJavaLauncher().get().getMetadata();
-        File executablePath = metadata.getInstallationPath().file(NATIVE_IMAGE_EXE).getAsFile();
+        File executablePath = metadata.getInstallationPath().file("bin/" + NATIVE_IMAGE_EXE).getAsFile();
         if (!executablePath.exists() && getGraalVMHome().isPresent()) {
             executablePath = Paths.get(getGraalVMHome().get()).resolve("bin").resolve(NATIVE_IMAGE_EXE).toFile();
         }


### PR DESCRIPTION
This commit fixes a bug with the identification of the native image
executable, when the GraalVM JDK is found via a Gradle toolchain:
it was looking for the executable at the root of the installation
path instead of the `bin` directory.