### PR TITLE
Introduce a top-level `graalvmNative` DSL container

### DIFF
--- a/common/docs/ANNOUNCEMENT.md
+++ b/common/docs/ANNOUNCEMENT.md
@@ -43,19 +43,19 @@ pluginManagement {
 ```
 _(this step will be redundant once this plugin is published to the Gradle Plugin Portal)._
 
-After that, we can configure the image build by using a `nativeBuild` configuration block:
+After that, we can configure the image build by using a `graal` configuration block:
 ```groovy
-nativeBuild {
-  imageName = "my-app"
-  mainClass = "org.test.Main"
-  verbose = true
-  fallback = false
+graal {
+    main {
+        imageName = "my-app"
+        mainClass = "org.test.Main"
+        verbose = true
+        fallback = false
+    }
 }
 ```
 
-The plugin then adds `nativeBuild` and `nativeRun` tasks that build and run the main class (as one might expect ☺). If the reflection configuration is necessary for the Native Image building, this plugin also provides a simple option that activates the `[native-image-agent](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/#assisted-configuration-of-native-image-builds)` without any additional user setup. More information (and _Kotlin_ configuration syntax) is available in the [documentation](https://github.com/graalvm/native-build-tools/blob/master/native-gradle-plugin/README.md).
-
-> _To help ease the community transition, at the moment we support a subset of the configuration syntax and aliased task names from the most popular unofficial_ GraalVM  Gradle _plugins (_`_io.micronaut.application_` _and_ `_com.palantir.graal_`_). Note that this behavior might eventually be deprecated._
+The plugin then adds `nativeAssemble` and `nativeRun` tasks that respectively creates a native executable and runs the main class (as one might expect ☺). If the reflection configuration is necessary for the Native Image building, this plugin also provides a simple option that activates the `[native-image-agent](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/#assisted-configuration-of-native-image-builds)` without any additional user setup. More information (and _Kotlin_ configuration syntax) is available in the [documentation](https://github.com/graalvm/native-build-tools/blob/master/native-gradle-plugin/README.md).
 
 #### Testing in _Gradle_
 

--- a/common/docs/ANNOUNCEMENT.md
+++ b/common/docs/ANNOUNCEMENT.md
@@ -45,8 +45,8 @@ _(this step will be redundant once this plugin is published to the Gradle Plugin
 
 After that, we can configure the image build by using a `graal` configuration block:
 ```groovy
-graal {
-    nativeImages {
+javaNative {
+    images {
         main {
             imageName = "my-app"
             mainClass = "org.test.Main"

--- a/common/docs/ANNOUNCEMENT.md
+++ b/common/docs/ANNOUNCEMENT.md
@@ -46,11 +46,13 @@ _(this step will be redundant once this plugin is published to the Gradle Plugin
 After that, we can configure the image build by using a `graal` configuration block:
 ```groovy
 graal {
-    main {
-        imageName = "my-app"
-        mainClass = "org.test.Main"
-        verbose = true
-        fallback = false
+    nativeImages {
+        main {
+            imageName = "my-app"
+            mainClass = "org.test.Main"
+            verbose = true
+            fallback = false
+        }
     }
 }
 ```

--- a/common/docs/ANNOUNCEMENT.md
+++ b/common/docs/ANNOUNCEMENT.md
@@ -43,7 +43,8 @@ pluginManagement {
 ```
 _(this step will be redundant once this plugin is published to the Gradle Plugin Portal)._
 
-After that, we can configure the image build by using a `graal` configuration block:
+After that, we can configure the image build by using a `javaNative` configuration block:
+
 ```groovy
 javaNative {
     images {

--- a/common/docs/ANNOUNCEMENT.md
+++ b/common/docs/ANNOUNCEMENT.md
@@ -43,10 +43,10 @@ pluginManagement {
 ```
 _(this step will be redundant once this plugin is published to the Gradle Plugin Portal)._
 
-After that, we can configure the image build by using a `javaNative` configuration block:
+After that, we can configure the image build by using a `jvmNative` configuration block:
 
 ```groovy
-javaNative {
+jvmNative {
     images {
         main {
             imageName = "my-app"
@@ -58,7 +58,7 @@ javaNative {
 }
 ```
 
-The plugin then adds `nativeAssemble` and `nativeRun` tasks that respectively creates a native executable and runs the main class (as one might expect ☺). If the reflection configuration is necessary for the Native Image building, this plugin also provides a simple option that activates the `[native-image-agent](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/#assisted-configuration-of-native-image-builds)` without any additional user setup. More information (and _Kotlin_ configuration syntax) is available in the [documentation](https://github.com/graalvm/native-build-tools/blob/master/native-gradle-plugin/README.md).
+The plugin then adds `jvmNativeCompile` and `nativeRun` tasks that respectively creates a native executable and runs the main class (as one might expect ☺). If the reflection configuration is necessary for the Native Image building, this plugin also provides a simple option that activates the `[native-image-agent](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/#assisted-configuration-of-native-image-builds)` without any additional user setup. More information (and _Kotlin_ configuration syntax) is available in the [documentation](https://github.com/graalvm/native-build-tools/blob/master/native-gradle-plugin/README.md).
 
 #### Testing in _Gradle_
 

--- a/common/docs/ANNOUNCEMENT.md
+++ b/common/docs/ANNOUNCEMENT.md
@@ -43,11 +43,11 @@ pluginManagement {
 ```
 _(this step will be redundant once this plugin is published to the Gradle Plugin Portal)._
 
-After that, we can configure the image build by using a `jvmNative` configuration block:
+After that, we can configure the image build by using a `graalvmNative` configuration block:
 
 ```groovy
-jvmNative {
-    images {
+graalvmNative {
+    binaries {
         main {
             imageName = "my-app"
             mainClass = "org.test.Main"
@@ -58,7 +58,7 @@ jvmNative {
 }
 ```
 
-The plugin then adds `jvmNativeCompile` and `nativeRun` tasks that respectively creates a native executable and runs the main class (as one might expect ☺). If the reflection configuration is necessary for the Native Image building, this plugin also provides a simple option that activates the `[native-image-agent](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/#assisted-configuration-of-native-image-builds)` without any additional user setup. More information (and _Kotlin_ configuration syntax) is available in the [documentation](https://github.com/graalvm/native-build-tools/blob/master/native-gradle-plugin/README.md).
+The plugin then adds `nativeCompile` and `nativeRun` tasks that respectively creates a native executable and runs the main class (as one might expect ☺). If the reflection configuration is necessary for the Native Image building, this plugin also provides a simple option that activates the `[native-image-agent](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/#assisted-configuration-of-native-image-builds)` without any additional user setup. More information (and _Kotlin_ configuration syntax) is available in the [documentation](https://github.com/graalvm/native-build-tools/blob/master/native-gradle-plugin/README.md).
 
 #### Testing in _Gradle_
 

--- a/common/junit-platform-native/gradle/native-image-testing.gradle
+++ b/common/junit-platform-native/gradle/native-image-testing.gradle
@@ -127,7 +127,7 @@ tasks.named("test") {
     }
 }
 
-tasks.register("jvmNativeTestCompile", Exec) {
+tasks.register("nativeTestCompile", Exec) {
     dependsOn(test)
     inputs.files(test.classpath)
     workingDir "${buildDir}"
@@ -141,7 +141,7 @@ tasks.register("jvmNativeTestCompile", Exec) {
 }
 
 tasks.register("nativeTest", Exec) {
-    dependsOn jvmNativeTestCompile
+    dependsOn nativeTestCompile
     workingDir = "${buildDir}"
     executable = "${buildDir}/native-image-tests"
 }

--- a/common/junit-platform-native/gradle/native-image-testing.gradle
+++ b/common/junit-platform-native/gradle/native-image-testing.gradle
@@ -127,7 +127,7 @@ tasks.named("test") {
     }
 }
 
-tasks.register("nativeTestAssemble", Exec) {
+tasks.register("jvmNativeTestCompile", Exec) {
     dependsOn(test)
     inputs.files(test.classpath)
     workingDir "${buildDir}"
@@ -141,7 +141,7 @@ tasks.register("nativeTestAssemble", Exec) {
 }
 
 tasks.register("nativeTest", Exec) {
-    dependsOn nativeTestAssemble
+    dependsOn jvmNativeTestCompile
     workingDir = "${buildDir}"
     executable = "${buildDir}/native-image-tests"
 }

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -129,12 +129,14 @@ This plugin works with the `application` plugin and will register a number of ta
 
 The main tasks that you will want to execute are:
 
-- `nativeBuild`, which will trigger the generation of a native executable of your application
+- `nativeAssemble`, which will trigger the generation of a native executable of your application
 - `nativeRun`, which executes the generated native executable
-- `nativeTestBuild`, which will build a native image with tests found in the `test` source set
+- `nativeTestAssemble`, which will build a native image with tests found in the `test` source set
 - `nativeTest`, which will <<testing,execute tests>> found in the `test` source set in native mode
 
-Those tasks are configured with reasonable defaults respectively by the `nativeBuild` and `nativeTest` extensions, which are of type link:javadocs/native-gradle-plugin/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.html[NativeImageOptions].
+Those tasks are configured with reasonable defaults using the `javaNative` extension `images` container of type link:javadocs/native-gradle-plugin/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.html[NativeImageOptions].
+
+The main executable is configured by the image named `main`, while the test executable is configured via the image named `test`.
 
 === Native image options
 
@@ -148,21 +150,29 @@ If you want to use a different toolchain, for example a GraalVM Enterprise Editi
 .Selecting the GraalVM toolchain
 [role="multi-language-sample"]
 ```groovy
-nativeBuild {
-  javaLauncher = javaToolchains.launcherFor {
-    languageVersion = JavaLanguageVersion.of(8)
-    vendor = JvmVendorSpec.matching("GraalVM Enterprise")
-  }
+javaNative {
+    images {
+      main {
+          javaLauncher = javaToolchains.launcherFor {
+            languageVersion = JavaLanguageVersion.of(8)
+            vendor = JvmVendorSpec.matching("GraalVM Enterprise")
+          }
+      }
+    }
 }
 ```
 
 [role="multi-language-sample"]
 ```kotlin
-nativeBuild {
-  javaLauncher.set(javaToolchains.launcherFor {
-    languageVersion.set(JavaLanguageVersion.of(8))
-    vendor.set(JvmVendorSpec.matching("GraalVM Enterprise"))
-  })
+javaNative {
+   images {
+    main {
+      javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(8))
+        vendor.set(JvmVendorSpec.matching("GraalVM Enterprise"))
+      })
+    }
+  }
 }
 ```
 
@@ -173,58 +183,65 @@ The following configuration options are available for building images:
 .NativeImageOption configuration
 [role="multi-language-sample"]
 ```groovy
-nativeBuild {
-  // Main options
-  imageName = 'application' // The name of the native image, defaults to the project name
-  mainClass = 'org.test.Main' // The main class to use, defaults to the application.mainClass
-  debug = true // Determines if debug info should be generated, defaults to false
-  verbose = true // Add verbose output, defaults to false
-  fallback = true // Sets the fallback mode of native-image, defaults to false
-  sharedLibrary = false // Determines if image is a shared library, defaults to false if `java-library` plugin isn't included
+javaNative {
+  images {
+    main {
+      // Main options
+      imageName = 'application' // The name of the native image, defaults to the project name
+      mainClass = 'org.test.Main' // The main class to use, defaults to the application.mainClass
+      debug = true // Determines if debug info should be generated, defaults to false
+      verbose = true // Add verbose output, defaults to false
+      fallback = true // Sets the fallback mode of native-image, defaults to false
+      sharedLibrary = false // Determines if image is a shared library, defaults to false if `java-library` plugin isn't included
 
-  systemProperties = [name1: 'value1', name2: 'value2'] // Sets the system properties to use for the native image builder
-  configurationFileDirectories.from(file('src/my-config')) // Adds a native image configuration file directory, containing files like reflection configuration
+      systemProperties = [name1: 'value1', name2: 'value2'] // Sets the system properties to use for the native image builder
+      configurationFileDirectories.from(file('src/my-config')) // Adds a native image configuration file directory, containing files like reflection configuration
 
-  // Advanced options
-  buildArgs.add('-H:Extra') // Passes '-H:Extra' to the native image builder options. This can be used to pass parameters which are not directly supported by this extension
-  jvmArgs.add('flag') // Passes 'flag' directly to the JVM running the native image builder
+      // Advanced options
+      buildArgs.add('-H:Extra') // Passes '-H:Extra' to the native image builder options. This can be used to pass parameters which are not directly supported by this extension
+      jvmArgs.add('flag') // Passes 'flag' directly to the JVM running the native image builder
 
-  // Runtime options
-  runtimeArgs.add('--help') // Passes '--help' to built image, during "nativeRun" task
+      // Runtime options
+      runtimeArgs.add('--help') // Passes '--help' to built image, during "nativeRun" task
 
-  // Development options
-  agent = true // Enables the reflection agent. Can be also set on command line using '-Pagent'
+      // Development options
+      agent = true // Enables the reflection agent. Can be also set on command line using '-Pagent'
 
-  useFatJar = true // Instead of passing each jar individually, builds a fat jar
+      useFatJar = true // Instead of passing each jar individually, builds a fat jar
+    }
+  }
 }
 ```
 
 [role="multi-language-sample"]
 ```kotlin
-nativeBuild {
-  // Main options
-  imageName.set("application") // The name of the native image, defaults to the project name
-  mainClass.set("org.test.Main") // The main class to use, defaults to the application.mainClass
-  debug.set(true) // Determines if debug info should be generated, defaults to false
-  verbose.set(true) // Add verbose output, defaults to false
-  fallback.set(true) // Sets the fallback mode of native-image, defaults to false
-  sharedLibrary.set(false) // Determines if image is a shared library, defaults to false if `java-library` plugin isn't included
+javaNative {
+  images {
+    main {
+      // Main options
+      imageName.set("application") // The name of the native image, defaults to the project name
+      mainClass.set("org.test.Main") // The main class to use, defaults to the application.mainClass
+      debug.set(true) // Determines if debug info should be generated, defaults to false
+      verbose.set(true) // Add verbose output, defaults to false
+      fallback.set(true) // Sets the fallback mode of native-image, defaults to false
+      sharedLibrary.set(false) // Determines if image is a shared library, defaults to false if `java-library` plugin isn't included
 
-  systemProperties.putAll(mapOf(name1 to "value1", name2 to "value2")) // Sets the system properties to use for the native image builder
-  configurationFileDirectories.from(file("src/my-config")) // Adds a native image configuration file directory, containing files like reflection configuration
+      systemProperties.putAll(mapOf(name1 to "value1", name2 to "value2")) // Sets the system properties to use for the native image builder
+      configurationFileDirectories.from(file("src/my-config")) // Adds a native image configuration file directory, containing files like reflection configuration
 
-  // Advanced options
-  buildArgs.add("-H:Extra") // Passes '-H:Extra' to the native image builder options. This can be used to pass parameters which are not directly supported by this extension
-  jvmArgs.add("flag") // Passes 'flag' directly to the JVM running the native image builder
+      // Advanced options
+      buildArgs.add("-H:Extra") // Passes '-H:Extra' to the native image builder options. This can be used to pass parameters which are not directly supported by this extension
+      jvmArgs.add("flag") // Passes 'flag' directly to the JVM running the native image builder
 
-  // Runtime options
-  runtimeArgs.add("--help") // Passes '--help' to built image, during "nativeRun" task
+      // Runtime options
+      runtimeArgs.add("--help") // Passes '--help' to built image, during "nativeRun" task
 
-  // Development options
-  agent.set(true) // Enables the reflection agent. Can be also set on command line using '-Pagent'
+      // Development options
+      agent.set(true) // Enables the reflection agent. Can be also set on command line using '-Pagent'
 
-
-  useFatJar.set(true) // Instead of passing each jar individually, builds a fat jar
+      useFatJar.set(true) // Instead of passing each jar individually, builds a fat jar
+    }
+  }
 }
 ```
 
@@ -293,7 +310,7 @@ This should be as easy as appending `-Pagent` to `run` and `nativeBuild`, or `te
 
 ```bash
 ./gradlew -Pagent run # Runs on JVM with native-image-agent.
-./gradlew -Pagent nativeBuild # Builds image using configuration acquired by agent.
+./gradlew -Pagent nativeAssemble # Builds image using configuration acquired by agent.
 
 # For testing
 ./gradlew -Pagent test # Runs on JVM with native-image-agent.

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -131,12 +131,12 @@ This plugin works with the `application` plugin and will register a number of ta
 
 The main tasks that you will want to execute are:
 
-- `jvmNativeCompile`, which will trigger the generation of a native executable of your application
+- `nativeCompile`, which will trigger the generation of a native executable of your application
 - `nativeRun`, which executes the generated native executable
-- `jvmNativeTestCompile`, which will build a native image with tests found in the `test` source set
+- `nativeTestCompile`, which will build a native image with tests found in the `test` source set
 - `nativeTest`, which will <<testing,execute tests>> found in the `test` source set in native mode
 
-Those tasks are configured with reasonable defaults using the `jvmNative` extension `images` container of type link:javadocs/native-gradle-plugin/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.html[NativeImageOptions].
+Those tasks are configured with reasonable defaults using the `graalvmNative` extension `binaries` container of type link:javadocs/native-gradle-plugin/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.html[NativeImageOptions].
 
 The main executable is configured by the image named `main`, while the test executable is configured via the image named `test`.
 
@@ -152,8 +152,8 @@ If you want to use a different toolchain, for example a GraalVM Enterprise Editi
 .Selecting the GraalVM toolchain
 [role="multi-language-sample"]
 ```groovy
-jvmNative {
-    images {
+graalvmNative {
+    binaries {
       main {
           javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.of(8)
@@ -166,8 +166,8 @@ jvmNative {
 
 [role="multi-language-sample"]
 ```kotlin
-jvmNative {
-   images {
+graalvmNative {
+   binaries {
     main {
       javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(8))
@@ -185,8 +185,8 @@ The following configuration options are available for building images:
 .NativeImageOption configuration
 [role="multi-language-sample"]
 ```groovy
-jvmNative {
-  images {
+graalvmNative {
+  binaries {
     main {
       // Main options
       imageName = 'application' // The name of the native image, defaults to the project name
@@ -217,8 +217,8 @@ jvmNative {
 
 [role="multi-language-sample"]
 ```kotlin
-jvmNative {
-  images {
+graalvmNative {
+  binaries {
     main {
       // Main options
       imageName.set("application") // The name of the native image, defaults to the project name
@@ -312,7 +312,7 @@ This should be as easy as appending `-Pagent` to `run` and `nativeBuild`, or `te
 
 ```bash
 ./gradlew -Pagent run # Runs on JVM with native-image-agent.
-./gradlew -Pagent jvmNativeCompile # Builds image using configuration acquired by agent.
+./gradlew -Pagent nativeCompile # Builds image using configuration acquired by agent.
 
 # For testing
 ./gradlew -Pagent test # Runs on JVM with native-image-agent.
@@ -345,8 +345,8 @@ nativeBuild {
 you need to use:
 
 ```groovy
-jvmNative {
-  images {
+graalvmNative {
+  binaries {
     main {
       verbose = true
     }
@@ -365,8 +365,8 @@ nativeTest {
 you need to use:
 
 ```groovy
-jvmNative {
-  images {
+graalvmNative {
+  binaries {
     test {
       verbose = true
     }
@@ -374,8 +374,8 @@ jvmNative {
 }
 ```
 
-- The `nativeBuild` task has been renamed to `jvmNativeCompile`.
-- The `nativeTestBuild` task has been renamed to `jvmNativeTestCompile`.
+- The `nativeBuild` task has been renamed to `nativeCompile`.
+- The `nativeTestBuild` task has been renamed to `nativeTestCompile`.
 
 Both `nativeBuild` and `nativeTestBuild` task invocations are still supported but deprecated and will be removed in a future release.
 

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -8,6 +8,8 @@ image:https://github.com/graalvm/native-image-build-tools/actions/workflows/nati
 
 The {doctitle} adds support for building and testing native images using the https://gradle.org[Gradle build tool].
 
+For upgrading please take a look at the <<changelog,changes section>>.
+
 == Quickstart
 
 === Adding the plugin
@@ -324,3 +326,60 @@ The generated configuration files will be found in the `${buildDir}/native/agent
 == Javadocs
 
 In addition, you can consult the link:javadocs/native-gradle-plugin/index.html[Javadocs of the plugin].
+
+[[changelog]]
+== Changelog
+
+=== Release 0.9.3
+
+In preparation for supporting more images:
+
+- The `nativeBuild` and `nativeTest` extensions are now deprecated. A top-level container for configuring native images has been introduced. Instead of:
+
+```groovy
+nativeBuild {
+   verbose = true
+}
+```
+
+you need to use:
+
+```groovy
+javaNative {
+  images {
+    main {
+      verbose = true
+    }
+  }
+}
+```
+
+and instead of:
+
+```groovy
+nativeTest {
+    buildArgs("...")
+}
+```
+
+you need to use:
+
+```groovy
+javaNative {
+  images {
+    test {
+      verbose = true
+    }
+  }
+}
+```
+
+- The `nativeBuild` task has been renamed to `nativeAssemble`.
+- The `nativeTestBuild` task has been renamed to `nativeTestAssemble`.
+
+Both `nativeBuild` and `nativeTestBuild` task invocations are still supported but deprecated and will be removed in a future release.
+
+== Release 0.9.2
+
+- Added support for resources detection
+- Fixed a number of regressions

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -131,12 +131,12 @@ This plugin works with the `application` plugin and will register a number of ta
 
 The main tasks that you will want to execute are:
 
-- `nativeAssemble`, which will trigger the generation of a native executable of your application
+- `jvmNativeCompile`, which will trigger the generation of a native executable of your application
 - `nativeRun`, which executes the generated native executable
-- `nativeTestAssemble`, which will build a native image with tests found in the `test` source set
+- `jvmNativeTestCompile`, which will build a native image with tests found in the `test` source set
 - `nativeTest`, which will <<testing,execute tests>> found in the `test` source set in native mode
 
-Those tasks are configured with reasonable defaults using the `javaNative` extension `images` container of type link:javadocs/native-gradle-plugin/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.html[NativeImageOptions].
+Those tasks are configured with reasonable defaults using the `jvmNative` extension `images` container of type link:javadocs/native-gradle-plugin/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.html[NativeImageOptions].
 
 The main executable is configured by the image named `main`, while the test executable is configured via the image named `test`.
 
@@ -152,7 +152,7 @@ If you want to use a different toolchain, for example a GraalVM Enterprise Editi
 .Selecting the GraalVM toolchain
 [role="multi-language-sample"]
 ```groovy
-javaNative {
+jvmNative {
     images {
       main {
           javaLauncher = javaToolchains.launcherFor {
@@ -166,7 +166,7 @@ javaNative {
 
 [role="multi-language-sample"]
 ```kotlin
-javaNative {
+jvmNative {
    images {
     main {
       javaLauncher.set(javaToolchains.launcherFor {
@@ -185,7 +185,7 @@ The following configuration options are available for building images:
 .NativeImageOption configuration
 [role="multi-language-sample"]
 ```groovy
-javaNative {
+jvmNative {
   images {
     main {
       // Main options
@@ -217,7 +217,7 @@ javaNative {
 
 [role="multi-language-sample"]
 ```kotlin
-javaNative {
+jvmNative {
   images {
     main {
       // Main options
@@ -312,7 +312,7 @@ This should be as easy as appending `-Pagent` to `run` and `nativeBuild`, or `te
 
 ```bash
 ./gradlew -Pagent run # Runs on JVM with native-image-agent.
-./gradlew -Pagent nativeAssemble # Builds image using configuration acquired by agent.
+./gradlew -Pagent jvmNativeCompile # Builds image using configuration acquired by agent.
 
 # For testing
 ./gradlew -Pagent test # Runs on JVM with native-image-agent.
@@ -345,7 +345,7 @@ nativeBuild {
 you need to use:
 
 ```groovy
-javaNative {
+jvmNative {
   images {
     main {
       verbose = true
@@ -365,7 +365,7 @@ nativeTest {
 you need to use:
 
 ```groovy
-javaNative {
+jvmNative {
   images {
     test {
       verbose = true
@@ -374,8 +374,8 @@ javaNative {
 }
 ```
 
-- The `nativeBuild` task has been renamed to `nativeAssemble`.
-- The `nativeTestBuild` task has been renamed to `nativeTestAssemble`.
+- The `nativeBuild` task has been renamed to `jvmNativeCompile`.
+- The `nativeTestBuild` task has been renamed to `jvmNativeTestCompile`.
 
 Both `nativeBuild` and `nativeTestBuild` task invocations are still supported but deprecated and will be removed in a future release.
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/DeprecatedExtensionFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/DeprecatedExtensionFunctionalTest.groovy
@@ -57,15 +57,15 @@ class DeprecatedExtensionFunctionalTest extends AbstractFunctionalTest {
                 jvmArgs('hello', 'world')
             }
             
-            assert jvmNative.images.${replacedWith}.verbose.get() == true
-            assert jvmNative.images.${replacedWith}.jvmArgs.get() == ['hello', 'world']
+            assert graalvmNative.binaries.${replacedWith}.verbose.get() == true
+            assert graalvmNative.binaries.${replacedWith}.jvmArgs.get() == ['hello', 'world']
         """
 
         when:
         run 'help'
 
         then:
-        outputContains "The $extensionName extension is deprecated and will be removed. Please use the 'jvmNative.images.$replacedWith' extension to configure the native image instead."
+        outputContains "The $extensionName extension is deprecated and will be removed. Please use the 'graalvmNative.binaries.$replacedWith' extension to configure the native image instead."
 
         where:
         extensionName | replacedWith
@@ -84,12 +84,12 @@ class DeprecatedExtensionFunctionalTest extends AbstractFunctionalTest {
 
         then:
         tasks {
-            succeeded ':jvmNativeCompile'
+            succeeded ':nativeCompile'
             succeeded ':nativeBuild'
         }
 
         and:
-        outputContains 'Task nativeBuild is deprecated. Use jvmNativeCompile instead.'
+        outputContains 'Task nativeBuild is deprecated. Use nativeCompile instead.'
 
         where:
         version << TESTED_GRADLE_VERSIONS

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/DeprecatedExtensionFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/DeprecatedExtensionFunctionalTest.groovy
@@ -46,7 +46,6 @@ import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 class DeprecatedExtensionFunctionalTest extends AbstractFunctionalTest {
     def "using a deprecated extension issues a warning"() {
         given:
-        debug = true
         buildFile << """
             plugins {
                 id 'application'
@@ -72,5 +71,27 @@ class DeprecatedExtensionFunctionalTest extends AbstractFunctionalTest {
         extensionName | replacedWith
         'nativeBuild' | 'main'
         'nativeTest'  | 'test'
+    }
+
+    def "calling the deprecated nativeBuild task triggers a warning and execution of the native image task"() {
+        gradleVersion = version
+
+        given:
+        withSample("java-application")
+
+        when:
+        run 'nativeBuild'
+
+        then:
+        tasks {
+            succeeded ':nativeAssemble'
+            succeeded ':nativeBuild'
+        }
+
+        and:
+        outputContains 'Task nativeBuild is deprecated. Use nativeAssemble instead.'
+
+        where:
+        version << TESTED_GRADLE_VERSIONS
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/DeprecatedExtensionFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/DeprecatedExtensionFunctionalTest.groovy
@@ -57,15 +57,15 @@ class DeprecatedExtensionFunctionalTest extends AbstractFunctionalTest {
                 jvmArgs('hello', 'world')
             }
             
-            assert javaNative.images.${replacedWith}.verbose.get() == true
-            assert javaNative.images.${replacedWith}.jvmArgs.get() == ['hello', 'world']
+            assert jvmNative.images.${replacedWith}.verbose.get() == true
+            assert jvmNative.images.${replacedWith}.jvmArgs.get() == ['hello', 'world']
         """
 
         when:
         run 'help'
 
         then:
-        outputContains "The $extensionName extension is deprecated and will be removed. Please use the 'javaNative.images.$replacedWith' extension to configure the native image instead."
+        outputContains "The $extensionName extension is deprecated and will be removed. Please use the 'jvmNative.images.$replacedWith' extension to configure the native image instead."
 
         where:
         extensionName | replacedWith
@@ -84,12 +84,12 @@ class DeprecatedExtensionFunctionalTest extends AbstractFunctionalTest {
 
         then:
         tasks {
-            succeeded ':nativeAssemble'
+            succeeded ':jvmNativeCompile'
             succeeded ':nativeBuild'
         }
 
         and:
-        outputContains 'Task nativeBuild is deprecated. Use nativeAssemble instead.'
+        outputContains 'Task nativeBuild is deprecated. Use jvmNativeCompile instead.'
 
         where:
         version << TESTED_GRADLE_VERSIONS

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/DeprecatedExtensionFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/DeprecatedExtensionFunctionalTest.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.gradle
+
+import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
+
+class DeprecatedExtensionFunctionalTest extends AbstractFunctionalTest {
+    def "using a deprecated extension issues a warning"() {
+        given:
+        debug = true
+        buildFile << """
+            plugins {
+                id 'application'
+                id 'org.graalvm.buildtools.native'
+            }
+            
+            $extensionName {
+                verbose = true
+                jvmArgs('hello', 'world')
+            }
+            
+            assert javaNative.images.${replacedWith}.verbose.get() == true
+            assert javaNative.images.${replacedWith}.jvmArgs.get() == ['hello', 'world']
+        """
+
+        when:
+        run 'help'
+
+        then:
+        outputContains "The $extensionName extension is deprecated and will be removed. Please use the 'javaNative.images.$replacedWith' extension to configure the native image instead."
+
+        where:
+        extensionName | replacedWith
+        'nativeBuild' | 'main'
+        'nativeTest'  | 'test'
+    }
+}

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -46,7 +46,7 @@ import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
     def "can build a native image for a simple application"() {
         gradleVersion = version
-        def nativeApp = file("build/native/nativeAssemble/java-application")
+        def nativeApp = file("build/native/jvmNativeCompile/java-application")
         debug  = true
 
         given:
@@ -59,11 +59,11 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         """.stripIndent()
 
         when:
-        run 'nativeAssemble'
+        run 'jvmNativeCompile'
 
         then:
         tasks {
-            succeeded ':jar', ':nativeAssemble'
+            succeeded ':jar', ':jvmNativeCompile'
             doesNotContain ':build', ':run'
         }
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -46,7 +46,7 @@ import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
     def "can build a native image for a simple application"() {
         gradleVersion = version
-        def nativeApp = file("build/native/nativeBuild/java-application")
+        def nativeApp = file("build/native/nativeAssemble/java-application")
         debug  = true
 
         given:
@@ -59,11 +59,11 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         """.stripIndent()
 
         when:
-        run 'nativeBuild'
+        run 'nativeAssemble'
 
         then:
         tasks {
-            succeeded ':jar', ':nativeBuild'
+            succeeded ':jar', ':nativeAssemble'
             doesNotContain ':build', ':run'
         }
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -46,7 +46,7 @@ import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
     def "can build a native image for a simple application"() {
         gradleVersion = version
-        def nativeApp = file("build/native/jvmNativeCompile/java-application")
+        def nativeApp = file("build/native/nativeCompile/java-application")
         debug  = true
 
         given:
@@ -59,11 +59,11 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         """.stripIndent()
 
         when:
-        run 'jvmNativeCompile'
+        run 'nativeCompile'
 
         then:
         tasks {
-            succeeded ':jar', ':jvmNativeCompile'
+            succeeded ':jar', ':nativeCompile'
             doesNotContain ':build', ':run'
         }
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -47,7 +47,7 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
     @Unroll("can build an application which uses resources using #pattern on Gradle #version with JUnit Platform #junitVersion")
     def "can build an application which uses resources"() {
         gradleVersion = version
-        def nativeApp = file("build/native/nativeAssemble/java-application")
+        def nativeApp = file("build/native/jvmNativeCompile/java-application")
         debug = true
         given:
         withSample("java-application-with-resources")
@@ -60,11 +60,11 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
         """
 
         when:
-        run 'nativeAssemble'
+        run 'jvmNativeCompile'
 
         then:
         tasks {
-            succeeded ':jar', ':nativeAssemble'
+            succeeded ':jar', ':jvmNativeCompile'
             doesNotContain ':build', ':run'
         }
 
@@ -92,7 +92,7 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
         junitVersion = System.getProperty('versions.junit')
         [version, [pattern, config]] << [TESTED_GRADLE_VERSIONS,
                                          [["explicit resource declaration", """
-javaNative {
+jvmNative {
     images {
         main {
             resources {
@@ -103,7 +103,7 @@ javaNative {
 }
 """],
                                          ["detected", """
-javaNative {
+jvmNative {
     images {
         main {
             resources {
@@ -119,7 +119,7 @@ javaNative {
 """
                                          ],
                                           ["project local detection only", """
-javaNative {
+jvmNative {
     images {
         main {
             resources {
@@ -171,7 +171,7 @@ javaNative {
         junitVersion = System.getProperty('versions.junit')
         [version, [pattern, config]] << [TESTED_GRADLE_VERSIONS,
                                          [["explicit resource declaration", """
-javaNative {
+jvmNative {
     images {
         test {
             resources {
@@ -183,7 +183,7 @@ javaNative {
 }
 """],
                                          ["detected", """
-javaNative {
+jvmNative {
     images {
         test {
             resources {

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -47,7 +47,7 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
     @Unroll("can build an application which uses resources using #pattern on Gradle #version with JUnit Platform #junitVersion")
     def "can build an application which uses resources"() {
         gradleVersion = version
-        def nativeApp = file("build/native/jvmNativeCompile/java-application")
+        def nativeApp = file("build/native/nativeCompile/java-application")
         debug = true
         given:
         withSample("java-application-with-resources")
@@ -60,11 +60,11 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
         """
 
         when:
-        run 'jvmNativeCompile'
+        run 'nativeCompile'
 
         then:
         tasks {
-            succeeded ':jar', ':jvmNativeCompile'
+            succeeded ':jar', ':nativeCompile'
             doesNotContain ':build', ':run'
         }
 
@@ -92,8 +92,8 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
         junitVersion = System.getProperty('versions.junit')
         [version, [pattern, config]] << [TESTED_GRADLE_VERSIONS,
                                          [["explicit resource declaration", """
-jvmNative {
-    images {
+graalvmNative {
+    binaries {
         main {
             resources {
                 includedPatterns.add(java.util.regex.Pattern.quote("message.txt"))
@@ -103,8 +103,8 @@ jvmNative {
 }
 """],
                                          ["detected", """
-jvmNative {
-    images {
+graalvmNative {
+    binaries {
         main {
             resources {
                 autodetection {
@@ -119,8 +119,8 @@ jvmNative {
 """
                                          ],
                                           ["project local detection only", """
-jvmNative {
-    images {
+graalvmNative {
+    binaries {
         main {
             resources {
                 autodetection {
@@ -171,8 +171,8 @@ jvmNative {
         junitVersion = System.getProperty('versions.junit')
         [version, [pattern, config]] << [TESTED_GRADLE_VERSIONS,
                                          [["explicit resource declaration", """
-jvmNative {
-    images {
+graalvmNative {
+    binaries {
         test {
             resources {
                 includedPatterns.add(java.util.regex.Pattern.quote("message.txt"))
@@ -183,8 +183,8 @@ jvmNative {
 }
 """],
                                          ["detected", """
-jvmNative {
-    images {
+graalvmNative {
+    binaries {
         test {
             resources {
                 autodetection {

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -47,7 +47,7 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
     @Unroll("can build an application which uses resources using #pattern on Gradle #version with JUnit Platform #junitVersion")
     def "can build an application which uses resources"() {
         gradleVersion = version
-        def nativeApp = file("build/native/nativeBuild/java-application")
+        def nativeApp = file("build/native/nativeAssemble/java-application")
         debug = true
         given:
         withSample("java-application-with-resources")
@@ -60,11 +60,11 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
         """
 
         when:
-        run 'nativeBuild'
+        run 'nativeAssemble'
 
         then:
         tasks {
-            succeeded ':jar', ':nativeBuild'
+            succeeded ':jar', ':nativeAssemble'
             doesNotContain ':build', ':run'
         }
 
@@ -92,30 +92,42 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
         junitVersion = System.getProperty('versions.junit')
         [version, [pattern, config]] << [TESTED_GRADLE_VERSIONS,
                                          [["explicit resource declaration", """
-nativeBuild {
-    resources {
-        includedPatterns.add(java.util.regex.Pattern.quote("message.txt"))
+graal {
+    nativeImages {
+        main {
+            resources {
+                includedPatterns.add(java.util.regex.Pattern.quote("message.txt"))
+            }
+        }
     }
 }
 """],
                                          ["detected", """
-nativeBuild {
-    resources {
-        autodetection {
-            enabled = true
-            restrictToProjectDependencies = false
-            detectionExclusionPatterns.add("META-INF/.*")
+graal {
+    nativeImages {
+        main {
+            resources {
+                autodetection {
+                    enabled = true
+                    restrictToProjectDependencies = false
+                    detectionExclusionPatterns.add("META-INF/.*")
+                }
+            }
         }
     }
 }
 """
                                          ],
                                           ["project local detection only", """
-nativeBuild {
-    resources {
-        autodetection {
-            enabled = true
-            restrictToProjectDependencies = true
+graal {
+    nativeImages {
+        main {
+            resources {
+                autodetection {
+                    enabled = true
+                    restrictToProjectDependencies = true
+                }
+            }
         }
     }
 }
@@ -159,19 +171,27 @@ nativeBuild {
         junitVersion = System.getProperty('versions.junit')
         [version, [pattern, config]] << [TESTED_GRADLE_VERSIONS,
                                          [["explicit resource declaration", """
-nativeTest {
-    resources {
-        includedPatterns.add(java.util.regex.Pattern.quote("message.txt"))
-        includedPatterns.add(java.util.regex.Pattern.quote("org/graalvm/demo/expected.txt"))
+graal {
+    nativeImages {
+        test {
+            resources {
+                includedPatterns.add(java.util.regex.Pattern.quote("message.txt"))
+                includedPatterns.add(java.util.regex.Pattern.quote("org/graalvm/demo/expected.txt"))
+            }
+        }
     }
 }
 """],
                                          ["detected", """
-nativeTest {
-    resources {
-        autodetection {
-            enabled = true
-            detectionExclusionPatterns.addAll("META-INF/.*", "junit-platform-unique-ids.*")
+graal {
+    nativeImages {
+        test {
+            resources {
+                autodetection {
+                    enabled = true
+                    detectionExclusionPatterns.addAll("META-INF/.*", "junit-platform-unique-ids.*")
+                }
+            }
         }
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -92,8 +92,8 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
         junitVersion = System.getProperty('versions.junit')
         [version, [pattern, config]] << [TESTED_GRADLE_VERSIONS,
                                          [["explicit resource declaration", """
-graal {
-    nativeImages {
+javaNative {
+    images {
         main {
             resources {
                 includedPatterns.add(java.util.regex.Pattern.quote("message.txt"))
@@ -103,8 +103,8 @@ graal {
 }
 """],
                                          ["detected", """
-graal {
-    nativeImages {
+javaNative {
+    images {
         main {
             resources {
                 autodetection {
@@ -119,8 +119,8 @@ graal {
 """
                                          ],
                                           ["project local detection only", """
-graal {
-    nativeImages {
+javaNative {
+    images {
         main {
             resources {
                 autodetection {
@@ -171,8 +171,8 @@ graal {
         junitVersion = System.getProperty('versions.junit')
         [version, [pattern, config]] << [TESTED_GRADLE_VERSIONS,
                                          [["explicit resource declaration", """
-graal {
-    nativeImages {
+javaNative {
+    images {
         test {
             resources {
                 includedPatterns.add(java.util.regex.Pattern.quote("message.txt"))
@@ -183,8 +183,8 @@ graal {
 }
 """],
                                          ["detected", """
-graal {
-    nativeImages {
+javaNative {
+    images {
         test {
             resources {
                 autodetection {

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
@@ -49,17 +49,17 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
     @Unroll("can execute tests in a native image on Gradle #version with JUnit Platform #junitVersion")
     def "can build a native image and run it"() {
         gradleVersion = version
-        def nativeTestsApp = file("build/native/nativeTestAssemble/java-application-tests")
+        def nativeTestsApp = file("build/native/jvmNativeTestCompile/java-application-tests")
 
         given:
         withSample("java-application-with-tests")
 
         when:
-        run 'nativeTestAssemble'
+        run 'jvmNativeTestCompile'
 
         then:
         tasks {
-            succeeded ':testClasses', ':nativeTestAssemble'
+            succeeded ':testClasses', ':jvmNativeTestCompile'
             // doesNotContain ':build'
         }
         outputDoesNotContain "Running in 'test discovery' mode. Note that this is a fallback mode."
@@ -105,7 +105,7 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         then:
         tasks {
             succeeded ':testClasses',
-                    ':nativeTestAssemble',
+                    ':jvmNativeTestCompile',
                     ':test', // there should probably not be a dependency here
                     ':nativeTest'
             doesNotContain ':build'

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
@@ -49,17 +49,17 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
     @Unroll("can execute tests in a native image on Gradle #version with JUnit Platform #junitVersion")
     def "can build a native image and run it"() {
         gradleVersion = version
-        def nativeTestsApp = file("build/native/jvmNativeTestCompile/java-application-tests")
+        def nativeTestsApp = file("build/native/nativeTestCompile/java-application-tests")
 
         given:
         withSample("java-application-with-tests")
 
         when:
-        run 'jvmNativeTestCompile'
+        run 'nativeTestCompile'
 
         then:
         tasks {
-            succeeded ':testClasses', ':jvmNativeTestCompile'
+            succeeded ':testClasses', ':nativeTestCompile'
             // doesNotContain ':build'
         }
         outputDoesNotContain "Running in 'test discovery' mode. Note that this is a fallback mode."
@@ -105,7 +105,7 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         then:
         tasks {
             succeeded ':testClasses',
-                    ':jvmNativeTestCompile',
+                    ':nativeTestCompile',
                     ':test', // there should probably not be a dependency here
                     ':nativeTest'
             doesNotContain ':build'

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
@@ -49,17 +49,17 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
     @Unroll("can execute tests in a native image on Gradle #version with JUnit Platform #junitVersion")
     def "can build a native image and run it"() {
         gradleVersion = version
-        def nativeTestsApp = file("build/native/nativeTestBuild/java-application-tests")
+        def nativeTestsApp = file("build/native/nativeTestAssemble/java-application-tests")
 
         given:
         withSample("java-application-with-tests")
 
         when:
-        run 'nativeTestBuild'
+        run 'nativeTestAssemble'
 
         then:
         tasks {
-            succeeded ':testClasses', ':nativeTestBuild'
+            succeeded ':testClasses', ':nativeTestAssemble'
             // doesNotContain ':build'
         }
         outputDoesNotContain "Running in 'test discovery' mode. Note that this is a fallback mode."
@@ -105,7 +105,7 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         then:
         tasks {
             succeeded ':testClasses',
-                    ':nativeTestBuild',
+                    ':nativeTestAssemble',
                     ':test', // there should probably not be a dependency here
                     ':nativeTest'
             doesNotContain ':build'

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaLibraryFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaLibraryFunctionalTest.groovy
@@ -57,18 +57,18 @@ class JavaLibraryFunctionalTest extends AbstractFunctionalTest {
             libExt = ".dylib"
         }
 
-        def library = file("build/native/nativeBuild/java-library" + libExt)
+        def library = file("build/native/nativeAssemble/java-library" + libExt)
         debug  = true
 
         given:
         withSample("java-library")
 
         when:
-        run 'nativeBuild'
+        run 'nativeAssemble'
 
         then:
         tasks {
-            succeeded ':jar', ':nativeBuild'
+            succeeded ':jar', ':nativeAssemble'
             doesNotContain ':build'
         }
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaLibraryFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaLibraryFunctionalTest.groovy
@@ -57,18 +57,18 @@ class JavaLibraryFunctionalTest extends AbstractFunctionalTest {
             libExt = ".dylib"
         }
 
-        def library = file("build/native/jvmNativeCompile/java-library" + libExt)
+        def library = file("build/native/nativeCompile/java-library" + libExt)
         debug  = true
 
         given:
         withSample("java-library")
 
         when:
-        run 'jvmNativeCompile'
+        run 'nativeCompile'
 
         then:
         tasks {
-            succeeded ':jar', ':jvmNativeCompile'
+            succeeded ':jar', ':nativeCompile'
             doesNotContain ':build'
         }
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaLibraryFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaLibraryFunctionalTest.groovy
@@ -57,18 +57,18 @@ class JavaLibraryFunctionalTest extends AbstractFunctionalTest {
             libExt = ".dylib"
         }
 
-        def library = file("build/native/nativeAssemble/java-library" + libExt)
+        def library = file("build/native/jvmNativeCompile/java-library" + libExt)
         debug  = true
 
         given:
         withSample("java-library")
 
         when:
-        run 'nativeAssemble'
+        run 'jvmNativeCompile'
 
         then:
         tasks {
-            succeeded ':jar', ':nativeAssemble'
+            succeeded ':jar', ':jvmNativeCompile'
             doesNotContain ':build'
         }
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/KotlinApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/KotlinApplicationWithTestsFunctionalTest.groovy
@@ -60,7 +60,7 @@ class KotlinApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         then:
         tasks {
             succeeded ':compileTestKotlin',
-                    ':nativeTestBuild',
+                    ':nativeTestAssemble',
                     ':test',
                     ':nativeTest'
             doesNotContain ':build'

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/KotlinApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/KotlinApplicationWithTestsFunctionalTest.groovy
@@ -60,7 +60,7 @@ class KotlinApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         then:
         tasks {
             succeeded ':compileTestKotlin',
-                    ':jvmNativeTestCompile',
+                    ':nativeTestCompile',
                     ':test',
                     ':nativeTest'
             doesNotContain ':build'

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/KotlinApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/KotlinApplicationWithTestsFunctionalTest.groovy
@@ -60,7 +60,7 @@ class KotlinApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         then:
         tasks {
             succeeded ':compileTestKotlin',
-                    ':nativeTestAssemble',
+                    ':jvmNativeTestCompile',
                     ':test',
                     ':nativeTest'
             doesNotContain ':build'

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/MultiProjectJavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/MultiProjectJavaApplicationWithTestsFunctionalTest.groovy
@@ -59,7 +59,7 @@ class MultiProjectJavaApplicationWithTestsFunctionalTest extends AbstractFunctio
         tasks {
             succeeded ':utils:jar',
                     ':core:testClasses',
-                    ':core:nativeTestAssemble',
+                    ':core:jvmNativeTestCompile',
                     ':core:nativeTest'
             doesNotContain ':core:build'
         }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/MultiProjectJavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/MultiProjectJavaApplicationWithTestsFunctionalTest.groovy
@@ -59,7 +59,7 @@ class MultiProjectJavaApplicationWithTestsFunctionalTest extends AbstractFunctio
         tasks {
             succeeded ':utils:jar',
                     ':core:testClasses',
-                    ':core:jvmNativeTestCompile',
+                    ':core:nativeTestCompile',
                     ':core:nativeTest'
             doesNotContain ':core:build'
         }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/MultiProjectJavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/MultiProjectJavaApplicationWithTestsFunctionalTest.groovy
@@ -59,7 +59,7 @@ class MultiProjectJavaApplicationWithTestsFunctionalTest extends AbstractFunctio
         tasks {
             succeeded ':utils:jar',
                     ':core:testClasses',
-                    ':core:nativeTestBuild',
+                    ':core:nativeTestAssemble',
                     ':core:nativeTest'
             doesNotContain ':core:build'
         }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
@@ -29,7 +29,7 @@ class NativeImageOptionsTest extends Specification {
                 id 'org.graalvm.buildtools.native'
             }
             
-            assert nativeBuild.javaLauncher
+            assert graal.nativeImages.main.javaLauncher
                 .get()
                 .metadata
                 .languageVersion

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
@@ -29,7 +29,7 @@ class NativeImageOptionsTest extends Specification {
                 id 'org.graalvm.buildtools.native'
             }
             
-            assert graal.nativeImages.main.javaLauncher
+            assert javaNative.images.main.javaLauncher
                 .get()
                 .metadata
                 .languageVersion

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
@@ -29,7 +29,7 @@ class NativeImageOptionsTest extends Specification {
                 id 'org.graalvm.buildtools.native'
             }
             
-            assert javaNative.images.main.javaLauncher
+            assert jvmNative.images.main.javaLauncher
                 .get()
                 .metadata
                 .languageVersion

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
@@ -29,7 +29,7 @@ class NativeImageOptionsTest extends Specification {
                 id 'org.graalvm.buildtools.native'
             }
             
-            assert jvmNative.images.main.javaLauncher
+            assert graalvmNative.binaries.main.javaLauncher
                 .get()
                 .metadata
                 .languageVersion

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -279,7 +279,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                                 project.getExtensions().findByType(JavaToolchainService.class),
                                 project.getName())
                 );
-        return project.getExtensions().create(GraalVMExtension.class, "graal", DefaultGraalVmExtension.class, nativeImages);
+        return project.getExtensions().create(GraalVMExtension.class, "javaNative", DefaultGraalVmExtension.class, nativeImages);
     }
 
     private TaskProvider<GenerateResourcesConfigFile> registerResourcesConfigTask(Provider<Directory> generatedDir,
@@ -335,14 +335,14 @@ public class NativeImagePlugin implements Plugin<Project> {
     }
 
     private static NativeImageOptions createMainOptions(GraalVMExtension graalExtension, Project project) {
-        NativeImageOptions buildExtension = graalExtension.getNativeImages().create(NATIVE_MAIN_EXTENSION);
+        NativeImageOptions buildExtension = graalExtension.getImages().create(NATIVE_MAIN_EXTENSION);
         buildExtension.getClasspath().from(GradleUtils.findMainArtifacts(project));
         buildExtension.getClasspath().from(GradleUtils.findConfiguration(project, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
         return buildExtension;
     }
 
     private static NativeImageOptions createTestOptions(GraalVMExtension graalExtension, Project project, NativeImageOptions mainExtension, DirectoryProperty testListDirectory) {
-        NativeImageOptions testExtension = graalExtension.getNativeImages().create(NATIVE_TEST_EXTENSION);
+        NativeImageOptions testExtension = graalExtension.getImages().create(NATIVE_TEST_EXTENSION);
         testExtension.getMainClass().set("org.graalvm.junit.platform.NativeImageJUnitLauncher");
         testExtension.getMainClass().finalizeValue();
         testExtension.getImageName().convention(mainExtension.getImageName().map(name -> name + SharedConstants.NATIVE_TESTS_SUFFIX));

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -104,8 +104,8 @@ import static org.graalvm.buildtools.utils.SharedConstants.AGENT_PROPERTY;
  */
 @SuppressWarnings("unused")
 public class NativeImagePlugin implements Plugin<Project> {
-    public static final String NATIVE_COMPILE_TASK_NAME = "jvmNativeCompile";
-    public static final String NATIVE_TEST_COMPILE_TASK_NAME = "jvmNativeTestCompile";
+    public static final String NATIVE_COMPILE_TASK_NAME = "nativeCompile";
+    public static final String NATIVE_TEST_COMPILE_TASK_NAME = "nativeTestCompile";
     public static final String NATIVE_TEST_TASK_NAME = "nativeTest";
     public static final String NATIVE_TEST_EXTENSION = "test";
     public static final String NATIVE_MAIN_EXTENSION = "main";
@@ -310,7 +310,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                                 project.getExtensions().findByType(JavaToolchainService.class),
                                 project.getName())
                 );
-        return project.getExtensions().create(GraalVMExtension.class, "jvmNative", DefaultGraalVmExtension.class, nativeImages);
+        return project.getExtensions().create(GraalVMExtension.class, "graalvmNative", DefaultGraalVmExtension.class, nativeImages);
     }
 
     private TaskProvider<GenerateResourcesConfigFile> registerResourcesConfigTask(Provider<Directory> generatedDir,
@@ -366,14 +366,14 @@ public class NativeImagePlugin implements Plugin<Project> {
     }
 
     private static NativeImageOptions createMainOptions(GraalVMExtension graalExtension, Project project) {
-        NativeImageOptions buildExtension = graalExtension.getImages().create(NATIVE_MAIN_EXTENSION);
+        NativeImageOptions buildExtension = graalExtension.getBinaries().create(NATIVE_MAIN_EXTENSION);
         buildExtension.getClasspath().from(GradleUtils.findMainArtifacts(project));
         buildExtension.getClasspath().from(GradleUtils.findConfiguration(project, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
         return buildExtension;
     }
 
     private static NativeImageOptions createTestOptions(GraalVMExtension graalExtension, Project project, NativeImageOptions mainExtension, DirectoryProperty testListDirectory) {
-        NativeImageOptions testExtension = graalExtension.getImages().create(NATIVE_TEST_EXTENSION);
+        NativeImageOptions testExtension = graalExtension.getBinaries().create(NATIVE_TEST_EXTENSION);
         testExtension.getMainClass().set("org.graalvm.junit.platform.NativeImageJUnitLauncher");
         testExtension.getMainClass().finalizeValue();
         testExtension.getImageName().convention(mainExtension.getImageName().map(name -> name + SharedConstants.NATIVE_TESTS_SUFFIX));

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -118,6 +118,8 @@ public class NativeImagePlugin implements Plugin<Project> {
 
     public static final String DEPRECATED_NATIVE_BUILD_EXTENSION = "nativeBuild";
     public static final String DEPRECATED_NATIVE_TEST_EXTENSION = "nativeTest";
+    public static final String DEPRECATED_NATIVE_BUILD_TASK = "nativeBuild";
+    public static final String DEPRECATED_NATIVE_TEST_BUILD_TASK = "nativeTestBuild";
 
     /**
      * This looks strange, but it is used to force the configuration of a dependent
@@ -174,6 +176,10 @@ public class NativeImagePlugin implements Plugin<Project> {
                     builder.getOptions().convention(mainOptions);
                     builder.getAgentEnabled().set(agent);
                 });
+        TaskProvider<Task> deprecatedTask = tasks.register(DEPRECATED_NATIVE_BUILD_TASK, t -> {
+            t.dependsOn(imageBuilder);
+            t.doFirst("Warn about deprecation", task -> task.getLogger().warn("Task " + DEPRECATED_NATIVE_BUILD_TASK + " is deprecated. Use " + NATIVE_ASSEMBLE_TASK_NAME + " instead."));
+        });
         tasks.register(NativeRunTask.TASK_NAME, NativeRunTask.class, task -> {
             task.getImage().convention(imageBuilder.map(t -> t.getOutputFile().get()));
             task.getRuntimeArgs().convention(mainOptions.getRuntimeArgs());
@@ -248,6 +254,10 @@ public class NativeImagePlugin implements Plugin<Project> {
             testList.from(testListDirectory).builtBy(testTask);
             testOptions.getClasspath().from(testList);
             task.getAgentEnabled().set(testAgent);
+        });
+        tasks.register(DEPRECATED_NATIVE_TEST_BUILD_TASK, t -> {
+            t.dependsOn(imageBuilder);
+            t.doFirst("Warn about deprecation", task -> task.getLogger().warn("Task " + DEPRECATED_NATIVE_TEST_BUILD_TASK + " is deprecated. Use " + NATIVE_TEST_ASSEMBLE_TASK_NAME + " instead."));
         });
         configureClasspathJarFor(tasks, testOptions, testImageBuilder);
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
@@ -54,10 +54,10 @@ public interface GraalVMExtension {
      * By default, this plugin creates two images, one called "main" for
      * the main application and another one called "test" for tests.
      */
-    NamedDomainObjectContainer<NativeImageOptions> getImages();
+    NamedDomainObjectContainer<NativeImageOptions> getBinaries();
 
     /**
      * Configures the native image options.
      */
-    void images(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec);
+    void binaries(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec);
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -39,36 +39,25 @@
  * SOFTWARE.
  */
 
-plugins {
-    id 'application'
-    id 'org.graalvm.buildtools.native'
-}
+package org.graalvm.buildtools.gradle.dsl;
 
-repositories {
-    mavenCentral()
-}
+import org.gradle.api.Action;
+import org.gradle.api.NamedDomainObjectContainer;
 
-application {
-    mainClass.set('org.graalvm.demo.Application')
-}
+/**
+ * This is the entry point for configuring GraalVM relative features
+ * provided by this plugin.
+ */
+public interface GraalVMExtension {
+    /**
+     * Returns the native image configurations used to generate images.
+     * By default, this plugin creates two images, one called "main" for
+     * the main application and another one called "test" for tests.
+     */
+    NamedDomainObjectContainer<NativeImageOptions> getNativeImages();
 
-def junitVersion = providers.gradleProperty('junit.jupiter.version')
-        .forUseAtConfigurationTime()
-        .get()
-
-dependencies {
-    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-}
-
-test {
-    useJUnitPlatform()
-}
-
-graal {
-    nativeImages {
-        test {
-            agent = true
-        }
-    }
+    /**
+     * Configures the native image options.
+     */
+    void nativeImages(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec);
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
@@ -54,10 +54,10 @@ public interface GraalVMExtension {
      * By default, this plugin creates two images, one called "main" for
      * the main application and another one called "test" for tests.
      */
-    NamedDomainObjectContainer<NativeImageOptions> getNativeImages();
+    NamedDomainObjectContainer<NativeImageOptions> getImages();
 
     /**
      * Configures the native image options.
      */
-    void nativeImages(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec);
+    void images(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec);
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
@@ -78,9 +78,13 @@ import java.util.stream.StreamSupport;
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public abstract class NativeImageOptions implements Named {
+    private final String name;
+
     @Override
     @Internal
-    public abstract String getName();
+    public String getName() {
+        return name;
+    }
 
     /**
      * Gets the name of the native executable to be generated.
@@ -206,10 +210,12 @@ public abstract class NativeImageOptions implements Named {
     }
 
     @Inject
-    public NativeImageOptions(ObjectFactory objectFactory,
+    public NativeImageOptions(String name,
+                              ObjectFactory objectFactory,
                               ProviderFactory providers,
                               JavaToolchainService toolchains,
                               String defaultImageName) {
+        this.name = name;
         getDebug().convention(false);
         getFallback().convention(false);
         getVerbose().convention(false);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
@@ -42,10 +42,10 @@
 package org.graalvm.buildtools.gradle.dsl;
 
 import org.graalvm.buildtools.gradle.internal.GradleUtils;
+import org.gradle.api.Named;
 import org.graalvm.buildtools.utils.SharedConstants;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
@@ -56,6 +56,7 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
@@ -76,7 +77,11 @@ import java.util.stream.StreamSupport;
  * @author gkrocher
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public abstract class NativeImageOptions {
+public abstract class NativeImageOptions implements Named {
+    @Override
+    @Internal
+    public abstract String getName();
+
     /**
      * Gets the name of the native executable to be generated.
      *
@@ -227,16 +232,6 @@ public abstract class NativeImageOptions {
                 .forUseAtConfigurationTime()
                 .map(Boolean::valueOf)
                 .orElse(false);
-    }
-
-    public static NativeImageOptions register(Project project, String extensionName) {
-        return project.getExtensions().create(extensionName,
-                NativeImageOptions.class,
-                project.getObjects(),
-                project.getProviders(),
-                project.getExtensions().findByType(JavaToolchainService.class),
-                project.getName()
-        );
     }
 
     /**

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -157,15 +157,6 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
     public abstract Property<Boolean> getDebug();
 
     /**
-     * Returns the server property, used to determine if the native image
-     * build server should be used.
-     *
-     * @return the server property
-     */
-    @Input
-    public abstract Property<Boolean> getServer();
-
-    /**
      * @return Whether to enable fallbacks (defaults to false).
      */
     @Input
@@ -226,7 +217,6 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
                                   String defaultImageName) {
         this.name = name;
         getDebug().convention(false);
-        getServer().convention(false);
         getFallback().convention(false);
         getVerbose().convention(false);
         getAgent().convention(false);
@@ -367,16 +357,4 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         );
         return this;
     }
-
-    /**
-     * Enables server build. Server build is disabled by default.
-     *
-     * @param enabled Value which controls whether the server build is enabled.
-     * @return this
-     */
-    public BaseNativeImageOptions enableServerBuild(boolean enabled) {
-        getServer().set(enabled);
-        return this;
-    }
-
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -57,12 +57,12 @@ public class DefaultGraalVmExtension implements GraalVMExtension {
     }
 
     @Override
-    public NamedDomainObjectContainer<NativeImageOptions> getImages() {
+    public NamedDomainObjectContainer<NativeImageOptions> getBinaries() {
         return nativeImages;
     }
 
     @Override
-    public void images(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec) {
+    public void binaries(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec) {
         spec.execute(nativeImages);
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -39,36 +39,30 @@
  * SOFTWARE.
  */
 
-plugins {
-    id 'application'
-    id 'org.graalvm.buildtools.native'
-}
+package org.graalvm.buildtools.gradle.internal;
 
-repositories {
-    mavenCentral()
-}
+import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
+import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
+import org.gradle.api.Action;
+import org.gradle.api.NamedDomainObjectContainer;
 
-application {
-    mainClass.set('org.graalvm.demo.Application')
-}
+import javax.inject.Inject;
 
-def junitVersion = providers.gradleProperty('junit.jupiter.version')
-        .forUseAtConfigurationTime()
-        .get()
+public class DefaultGraalVmExtension implements GraalVMExtension {
+    private final NamedDomainObjectContainer<NativeImageOptions> nativeImages;
 
-dependencies {
-    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-}
+    @Inject
+    public DefaultGraalVmExtension(NamedDomainObjectContainer<NativeImageOptions> nativeImages) {
+        this.nativeImages = nativeImages;
+    }
 
-test {
-    useJUnitPlatform()
-}
+    @Override
+    public NamedDomainObjectContainer<NativeImageOptions> getNativeImages() {
+        return nativeImages;
+    }
 
-graal {
-    nativeImages {
-        test {
-            agent = true
-        }
+    @Override
+    public void nativeImages(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec) {
+        spec.execute(nativeImages);
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -57,12 +57,12 @@ public class DefaultGraalVmExtension implements GraalVMExtension {
     }
 
     @Override
-    public NamedDomainObjectContainer<NativeImageOptions> getNativeImages() {
+    public NamedDomainObjectContainer<NativeImageOptions> getImages() {
         return nativeImages;
     }
 
     @Override
-    public void nativeImages(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec) {
+    public void images(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec) {
         spec.execute(nativeImages);
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
@@ -93,7 +93,7 @@ public abstract class DeprecatedNativeImageOptions implements NativeImageOptions
 
     private void issueWarning() {
         if (warned.compareAndSet(false, true)) {
-            logger.warn("The " + name + " extension is deprecated and will be removed. Please use the 'jvmNative.images." + replacedWith + "' extension to configure the native image instead.");
+            logger.warn("The " + name + " extension is deprecated and will be removed. Please use the 'graalvmNative.binaries." + replacedWith + "' extension to configure the native image instead.");
         }
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
@@ -93,7 +93,7 @@ public abstract class DeprecatedNativeImageOptions implements NativeImageOptions
 
     private void issueWarning() {
         if (warned.compareAndSet(false, true)) {
-            logger.warn("The " + name + " extension is deprecated and will be removed. Please use the 'javaNative.images." + replacedWith + "' extension to configure the native image instead.");
+            logger.warn("The " + name + " extension is deprecated and will be removed. Please use the 'jvmNative.images." + replacedWith + "' extension to configure the native image instead.");
         }
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
@@ -155,12 +155,6 @@ public abstract class DeprecatedNativeImageOptions implements NativeImageOptions
 
     @Override
     @Input
-    public Property<Boolean> getServer() {
-        return warnAboutDeprecation(delegate::getServer);
-    }
-
-    @Override
-    @Input
     public Property<Boolean> getFallback() {
         return warnAboutDeprecation(delegate::getFallback);
     }
@@ -249,10 +243,5 @@ public abstract class DeprecatedNativeImageOptions implements NativeImageOptions
     @Override
     public NativeImageOptions runtimeArgs(Iterable<?> arguments) {
         return warnAboutDeprecation(() ->delegate.runtimeArgs(arguments));
-    }
-
-    @Override
-    public NativeImageOptions enableServerBuild(boolean enabled) {
-        return warnAboutDeprecation(() -> delegate.enableServerBuild(enabled));
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.internal;
+
+import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
+import org.graalvm.buildtools.gradle.dsl.NativeResourcesOptions;
+import org.gradle.api.Action;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated
+public abstract class DeprecatedNativeImageOptions implements NativeImageOptions {
+    private final String name;
+    private final NativeImageOptions delegate;
+    private final String replacedWith;
+    private final Logger logger;
+    private final AtomicBoolean warned = new AtomicBoolean();
+
+    @Inject
+    public DeprecatedNativeImageOptions(String name,
+                                        NativeImageOptions delegate,
+                                        String replacedWith,
+                                        Logger logger) {
+        this.name = name;
+        this.delegate = delegate;
+        this.replacedWith = replacedWith;
+        this.logger = logger;
+    }
+
+    private <T> T warnAboutDeprecation(Supplier<T> action) {
+        issueWarning();
+        return action.get();
+    }
+
+    private void warnAboutDeprecation(Runnable action) {
+        issueWarning();
+        action.run();
+    }
+
+    private void issueWarning() {
+        if (warned.compareAndSet(false, true)) {
+            logger.warn("The " + name + " extension is deprecated and will be removed. Please use the 'javaNative.images." + replacedWith + "' extension to configure the native image instead.");
+        }
+    }
+
+    @Override
+    @Internal
+    public String getName() {
+        return warnAboutDeprecation(delegate::getName);
+    }
+
+    @Override
+    @Input
+    public Property<String> getImageName() {
+        return warnAboutDeprecation(delegate::getImageName);
+    }
+
+    @Override
+    @Optional
+    @Input
+    public Property<String> getMainClass() {
+        return warnAboutDeprecation(delegate::getMainClass);
+    }
+
+    @Override
+    @Input
+    public ListProperty<String> getBuildArgs() {
+        return warnAboutDeprecation(delegate::getBuildArgs);
+    }
+
+    @Override
+    @Input
+    public MapProperty<String, Object> getSystemProperties() {
+        return warnAboutDeprecation(delegate::getSystemProperties);
+    }
+
+    @Override
+    @Classpath
+    @InputFiles
+    public ConfigurableFileCollection getClasspath() {
+        return warnAboutDeprecation(delegate::getClasspath);
+    }
+
+    @Override
+    @Input
+    public ListProperty<String> getJvmArgs() {
+        return warnAboutDeprecation(delegate::getJvmArgs);
+    }
+
+    @Override
+    @Input
+    public ListProperty<String> getRuntimeArgs() {
+        return warnAboutDeprecation(delegate::getRuntimeArgs);
+    }
+
+    @Override
+    @Input
+    public Property<Boolean> getDebug() {
+        return warnAboutDeprecation(delegate::getDebug);
+    }
+
+    @Override
+    @Input
+    public Property<Boolean> getServer() {
+        return warnAboutDeprecation(delegate::getServer);
+    }
+
+    @Override
+    @Input
+    public Property<Boolean> getFallback() {
+        return warnAboutDeprecation(delegate::getFallback);
+    }
+
+    @Override
+    @Input
+    public Property<Boolean> getVerbose() {
+        return warnAboutDeprecation(delegate::getVerbose);
+    }
+
+    @Override
+    @Input
+    public Property<Boolean> getAgent() {
+        return warnAboutDeprecation(delegate::getAgent);
+    }
+
+    @Override
+    @Input
+    public Property<Boolean> getSharedLibrary() {
+        return warnAboutDeprecation(delegate::getSharedLibrary);
+    }
+
+    @Override
+    @Nested
+    public Property<JavaLauncher> getJavaLauncher() {
+        return warnAboutDeprecation(delegate::getJavaLauncher);
+    }
+
+    @Override
+    @InputFiles
+    public ConfigurableFileCollection getConfigurationFileDirectories() {
+        return warnAboutDeprecation(delegate::getConfigurationFileDirectories);
+    }
+
+    @Override
+    @Nested
+    public NativeResourcesOptions getResources() {
+        return warnAboutDeprecation(delegate::getResources);
+    }
+
+    @Override
+    public void resources(Action<? super NativeResourcesOptions> spec) {
+        warnAboutDeprecation(() -> delegate.resources(spec));
+    }
+
+    @Override
+    public NativeImageOptions buildArgs(Object... buildArgs) {
+        return warnAboutDeprecation(() -> delegate.buildArgs(buildArgs));
+    }
+
+    @Override
+    public NativeImageOptions buildArgs(Iterable<?> buildArgs) {
+        return warnAboutDeprecation(() -> delegate.buildArgs(buildArgs));
+    }
+
+    @Override
+    public NativeImageOptions systemProperties(Map<String, ?> properties) {
+        return warnAboutDeprecation(() -> delegate.systemProperties(properties));
+    }
+
+    @Override
+    public NativeImageOptions systemProperty(String name, Object value) {
+        return warnAboutDeprecation(() -> delegate.systemProperty(name, value));
+    }
+
+    @Override
+    public NativeImageOptions classpath(Object... paths) {
+        return warnAboutDeprecation(() -> delegate.classpath(paths));
+    }
+
+    @Override
+    public NativeImageOptions jvmArgs(Object... arguments) {
+        return warnAboutDeprecation(() -> delegate.jvmArgs(arguments));
+    }
+
+    @Override
+    public NativeImageOptions jvmArgs(Iterable<?> arguments) {
+        return warnAboutDeprecation(() -> delegate.jvmArgs(arguments));
+    }
+
+    @Override
+    public NativeImageOptions runtimeArgs(Object... arguments) {
+        return warnAboutDeprecation(() -> delegate.runtimeArgs(arguments));
+    }
+
+    @Override
+    public NativeImageOptions runtimeArgs(Iterable<?> arguments) {
+        return warnAboutDeprecation(() ->delegate.runtimeArgs(arguments));
+    }
+
+    @Override
+    public NativeImageOptions enableServerBuild(boolean enabled) {
+        return warnAboutDeprecation(() -> delegate.enableServerBuild(enabled));
+    }
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -49,6 +49,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -61,7 +62,6 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
-import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
 
@@ -123,9 +123,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         Provider<Directory> outputDir = buildDir.dir("native/" + getName());
         getWorkingDirectory().set(outputDir);
         setDescription("Builds a native image.");
-        setGroup(LifecycleBasePlugin.BUILD_GROUP);
-
-        getOptions().convention(getProject().getExtensions().findByType(NativeImageOptions.class));
+        setGroup(JavaBasePlugin.VERIFICATION_GROUP);
         getOutputDirectory().convention(outputDir);
         this.graalvmHomeProvider = getProject().getProviders().environmentVariable("GRAALVM_HOME");
     }

--- a/samples/java-application-with-reflection/build.gradle
+++ b/samples/java-application-with-reflection/build.gradle
@@ -65,6 +65,8 @@ test {
     useJUnitPlatform()
 }
 
-nativeTest {
-    agent = true
+graal {
+    test {
+        agent = true
+    }
 }

--- a/samples/java-application-with-reflection/build.gradle
+++ b/samples/java-application-with-reflection/build.gradle
@@ -65,8 +65,8 @@ test {
     useJUnitPlatform()
 }
 
-graal {
-    nativeImages {
+javaNative {
+    images {
         test {
             agent = true
         }

--- a/samples/java-application-with-reflection/build.gradle
+++ b/samples/java-application-with-reflection/build.gradle
@@ -65,8 +65,8 @@ test {
     useJUnitPlatform()
 }
 
-jvmNative {
-    images {
+graalvmNative {
+    binaries {
         test {
             agent = true
         }

--- a/samples/java-application-with-reflection/build.gradle
+++ b/samples/java-application-with-reflection/build.gradle
@@ -65,7 +65,7 @@ test {
     useJUnitPlatform()
 }
 
-javaNative {
+jvmNative {
     images {
         test {
             agent = true

--- a/samples/java-library/build.gradle
+++ b/samples/java-library/build.gradle
@@ -57,8 +57,8 @@ dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter')
 }
 
-jvmNative {
-    images {
+graalvmNative {
+    binaries {
         main {
             verbose = true
         }

--- a/samples/java-library/build.gradle
+++ b/samples/java-library/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter')
 }
 
-javaNative {
+jvmNative {
     images {
         main {
             verbose = true

--- a/samples/java-library/build.gradle
+++ b/samples/java-library/build.gradle
@@ -57,8 +57,12 @@ dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter')
 }
 
-nativeBuild {
-    verbose=true
+graal {
+    nativeImages {
+        main {
+            verbose = true
+        }
+    }
 }
 
 test {

--- a/samples/java-library/build.gradle
+++ b/samples/java-library/build.gradle
@@ -57,8 +57,8 @@ dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter')
 }
 
-graal {
-    nativeImages {
+javaNative {
+    images {
         main {
             verbose = true
         }


### PR DESCRIPTION
This is a follow-up to the idiomatic Gradle conversion. Before this commit,
there were 2 extensions configured at the top level, with the same type,
to configure the main native image and the test native image. Those
extensions were respectively named `nativeBuild` and `nativeTest`. In
addition, there were 2 tasks with similar names, which had slightly
different semantics: `nativeBuild` would build the main image, but
`nativeTest` would _run_ the tests. The task which would build the native
test image was called `nativeTestBuild`.

There were therefore a few issues to fix:

- the confusion between the extension names and the task names, making it
unclear whether you were configuring one or the other
- the fact that multiple extensions of the same type were created, which is
considered an anti-pattern in Gradle and makes it complicated to get the
expected extensions (See https://github.com/gradle/gradle/issues/17622)
- it was complicated to add support for more test images, as hinted by
the follow up issue #77

So this commit changes the configuration to use an idiomatic container,
named `graalvmNative` which can contain _many_ images. For now it contains only
two:

```
graalvmNative {
    binaries {
        main {
            // .. the main native image
        }
        test {
            // .. the test image
        }
    }
}
```

In addition, it renames the confusing task names to something closer to the
actual semantics of other tasks in Gradle:

- `nativeBuild` -> `nativeCompile` (`build` does much more)
- `nativeTestBuild` -> `nativeTestCompile`