### PR TITLE
Fix documentation CI script

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,8 +20,5 @@ jobs:
           echo "JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
           echo "GRAALVM_HOME=$GRAALVM_HOME" >> $GITHUB_ENV
       - name: Build documentation
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: :docs:asciidoctor
-          distributions-cache-enabled: true
-          dependencies-cache-enabled: true
+        run: |
+          ./gradlew :docs:asciidoctor


### PR DESCRIPTION
Since `eskatos/gradle-command-action@v1` is disabled due to security policy, lets invoke Gradle directly.