### PR TITLE
Remove broken `server` configuration option

### DIFF
--- a/build-logic/src/main/kotlin/org.graalvm.build.java.gradle.kts
+++ b/build-logic/src/main/kotlin/org.graalvm.build.java.gradle.kts
@@ -80,6 +80,7 @@ tasks.javadoc {
         languageVersion.set(JavaLanguageVersion.of(11))
     })
     (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
+    (options as StandardJavadocDocletOptions).noTimestamp(true)
 }
 
 tasks.withType<Test>().configureEach {

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -145,7 +145,6 @@ nativeBuild {
   debug = true // Determines if debug info should be generated, defaults to false
   verbose = true // Add verbose output, defaults to false
   fallback = true // Sets the fallback mode of native-image, defaults to false
-  server = true // Sets the server mode, defaults to false
   sharedLibrary = false // Determines if image is a shared library, defaults to false if `java-library` plugin isn't included
 
   systemProperties = [name1: 'value1', name2: 'value2'] // Sets the system properties to use for the native image builder
@@ -172,7 +171,6 @@ nativeBuild {
   debug.set(true) // Determines if debug info should be generated, defaults to false
   verbose.set(true) // Add verbose output, defaults to false
   fallback.set(true) // Sets the fallback mode of native-image, defaults to false
-  server.set(true) // Sets the server mode, defaults to false
   sharedLibrary.set(false) // Determines if image is a shared library, defaults to false if `java-library` plugin isn't included
 
   systemProperties.putAll(mapOf(name1 to "value1", name2 to "value2")) // Sets the system properties to use for the native image builder

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
@@ -147,15 +147,6 @@ public abstract class NativeImageOptions {
     public abstract Property<Boolean> getDebug();
 
     /**
-     * Returns the server property, used to determine if the native image
-     * build server should be used.
-     *
-     * @return the server property
-     */
-    @Input
-    public abstract Property<Boolean> getServer();
-
-    /**
      * @return Whether to enable fallbacks (defaults to false).
      */
     @Input
@@ -214,7 +205,6 @@ public abstract class NativeImageOptions {
                               JavaToolchainService toolchains,
                               String defaultImageName) {
         getDebug().convention(false);
-        getServer().convention(false);
         getFallback().convention(false);
         getVerbose().convention(false);
         getAgent().convention(false);
@@ -362,17 +352,6 @@ public abstract class NativeImageOptions {
                         .map(String::valueOf)
                         .collect(Collectors.toList())
         );
-        return this;
-    }
-
-    /**
-     * Enables server build. Server build is disabled by default.
-     *
-     * @param enabled Value which controls whether the server build is enabled.
-     * @return this
-     */
-    public NativeImageOptions enableServerBuild(boolean enabled) {
-        getServer().set(enabled);
         return this;
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -104,7 +104,6 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         appendBooleanOption(cliArgs, options.getDebug(), "-H:GenerateDebugInfo=1");
         appendBooleanOption(cliArgs, options.getFallback().map(NEGATE), "--no-fallback");
         appendBooleanOption(cliArgs, options.getVerbose(), "--verbose");
-        appendBooleanOption(cliArgs, options.getServer(), "-Dcom.oracle.graalvm.isaot=true");
         appendBooleanOption(cliArgs, options.getSharedLibrary(), "--shared");
         if (getOutputDirectory().isPresent()) {
             cliArgs.add("-H:Path=" + getOutputDirectory().get());


### PR DESCRIPTION
This option originated from Micronaut Gradle plugin. 
In Micronaut plugin it is connected to the `verbose` configuration option, and thus broken.
As it isn't functional and server building is now disabled by default, it is removed here.
This commit also disables JavaDoc timestamp.