### PR TITLE
Add publication of snapshots to GitHub

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -17,6 +17,20 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+          ssh-key: "${{ secrets.SSH_PRIVATE_KEY }}"
+      - name: Setup git
+        env:
+          GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
+          SSH_PRIVATE_KEY: "${{ secrets.SSH_PRIVATE_KEY }}"
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+          chmod 700 -R ~/.ssh
+          eval "$(ssh-agent -s)"
+          ssh-add
+          ssh git@github.com || true
+          git config --global user.name 'graalvm bot'
+          git config --global user.email 'graalvmbot@users.noreply.github.com'
       - name: Get GraalVM Nightly
         run: |
           source common/scripts/downloadGraalVM.sh

--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -1,0 +1,27 @@
+name: Deploy snapshots to GitHub
+
+on:
+  workflow_run:
+    workflows: [ "native-gradle-plugin", "native-maven-plugin", "junit-platform-native-feature" ]
+    branches: [ "master" ]
+    types:
+      - completed
+
+jobs:
+  deploy-snapshots:
+    name: Deploy
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Get GraalVM Nightly
+        run: |
+          source common/scripts/downloadGraalVM.sh
+          echo "$GRAALVM_HOME/bin" >> $GITHUB_PATH
+          echo "JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
+          echo "GRAALVM_HOME=$GRAALVM_HOME" >> $GITHUB_ENV
+      - name: Run gradle
+        run: ./gradlew publishAllPublicationsToSnapshotsRepository --no-parallel

--- a/build-logic/src/main/kotlin/org.graalvm.build.publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/org.graalvm.build.publishing.gradle.kts
@@ -90,6 +90,10 @@ publishing {
             name = "common"
             url = uri(repoDirectory)
         }
