### PR TITLE
Allow disabling testing support

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -329,7 +329,7 @@ The generated configuration files will be found in the `${buildDir}/native/agent
 There are cases where you might want to disable test support:
 
 - you don't actually want to run your tests in native mode
-- your library or application uses another test framework than JUnit Platform (currently this plugin only supports testing with JUnit Platform)
+- your library or application uses another test framework than JUnit 5 (currently this plugin only supports testing with JUnit Platform 5.8+)
 
 In this case, you can disable test support by configuring the `graalvmNative` extension:
 

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -324,6 +324,30 @@ Same can be achieved by setting corresponding DSL option, althought this isn't r
 
 The generated configuration files will be found in the `${buildDir}/native/agent-output/${taskName}` directory, for example, `build/native/agent-output/run`.
 
+=== Disabling test support
+
+There are cases where you might want to disable test support:
+
+- you don't actually want to run your tests in native mode
+- your library or application uses another test framework than JUnit Platform (currently this plugin only supports testing with JUnit Platform)
+
+In this case, you can disable test support by configuring the `graalvmNative` extension:
+
+.Disabling test support
+[role="multi-language-sample"]
+```groovy
+graalvmNative {
+    testSupport = false
+}
+```
+
+[role="multi-language-sample"]
+```kotlin
+graalvmNative {
+    testSupport.set(false)
+}
+```
+
 == Javadocs
 
 In addition, you can consult the link:javadocs/native-gradle-plugin/index.html[Javadocs of the plugin].

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
@@ -43,12 +43,23 @@ package org.graalvm.buildtools.gradle.dsl;
 
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.provider.Property;
 
 /**
  * This is the entry point for configuring GraalVM relative features
  * provided by this plugin.
  */
 public interface GraalVMExtension {
+
+    /**
+     * Determines if test support is active. This can be used
+     * to disable automatic test support, especially in cases
+     * where the test framework doesn't allow testing within
+     * a native image.
+     *
+     */
+    Property<Boolean> getTestSupport();
+
     /**
      * Returns the native image configurations used to generate images.
      * By default, this plugin creates two images, one called "main" for

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -48,12 +48,13 @@ import org.gradle.api.NamedDomainObjectContainer;
 
 import javax.inject.Inject;
 
-public class DefaultGraalVmExtension implements GraalVMExtension {
+public abstract class DefaultGraalVmExtension implements GraalVMExtension {
     private final NamedDomainObjectContainer<NativeImageOptions> nativeImages;
 
     @Inject
     public DefaultGraalVmExtension(NamedDomainObjectContainer<NativeImageOptions> nativeImages) {
         this.nativeImages = nativeImages;
+        getTestSupport().convention(true);
     }
 
     @Override

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -228,6 +228,13 @@ abstract class AbstractFunctionalTest extends Specification {
             }
         }
 
+        void skipped(String... tasks) {
+            tasks.each { task ->
+                contains(task)
+                assert result.task(task).outcome == TaskOutcome.SKIPPED
+            }
+        }
+
         void contains(String... tasks) {
             tasks.each { task ->
                 assert result.task(task) != null: "Expected to find task $task in the graph but it was missing"


### PR DESCRIPTION
This commit adds an option to disable testing support in the Gradle
plugin. This is useful whenever the test framework that the application
or library is using is not JUnit Platform (e.g TestNG) or in cases the
user doesn't want to run tests in native mode.

Fixes #133