### PR TITLE
Use a classpath jar under Windows

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -159,6 +159,8 @@ nativeBuild {
 
   // Development options
   agent = true // Enables the reflection agent. Can be also set on command line using '-Pagent'
+
+  useFatJar = true // Instead of passing each jar individually, builds a fat jar
 }
 ```
 
@@ -185,10 +187,54 @@ nativeBuild {
 
   // Development options
   agent.set(true) // Enables the reflection agent. Can be also set on command line using '-Pagent'
+
+
+  useFatJar.set(true) // Instead of passing each jar individually, builds a fat jar
 }
 ```
 
 NOTE: For options that can be set using command-line, if both DSL and command-line options are present, command-line options take precedence.
+
+==== Long classpath and fat jar support
+
+Under Windows, https://github.com/graalvm/native-build-tools/issues/85[it is possible that the length of the classpath exceeds what the operating system supports] when invoking the CLI to build a native image.
+As a consequence, if you are running under Windows, the plugin will automatically shorten the classpath of your project by building a so called "fat jar", which includes all entries from the classpath automatically.
+
+In case this behavior is not required, you can disable the fat jar creation by calling:
+
+.Disabling the fat jar creation
+[role="multi-language-sample"]
+```groovy
+nativeBuild {
+    useFatJar = false
+}
+```
+
+[role="multi-language-sample"]
+```kotlin
+nativeBuild {
+    useFatJar.set(false)
+}
+```
+
+Alternatively, it is possible to use your own fat jar (for example created using the https://imperceptiblethoughts.com/shadow/[Shadow plugin]) by setting the `classpathJar` property directly on the _task_:
+
+.Disabling the fat jar creation
+[role="multi-language-sample"]
+```groovy
+tasks.named("nativeBuild") {
+    classpathJar = myFatJar
+}
+```
+
+[role="multi-language-sample"]
+```kotlin
+tasks.named<BuildNativeImageTask>("nativeBuild") {
+    classpathJar.set(myFatJar)
+}
+```
+
+When the `classpathJar` property is set, the `classpath` property is _ignored_.
 
 [[testing]]
 === Testing support

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -147,6 +147,24 @@ This step won't be needed as of JUnit 5.8 with a future release of native-maven-
 
 Running `mvn -Pnative -Dskip test` will then build and run native tests.
 
+== Long classpath and shading support
+
+Under Windows, https://github.com/graalvm/native-build-tools/issues/85[it is possible that the length of the classpath exceeds what the operating system supports] when invoking the CLI to build a native image.
+
+If this happens, one option is to use a https://maven.apache.org/plugins/maven-shade-plugin[shaded jar] and use it instead of individual jars on classpath.
+
+First, you'll need to setup the https://maven.apache.org/plugins/maven-shade-plugin[Maven Shade plugin]:
+
+[source,xml,indent=0]
+include::../../../../samples/java-application/pom.xml[tag=shade-plugin]
+
+Then the native plugin needs to be configured to use this jar instead of the full classpath:
+
+[source,xml,indent=0]
+include::../../../../samples/java-application/pom.xml[tag=native-plugin]
+
+Please refer to the https://maven.apache.org/plugins/maven-shade-plugin[Maven Shade plugin documentation] for more details on how to configure shading.
+
 == Javadocs
 
 In addition, you can consult the link:javadocs/native-maven-plugin/index.html[Javadocs of the plugin].

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -127,6 +127,7 @@ In this case, the arguments that will be passed to the `native-image` executable
 --no-fallback --verbose
 ```
 
+[[testing-support]]
 == JUnit Testing support
 
 In order to use the recommended test listener mode, you need to add following dependency:
@@ -163,7 +164,30 @@ Then the native plugin needs to be configured to use this jar instead of the ful
 [source,xml,indent=0]
 include::../../../../samples/java-application/pom.xml[tag=native-plugin]
 
-Please refer to the https://maven.apache.org/plugins/maven-shade-plugin[Maven Shade plugin documentation] for more details on how to configure shading.
+To be able to <<testing-support,execute tests in native mode>>, you will need more setup:
+
+- Create a `src/assembly/test-jar-with-dependencies.xml` file with the following contents:
+
+[source,xml,indent=0]
+include::../../../../samples/java-application-with-tests/src/assembly/test-jar-with-dependencies.xml[tag=assembly]
+
+- Add the assembly plugin to your `native` profile:
+
+[source,xml,indent=0]
+include::../../../../samples/java-application-with-tests/pom.xml[tag=assembly-plugin]
+
+- Due to a limitation in Maven, you will need to move the tests execution to the "integration-test" phase:
+
+[source,xml,indent=0]
+include::../../../../samples/java-application-with-tests/pom.xml[tag=native-plugin]
+
+Finally, you will need to execute tests using the `integration-test` phase instead of `test`:
+
+```bash
+./mvn -Pnative integration-test
+```
+
+Please refer to the https://maven.apache.org/plugins/maven-shade-plugin[Maven Shade plugin documentation] for more details on how to configure shading and the https://maven.apache.org/plugins/maven-assembly-plugin[Maven Assembly plugin documentation] to tweak what to include in tests.
 
 == Javadocs
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -53,6 +53,11 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
         withSample("java-application-with-resources")
 
         buildFile << config
+        buildFile << """
+            nativeBuild {
+                verbose = true
+            }
+        """
 
         when:
         run 'nativeBuild'

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -254,7 +254,7 @@ public class NativeImagePlugin implements Plugin<Project> {
             jar.getArchiveBaseName().set(baseName.toLowerCase(Locale.ENGLISH) + "-classpath");
         });
         imageBuilder.configure(nit -> {
-            if (SharedConstants.IS_WINDOWS) {
+            if (options.getUseFatJar().get()) {
                 nit.getClasspathJar().set(classpathJar.flatMap(AbstractArchiveTask::getArchiveFile));
             }
         });

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
@@ -42,6 +42,7 @@
 package org.graalvm.buildtools.gradle.dsl;
 
 import org.graalvm.buildtools.gradle.internal.GradleUtils;
+import org.graalvm.buildtools.utils.SharedConstants;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
@@ -210,6 +211,7 @@ public abstract class NativeImageOptions {
         getAgent().convention(false);
         getSharedLibrary().convention(false);
         getImageName().convention(defaultImageName);
+        getUseFatJar().convention(SharedConstants.IS_WINDOWS);
         getJavaLauncher().convention(
                 toolchains.launcherFor(spec -> {
                     spec.getLanguageVersion().set(JavaLanguageVersion.of(JavaVersion.current().getMajorVersion()));
@@ -355,4 +357,14 @@ public abstract class NativeImageOptions {
         return this;
     }
 
+    /**
+     * If set to true, this will build a fat jar of the image classpath
+     * instead of passing each jar individually to the classpath. This
+     * option can be used in case the classpath is too long and that
+     * invoking native image fails, which can happen on Windows.
+     *
+     * @return true if a fatjar should be used. Defaults to true for Windows, and false otherwise.
+     */
+    @Input
+    public abstract Property<Boolean> getUseFatJar();
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -49,10 +49,12 @@ import org.gradle.api.GradleException;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
@@ -112,6 +114,10 @@ public abstract class BuildNativeImageTask extends DefaultTask {
     @Inject
     protected abstract ProviderFactory getProviders();
 
+    @InputFile
+    @Optional
+    public abstract RegularFileProperty getClasspathJar();
+
     public BuildNativeImageTask() {
         DirectoryProperty buildDir = getProject().getLayout().getBuildDirectory();
         Provider<Directory> outputDir = buildDir.dir("native/" + getName());
@@ -132,8 +138,8 @@ public abstract class BuildNativeImageTask extends DefaultTask {
                 getExecutableName(),
                 // Can't use getOutputDirectory().map(...) because Gradle would complain that we use
                 // a mapped value before the task was called, when we are actually calling it...
-                getProviders().provider(() -> getOutputDirectory().getAsFile().get().getAbsolutePath())
-        ).asArguments();
+                getProviders().provider(() -> getOutputDirectory().getAsFile().get().getAbsolutePath()),
+                getClasspathJar()).asArguments();
     }
 
     // This property provides access to the service instance

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
@@ -52,4 +52,15 @@ class JavaApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
         buildSucceeded
         outputContains "Hello, native!"
     }
+
+    def "can build and execute a native image with the Maven plugin and the shade plugin"() {
+        withSample("java-application")
+
+        when:
+        mvn '-Pshaded', '-DskipTests', 'package', 'exec:exec@native'
+
+        then:
+        buildSucceeded
+        outputContains "Hello, native!"
+    }
 }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
@@ -66,4 +66,29 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractGraalVMMavenFunctio
 [         0 tests failed          ]
 """.trim()
     }
+
+    def "can run tests in a native image with the Maven plugin using shading"() {
+        withSample("java-application-with-tests")
+
+        when:
+        mvn '-Pshaded', 'integration-test'
+
+        then:
+        buildSucceeded
+        outputContains "[junit-platform-native] Running in 'test listener' mode"
+        outputContains """
+[         3 containers found      ]
+[         0 containers skipped    ]
+[         3 containers started    ]
+[         0 containers aborted    ]
+[         3 containers successful ]
+[         0 containers failed     ]
+[         6 tests found           ]
+[         0 tests skipped         ]
+[         6 tests started         ]
+[         0 tests aborted         ]
+[         6 tests successful      ]
+[         0 tests failed          ]
+""".trim()
+    }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -79,6 +79,9 @@ public class NativeTestMojo extends AbstractNativeMojo {
     @Parameter(property = "skipTests", defaultValue = "false")
     private boolean skipTests;
 
+    @Parameter(property = "classpath")
+    private List<String> classpath;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (skipTests) {
@@ -182,6 +185,9 @@ public class NativeTestMojo extends AbstractNativeMojo {
     }
 
     private String getClassPath() throws MojoFailureException {
+        if (classpath != null && !classpath.isEmpty()) {
+            return String.join(File.pathSeparator, classpath);
+        }
         try {
             List<Artifact> pluginDependencies = pluginArtifacts.stream()
                     .filter(it -> it.getGroupId().startsWith(Utils.MAVEN_GROUP_ID) || it.getGroupId().startsWith("org.junit"))

--- a/samples/java-application-with-tests/pom.xml
+++ b/samples/java-application-with-tests/pom.xml
@@ -109,10 +109,97 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>shaded</id>
+            <build>
+                <plugins>
+                    <!-- tag::shade-plugin[] -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.2.4</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                        </configuration>
+                    </plugin>
+                    <!-- end::shade-plugin[] -->
+
+                    <!-- tag::assembly-plugin[] -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>2.4.1</version>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/assembly/test-jar-with-dependencies.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-test-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- end::assembly-plugin[] -->
+
+                    <!-- tag::native-plugin[] -->
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>test-native</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>integration-test</phase>
+                                <configuration>
+                                    <classpath>
+                                        <param>${project.build.directory}/${project.artifactId}-${project.version}-tests.jar</param>
+                                    </classpath>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <classpath>
+                                        <param>${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar</param>
+                                    </classpath>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skip>false</skip>
+                            <imageName>${imageName}</imageName>
+                            <buildArgs>
+                                <buildArg>--no-fallback</buildArg>
+                            </buildArgs>
+                        </configuration>
+                    </plugin>
+                    <!-- end::native-plugin[] -->
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
-        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/samples/java-application-with-tests/src/assembly/test-jar-with-dependencies.xml
+++ b/samples/java-application-with-tests/src/assembly/test-jar-with-dependencies.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    The Universal Permissive License (UPL), Version 1.0
+
+    Subject to the condition set forth below, permission is hereby granted to any
+    person obtaining a copy of this software, associated documentation and/or
+    data (collectively the "Software"), free of charge and under any and all
+    copyright rights in the Software, and any and all patent rights owned or
+    freely licensable by each licensor hereunder covering either (i) the
+    unmodified Software as contributed to or provided by such licensor, or (ii)
+    the Larger Works (as defined below), to deal in both
+
+    (a) the Software, and
+
+    (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+    one is included with the Software each a "Larger Work" to which the Software
+    is contributed by such licensors),
+
+    without restriction, including without limitation the rights to copy, create
+    derivative works of, display, perform, and distribute the Software and make,
+    use, sell, offer for sale, import, export, have made, and have sold the
+    Software and the Larger Work(s), and to sublicense the foregoing rights on
+    either these or other terms.
+
+    This license is subject to the following condition:
+
+    The above copyright notice and either this complete permission notice or at a
+    minimum a reference to the UPL must be included in all copies or substantial
+    portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+-->
+
+<!-- tag::assembly[] -->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>tests</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/test-classes</directory>
+            <outputDirectory>/</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.outputDirectory}</directory>
+            <outputDirectory>/</outputDirectory>
+        </fileSet>
+    </fileSets>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>test</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>
+<!-- end::assembly[] -->

--- a/samples/java-application/pom.xml
+++ b/samples/java-application/pom.xml
@@ -95,6 +95,58 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>shaded</id>
+            <build>
+                <plugins>
+                    <!-- tag::shade-plugin[] -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.2.4</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- end::shade-plugin[] -->
+
+                    <!-- tag::native-plugin[] -->
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skip>false</skip>
+                            <imageName>${imageName}</imageName>
+                            <buildArgs>
+                                <buildArg>--no-fallback</buildArg>
+                            </buildArgs>
+                            <classpath>
+                                <param>${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar</param>
+                            </classpath>
+                        </configuration>
+                    </plugin>
+                    <!-- end::native-plugin[] -->
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
This commit introduces a classpath jar, a jar which contains no
classes but only a Class-Path manifest entry, so that the classpath
to `native-image` is passed this way instead of on the CLI.

This would fix the issue of long classpath entries on Windows.

Fixes #85