### PR TITLE
Introduce configurations for configuring the classpath

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -348,6 +348,30 @@ graalvmNative {
 }
 ```
 
+[[plugin-configurations]]
+=== Configurations defined by the plugin
+
+For each binary (`main` and `test`), the plugin declares 2 configurations that users or plugin authors can use to tweak the native image compilation classpath:
+
+- `nativeImageCompileOnly` (for the `main` binary) and `nativeImageTestCompileOnly` (for the `test` binary) can be used to declare dependencies which are only needed at image compilation.
+- `nativeImageClasspath` (for the `main` binary) and `nativeImageTestClasspath` (for the `test` binary) are the configurations which are resolved to determine the image classpaths.
+
+The native image "compile only" configurations can typically be used to declare dependencies which are only required when building a native binary, and therefore shouldn't leak to the classic "JVM" runtime.
+
+For example, you could declare a source set which uses the GraalVM SDK to implement native features.
+This source set would contain code which is only relevant to native images building:
+
+.Declaring a custom source set
+[role="multi-language-sample"]
+```groovy
+include::../../../../samples/java-application-with-extra-sourceset/build.gradle[tag=extra-sourceset]
+```
+
+[role="multi-language-sample"]
+```kotlin
+include::../../../../samples/java-application-with-extra-sourceset/build.gradle.kts[tag=extra-sourceset]
+```
+
 == Javadocs
 
 In addition, you can consult the link:javadocs/native-gradle-plugin/index.html[Javadocs of the plugin].

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeConfigurations.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeConfigurations.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.internal;
+
+import org.gradle.api.artifacts.Configuration;
+
+public class NativeConfigurations {
+    private final Configuration imageCompileOnly;
+    private final Configuration imageClasspath;
+
+    public NativeConfigurations(Configuration imageCompileOnly, Configuration imageClasspath) {
+        this.imageCompileOnly = imageCompileOnly;
+        this.imageClasspath = imageClasspath;
+    }
+
+    public Configuration getImageCompileOnlyConfiguration() {
+        return imageCompileOnly;
+    }
+
+    public Configuration getImageClasspathConfiguration() {
+        return imageClasspath;
+    }
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -183,7 +183,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
             "native-image in a standard location recognized by Gradle Java toolchain support");
         }
 
-        logger.log("Using executable path: " + executablePath);
+        logger.lifecycle("Using executable path: " + executablePath);
         String executable = executablePath.getAbsolutePath();
         File outputDir = getOutputDirectory().getAsFile().get();
         if (outputDir.isDirectory() || outputDir.mkdirs()) {

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -56,6 +56,7 @@ abstract class AbstractFunctionalTest extends Specification {
             GradleVersion.current().version // Only current Gradle version
     ]
     private static final Set<String> FULL_COVERAGE = MINIMAL_COVERAGE + [
+            '7.2',
             '7.1',
             '6.8.3',
             '6.7.1'

--- a/samples/java-application-with-extra-sourceset/build.gradle
+++ b/samples/java-application-with-extra-sourceset/build.gradle
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+plugins {
+    id 'application'
+    id 'org.graalvm.buildtools.native'
+}
+
+application {
+    mainClass.set('org.graalvm.demo.Application')
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::extra-sourceset[]
+sourceSets {
+    graal
+}
+
+dependencies {
+    graalCompileOnly 'org.graalvm.nativeimage:svm:21.2.0'
+    graalCompileOnly 'org.graalvm.sdk:graal-sdk:21.2.0'
+    nativeImageCompileOnly sourceSets.graal.output.classesDirs
+}
+
+configurations {
+    nativeImageClasspath.extendsFrom(graalImplementation)
+}
+// end::extra-sourceset[]

--- a/samples/java-application-with-extra-sourceset/build.gradle.kts
+++ b/samples/java-application-with-extra-sourceset/build.gradle.kts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+plugins {
+    application
+    id("org.graalvm.buildtools.native")
+}
+
+application {
+    mainClass.set("org.graalvm.demo.Application")
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::extra-sourceset[]
+val graal by sourceSets.creating
+
+dependencies {
+    "graalCompileOnly"("org.graalvm.nativeimage:svm:21.2.0")
+    "graalCompileOnly"("org.graalvm.sdk:graal-sdk:21.2.0")
+    nativeImageCompileOnly(graal.output.classesDirs)
+}
+
+configurations {
+    nativeImageClasspath.extendsFrom(getByName("graalImplementation"))
+}
+// end::extra-sourceset[]

--- a/samples/java-application-with-extra-sourceset/gradle.properties
+++ b/samples/java-application-with-extra-sourceset/gradle.properties
@@ -1,0 +1,3 @@
+native.gradle.plugin.version = 0.9.6-SNAPSHOT
+junit.jupiter.version = 5.7.2
+junit.platform.version = 1.7.2

--- a/samples/java-application-with-extra-sourceset/settings.gradle
+++ b/samples/java-application-with-extra-sourceset/settings.gradle
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+pluginManagement {
+    plugins {
+        id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
+    }
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = 'java-application'

--- a/samples/java-application-with-extra-sourceset/src/graal/java/org/graalvm/demo/ApplicationFeature.java
+++ b/samples/java-application-with-extra-sourceset/src/graal/java/org/graalvm/demo/ApplicationFeature.java
@@ -1,0 +1,24 @@
+package org.graalvm.demo;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import org.graalvm.nativeimage.hosted.Feature;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@AutomaticFeature
+public class ApplicationFeature implements Feature {
+    @Override
+    public void afterImageWrite(AfterImageWriteAccess access) {
+        try (PrintWriter wrt = new PrintWriter(new FileWriter(new File(access.getImagePath().toFile().getParentFile(), "app.txt")))) {
+            wrt.println("-------------------\n");
+            wrt.println("Application Feature\n");
+            wrt.println("-------------------\n");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/samples/java-application-with-extra-sourceset/src/main/java/org/graalvm/demo/Application.java
+++ b/samples/java-application-with-extra-sourceset/src/main/java/org/graalvm/demo/Application.java
@@ -1,0 +1,7 @@
+package org.graalvm.demo;
+
+public class Application {
+    public static void main(String[] args) {
+        System.out.println("Hello, native!");
+    }
+}


### PR DESCRIPTION
Previously to this commit, the classpath used by native image was
hardcoded to include the project artifact and its runtime classpath.
With this change, the plugin now introduces a couple of configurations:

- `nativeImageCompileOnly` which _can_ be used to declare dependencies
(or artifacts) which are required at image build time, but not by the
main application (JVM mode)
- `nativeImageClasspath`, which extends from the same configurations
as the `runtimeClasspath` configuration, but also from the new
`nativeImageCompileOnly` configuration. This is the configuration which
is now used to configure the plugin classpath.

This will allow other plugins to contribute more artifacts or dependencies
at image build time without having to tweak manually the image classpath,
which could before imply loosing some user configuration code.

This also makes it cleaner to contribute GraalVM native image features,
without leaking into the main application runtime classpath.

Eventually, the same mirror configurations are defines for the test
image building.

Closes #129 