### PR TITLE
Add a `sharedLibrary` configuration option for Gradle plugin

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -146,6 +146,8 @@ nativeBuild {
   verbose = true // Add verbose output, defaults to false
   fallback = true // Sets the fallback mode of native-image, defaults to false
   server = true // Sets the server mode, defaults to false
+  sharedLibrary = false // Determines if image is a shared library, defaults to false if `java-library` plugin isn't included
+
   systemProperties = [name1: 'value1', name2: 'value2'] // Sets the system properties to use for the native image builder
   configurationFileDirectories.from(file('src/my-config')) // Adds a native image configuration file directory, containing files like reflection configuration
 
@@ -171,6 +173,8 @@ nativeBuild {
   verbose.set(true) // Add verbose output, defaults to false
   fallback.set(true) // Sets the fallback mode of native-image, defaults to false
   server.set(true) // Sets the server mode, defaults to false
+  sharedLibrary.set(false) // Determines if image is a shared library, defaults to false if `java-library` plugin isn't included
+
   systemProperties.putAll(mapOf(name1 to "value1", name2 to "value2")) // Sets the system properties to use for the native image builder
   configurationFileDirectories.from(file("src/my-config")) // Adds a native image configuration file directory, containing files like reflection configuration
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaLibraryFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaLibraryFunctionalTest.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.gradle
+
+import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
+
+class JavaLibraryFunctionalTest extends AbstractFunctionalTest {
+
+    def "can build a native image for a simple library"() {
+        gradleVersion = version
+
+        def libExt = ""
+        if (IS_LINUX) {
+            libExt = ".so"
+        } else if (IS_WINDOWS) {
+            libExt = ".dll"
+        } else if (IS_MAC) {
+            libExt = ".dylib"
+        }
+
+        def library = file("build/native/nativeBuild/java-library" + libExt)
+        debug  = true
+
+        given:
+        withSample("java-library")
+
+        when:
+        run 'nativeBuild'
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeBuild'
+            doesNotContain ':build'
+        }
+
+        outputContains "-H:+SharedLibrary"
+
+        and:
+        library.exists()
+
+        where:
+        version << TESTED_GRADLE_VERSIONS
+    }
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -134,6 +134,8 @@ public class NativeImagePlugin implements Plugin<Project> {
                 project.getExtensions().findByType(JavaApplication.class).getMainClass()
         ));
 
+        project.getPlugins().withId("java-library", p -> buildExtension.getSharedLibrary().convention(true));
+
         registerServiceProvider(project, nativeImageServiceProvider);
 
         // Register Native Image tasks

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
@@ -178,6 +178,14 @@ public abstract class NativeImageOptions {
     public abstract Property<Boolean> getAgent();
 
     /**
+     * Gets the value which determines if shared library is being built.
+     *
+     * @return The value which determines if shared library is being built.
+     */
+    @Input
+    public abstract Property<Boolean> getSharedLibrary();
+
+    /**
      * Returns the toolchain used to invoke native-image. Currently pointing
      * to a Java launcher due to Gradle limitations.
      */
@@ -210,6 +218,7 @@ public abstract class NativeImageOptions {
         getFallback().convention(false);
         getVerbose().convention(false);
         getAgent().convention(false);
+        getSharedLibrary().convention(false);
         getImageName().convention(defaultImageName);
         getJavaLauncher().convention(
                 toolchains.launcherFor(spec -> {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -105,6 +105,7 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         appendBooleanOption(cliArgs, options.getFallback().map(NEGATE), "--no-fallback");
         appendBooleanOption(cliArgs, options.getVerbose(), "--verbose");
         appendBooleanOption(cliArgs, options.getServer(), "-Dcom.oracle.graalvm.isaot=true");
+        appendBooleanOption(cliArgs, options.getSharedLibrary(), "--shared");
         if (getOutputDirectory().isPresent()) {
             cliArgs.add("-H:Path=" + getOutputDirectory().get());
         }

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -70,6 +70,10 @@ abstract class AbstractFunctionalTest extends Specification {
     String gradleVersion
     boolean debug
 
+    boolean IS_WINDOWS = System.getProperty("os.name", "unknown").contains("Windows");
+    boolean IS_LINUX = System.getProperty("os.name", "unknown").contains("Linux");
+    boolean IS_MAC = System.getProperty("os.name", "unknown").contains("Mac");
+
     private StringWriter outputWriter
     private StringWriter errorOutputWriter
     private String output

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaLibraryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaLibraryFunctionalTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.maven
+
+class JavaLibraryFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
+    def "can build native image of a library with the Maven plugin"() {
+        withSample("java-library")
+
+        def libExt = ""
+        if (IS_LINUX) {
+            libExt = ".so"
+        } else if (IS_WINDOWS) {
+            libExt = ".dll"
+        } else if (IS_MAC) {
+            libExt = ".dylib"
+        }
+
+        def library = file("target/java-library" + libExt)
+
+        when:
+        mvn '-Pnative', '-DskipTests', 'package'
+
+        then:
+        buildSucceeded
+        outputContains "--shared"
+        and:
+        library.exists()
+
+    }
+}

--- a/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/AbstractGraalVMMavenFunctionalTest.groovy
+++ b/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/AbstractGraalVMMavenFunctionalTest.groovy
@@ -56,6 +56,10 @@ abstract class AbstractGraalVMMavenFunctionalTest extends Specification {
 
     MavenExecutionResult result
 
+    boolean IS_WINDOWS = System.getProperty("os.name", "unknown").contains("Windows");
+    boolean IS_LINUX = System.getProperty("os.name", "unknown").contains("Linux");
+    boolean IS_MAC = System.getProperty("os.name", "unknown").contains("Mac");
+
     def setup() {
         executor = new IsolatedMavenExecutor(
                 new File(System.getProperty("java.executable")),

--- a/samples/java-library/build.gradle
+++ b/samples/java-library/build.gradle
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+plugins {
+    id 'java-library'
+    id 'org.graalvm.buildtools.native'
+}
+
+repositories {
+    mavenCentral()
+}
+
+def junitVersion = providers.gradleProperty('junit.jupiter.version')
+    .forUseAtConfigurationTime()
+    .get()
+
+dependencies {
+    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
+    testImplementation('org.junit.jupiter:junit-jupiter')
+}
+
+nativeBuild {
+    verbose=true
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/samples/java-library/gradle.properties
+++ b/samples/java-library/gradle.properties
@@ -1,0 +1,3 @@
+native.gradle.plugin.version = 0.9.3-SNAPSHOT
+junit.jupiter.version = 5.7.2
+junit.platform.version = 1.7.2

--- a/samples/java-library/pom.xml
+++ b/samples/java-library/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    The Universal Permissive License (UPL), Version 1.0
+
+    Subject to the condition set forth below, permission is hereby granted to any
+    person obtaining a copy of this software, associated documentation and/or
+    data (collectively the "Software"), free of charge and under any and all
+    copyright rights in the Software, and any and all patent rights owned or
+    freely licensable by each licensor hereunder covering either (i) the
+    unmodified Software as contributed to or provided by such licensor, or (ii)
+    the Larger Works (as defined below), to deal in both
+
+    (a) the Software, and
+
+    (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+    one is included with the Software each a "Larger Work" to which the Software
+    is contributed by such licensors),
+
+    without restriction, including without limitation the rights to copy, create
+    derivative works of, display, perform, and distribute the Software and make,
+    use, sell, offer for sale, import, export, have made, and have sold the
+    Software and the Larger Work(s), and to sublicense the foregoing rights on
+    either these or other terms.
+
+    This license is subject to the following condition:
+
+    The above copyright notice and either this complete permission notice or at a
+    minimum a reference to the UPL must be included in all copies or substantial
+    portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.graalvm.buildtools.examples</groupId>
+    <artifactId>maven</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <java.version>1.8</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <native.maven.plugin.version>0.9.3-SNAPSHOT</native.maven.plugin.version>
+        <junit.platform.native.version>0.9.3-SNAPSHOT</junit.platform.native.version>
+        <imageName>java-library</imageName>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>junit-platform-native</artifactId>
+            <version>${junit.platform.native.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skip>false</skip>
+                            <imageName>${imageName}</imageName>
+                            <buildArgs>
+                                <buildArg>--no-fallback</buildArg>
+                                <buildArg>--shared</buildArg>
+                            </buildArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>1.8</target>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>${mainClass}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/samples/java-library/settings.gradle
+++ b/samples/java-library/settings.gradle
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+pluginManagement {
+    plugins {
+        id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
+    }
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = 'java-library'

--- a/samples/java-library/src/main/java/org/graalvm/demo/Library.java
+++ b/samples/java-library/src/main/java/org/graalvm/demo/Library.java
@@ -1,0 +1,7 @@
+package org.graalvm.demo;
+
+public class Library {
+    public boolean someLibraryMethod() {
+        return true;
+    }
+}

--- a/samples/java-library/src/test/java/org/graalvm/demo/LibraryTest.java
+++ b/samples/java-library/src/test/java/org/graalvm/demo/LibraryTest.java
@@ -1,0 +1,11 @@
+package org.graalvm.demo;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LibraryTest {
+    @Test void testSomeLibraryMethod() {
+        Library classUnderTest = new Library();
+        assertTrue(classUnderTest.someLibraryMethod(), "someLibraryMethod should return 'true'");
+    }
+}


### PR DESCRIPTION
This commit adds `sharedLibrary` configuration option to the Gradle plugin as it was a requested feature (closes #119).
`java-library` test sample is also included as well as corresponding functional test.