### PR TITLE
Fix `nativeCompile` task not getting the agent resources

### DIFF
--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -190,7 +190,7 @@ public class NativeImagePlugin implements Plugin<Project> {
         // Application Plugin is initialized.
         project.getPlugins().withType(ApplicationPlugin.class, applicationPlugin -> {
             TaskProvider<JavaExec> runTask = tasks.withType(JavaExec.class).named(ApplicationPlugin.TASK_RUN_NAME);
-            runTask.configure(run -> configureAgent(project, agent, mainOptions, runTask, processAgentFiles));
+            configureAgent(project, agent, mainOptions, runTask, processAgentFiles);
         });
 
         Provider<Directory> generatedResourcesDir = project.getLayout()

--- a/samples/java-application-with-reflection/build.gradle
+++ b/samples/java-application-with-reflection/build.gradle
@@ -68,6 +68,7 @@ test {
 graalvmNative {
     binaries {
         test {
+            verbose = true
             agent = true
         }
     }


### PR DESCRIPTION
This commit fixes a bug where using the `-Pagent=true nativeCompile`
task wouldn't trigger the generated resources files to be included
in the configuration of the native compile task.

Fixes #134