### PR TITLE
Exclude sha256/512 from release zip

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,10 @@ val pruneCommonRepo = tasks.register<Delete>("pruneCommonRepository") {
 
 tasks.register<Zip>("releaseZip") {
     dependsOn(pruneCommonRepo, "publishAllPublicationsToCommonRepository")
-    from(commonRepo)
+    from(commonRepo) {
+        exclude("**/*.sha256")
+        exclude("**/*.sha512")
+    }
 }
 
 tasks.register<org.graalvm.build.samples.SamplesUpdateTask>("updateSamples") {


### PR DESCRIPTION
This is a release process enhancement only: the current repository doesn't support sha256/sha512
so we're intentionally excluding them from the release zip so that the review of published
artifacts is easier.