### PR TITLE
Default to the current Java version

### DIFF
--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
@@ -1,0 +1,44 @@
+package org.graalvm.buildtools.gradle
+
+
+import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Issue
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Path
+
+class NativeImageOptionsTest extends Specification {
+    @TempDir
+    Path testDirectory
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/109")
+    def "toolchain defaults to the current Java version"() {
+        when:
+        def runner = GradleRunner.create()
+                .forwardStdOutput(new PrintWriter(System.out))
+                .forwardStdError(new PrintWriter(System.err))
+                .withPluginClasspath()
+                .withProjectDir(testDirectory.toFile())
+
+
+        def buildFile = testDirectory.resolve("build.gradle")
+        buildFile.text = """
+            plugins {
+                id 'java'
+                id 'org.graalvm.buildtools.native'
+            }
+            
+            assert nativeBuild.javaLauncher
+                .get()
+                .metadata
+                .languageVersion
+                .toString() == JavaVersion.current().majorVersion
+        """
+
+        runner.build()
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
@@ -43,6 +43,7 @@ package org.graalvm.buildtools.gradle.dsl;
 
 import org.graalvm.buildtools.gradle.internal.GradleUtils;
 import org.gradle.api.Action;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.model.ObjectFactory;
@@ -210,7 +211,7 @@ public abstract class NativeImageOptions {
         getImageName().convention(defaultImageName);
         getJavaLauncher().convention(
                 toolchains.launcherFor(spec -> {
-                    spec.getLanguageVersion().set(JavaLanguageVersion.of(11));
+                    spec.getLanguageVersion().set(JavaLanguageVersion.of(JavaVersion.current().getMajorVersion()));
                     if (GradleUtils.isAtLeastGradle7()) {
                         spec.getVendor().set(JvmVendorSpec.matching("GraalVM"));
                     }


### PR DESCRIPTION
This is a workaround for Gradle < 7 not being able to set the vendor
requirement, which causes hard to diagnose errors.

Fixes #109