+        maven {
+            name = "snapshots"
+            url = uri(snapshotsDirectory)
+        }
     }
     publications.withType<MavenPublication>().configureEach {
         pom {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -128,6 +128,7 @@ val addSnapshots = tasks.register<org.graalvm.build.tasks.GitAdd>("addSnapshots"
 val commitSnapshots = tasks.register<org.graalvm.build.tasks.GitCommit>("commitSnapshots") {
     dependsOn(addSnapshots)
     repositoryDirectory.set(layout.buildDirectory.dir("snapshots"))
+    amend.set(true)
     message.set("Publishing new snapshot")
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -47,3 +47,7 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
 }
+
+dependencies {
+    implementation(libs.jgit)
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -39,26 +39,13 @@
  * SOFTWARE.
  */
 
-import org.gradle.api.Project
-import org.gradle.api.invocation.Gradle
 
-val Gradle.rootGradle: Gradle
-    get() {
-        var cur = this
-        while (cur.parent != null) {
-            cur = cur.parent!!
+enableFeaturePreview("VERSION_CATALOGS")
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
         }
-        return cur
     }
-
-val Gradle.rootLayout
-    get() = rootGradle.rootProject.layout
-
-val Project.compositeRootBuildDirectory
-    get() = gradle.rootLayout.buildDirectory
-
-val Project.repoDirectory
-    get() = compositeRootBuildDirectory.dir("common-repo")
-
-val Project.snapshotsDirectory
-    get() = compositeRootBuildDirectory.dir("snapshots")
+}

--- a/buildSrc/src/main/kotlin/org/graalvm/build/tasks/GitAdd.kt
+++ b/buildSrc/src/main/kotlin/org/graalvm/build/tasks/GitAdd.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -39,26 +39,28 @@
  * SOFTWARE.
  */
 
-import org.gradle.api.Project
-import org.gradle.api.invocation.Gradle
+package org.graalvm.build.tasks
 
-val Gradle.rootGradle: Gradle
-    get() {
-        var cur = this
-        while (cur.parent != null) {
-            cur = cur.parent!!
+import org.eclipse.jgit.api.Git
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class GitAdd : DefaultTask() {
+    @get:InputDirectory
+    abstract val repositoryDirectory: DirectoryProperty
+
+    @get:Input
+    abstract val pattern: Property<String>
+
+    @TaskAction
+    fun execute() {
+        Git.open(repositoryDirectory.asFile.get()).use {
+            it.add().addFilepattern(pattern.get()).call()
         }
-        return cur
     }
-
-val Gradle.rootLayout
-    get() = rootGradle.rootProject.layout
-
-val Project.compositeRootBuildDirectory
-    get() = gradle.rootLayout.buildDirectory
-
-val Project.repoDirectory
-    get() = compositeRootBuildDirectory.dir("common-repo")
-
-val Project.snapshotsDirectory
-    get() = compositeRootBuildDirectory.dir("snapshots")
+}

--- a/buildSrc/src/main/kotlin/org/graalvm/build/tasks/GitCommit.kt
+++ b/buildSrc/src/main/kotlin/org/graalvm/build/tasks/GitCommit.kt
@@ -57,12 +57,16 @@ abstract class GitCommit : DefaultTask() {
     @get:Input
     abstract val message: Property<String>
 
+    @get:Input
+    abstract val amend: Property<Boolean>
+
     @TaskAction
     fun execute() {
         Git.open(repositoryDirectory.asFile.get()).use {
             it.commit()
                     .setAll(true)
                     .setMessage(message.get())
+                    .setAmend(true)
                     .setSign(false)
                     .call()
         }

--- a/buildSrc/src/main/kotlin/org/graalvm/build/tasks/GitPush.kt
+++ b/buildSrc/src/main/kotlin/org/graalvm/build/tasks/GitPush.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -39,26 +39,25 @@
  * SOFTWARE.
  */
 
-import org.gradle.api.Project
-import org.gradle.api.invocation.Gradle
+package org.graalvm.build.tasks
 
-val Gradle.rootGradle: Gradle
-    get() {
-        var cur = this
-        while (cur.parent != null) {
-            cur = cur.parent!!
+import org.eclipse.jgit.api.Git
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class GitPush : DefaultTask() {
+    @get:InputDirectory
+    abstract val repositoryDirectory: DirectoryProperty
+
+    @TaskAction
+    fun execute() {
+        Git.open(repositoryDirectory.asFile.get()).use {
+            it.push().call()
         }
-        return cur
     }
-
-val Gradle.rootLayout
-    get() = rootGradle.rootProject.layout
-
-val Project.compositeRootBuildDirectory
-    get() = gradle.rootLayout.buildDirectory
-
-val Project.repoDirectory
-    get() = compositeRootBuildDirectory.dir("common-repo")
-
-val Project.snapshotsDirectory
-    get() = compositeRootBuildDirectory.dir("snapshots")
+}

--- a/buildSrc/src/main/kotlin/org/graalvm/build/tasks/GitReset.kt
+++ b/buildSrc/src/main/kotlin/org/graalvm/build/tasks/GitReset.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.build.tasks
+
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.ResetCommand
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class GitReset : DefaultTask() {
+    @get:InputDirectory
+    abstract val repositoryDirectory: DirectoryProperty
+
+    @get:Input
+    abstract val ref: Property<String>
+
+    @get:Input
+    abstract val mode: Property<ResetCommand.ResetType>
+
+    @TaskAction
+    fun execute() {
+        Git.open(repositoryDirectory.asFile.get()).use {
+            it.reset()
+                    .setRef(ref.get())
+                    .setMode(mode.get())
+                    .call()
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ junitJupiter = "5.7.2"
 aether = "1.1.0"
 slf4j = "1.7.9"
 groovy = "3.0.8"
+jgit = "5.12.0.202106070339-r"
 
 [libraries]
 # Local projects
@@ -53,3 +54,5 @@ maven-wagon-http = { module = "org.apache.maven.wagon:wagon-http", version.ref =
 maven-wagon-provider = { module = "org.apache.maven.wagon:wagon-provider-api", version.ref = "mavenWagon" }
 
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+
+jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }


### PR DESCRIPTION
This commit introduces publication of snapshot artifacts to
a branch, so that we can use GitHub as a repository.