### PR TITLE
Fail native test build for failed tests and containers only

### DIFF
--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/NativeImageJUnitLauncher.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/NativeImageJUnitLauncher.java
@@ -134,7 +134,7 @@ public class NativeImageJUnitLauncher {
             summary.printTo(out);
         }
 
-        long failedCount = summary.getTestsFailedCount() + summary.getTestsAbortedCount();
+        long failedCount = summary.getTotalFailureCount();
         System.exit(failedCount > 0 ? 1 : 0);
     }
 }

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/BasicTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/BasicTests.java
@@ -42,6 +42,9 @@
 package org.graalvm.junit.jupiter;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -52,15 +55,36 @@ class BasicTests {
         System.out.println("Running test: " + info.getDisplayName());
     }
 
+    @BeforeAll
+    static void beforeAll() {
+        // Uncomment this block to see that a failed container fails the build.
+        //
+        // if (System.getProperty("org.graalvm.nativeimage.imagecode") != null) {
+        //     throw new RuntimeException("Failed test container within native image");
+        // }
+    }
+
+    @Test
+    @Disabled
+    void skippedTest() {
+        throw new RuntimeException("Test must have been disabled/skipped entirely");
+    }
+
+    @Test
+    void abortedTest() {
+        Assumptions.assumeTrue(false, "false is never true");
+        throw new RuntimeException("Test must have been aborted mid-flight");
+    }
+
     @Test
     @DisplayName("Basic test one")
-    void addsTwoNumbers(TestInfo testInfo) {
+    void basicTest1(TestInfo testInfo) {
         Assertions.assertEquals("Basic test one", testInfo.getDisplayName());
     }
 
     @Test
     @DisplayName("Basic test two")
-    void addsTwoNumbers2(TestInfo testInfo) {
+    void basicTest2(TestInfo testInfo) {
         Assertions.assertEquals("Basic test two", testInfo.getDisplayName());
     }
 


### PR DESCRIPTION
Prior to this commit, a native test build failed if there were any
failed tests or aborted tests within the native image. However, aborted
tests should not fail the build. In addition, prior to this commit a
failed container did not fail the native test build. A container (i.e.,
typically a test class) can fail if a class-level callback or extension
fails -- for example, if an exception is thrown from a JUnit Jupiter
@BeforeAll method.

This commit addresses these two issues by making the exit code for
the NativeImageJUnitLauncher based on the total failure count which
includes the test failure count and the container failure count.

An aborted test has been added to BasicTests. An @BeforeAll method
has also been added to BasicTests with a code block that throws an
exception when running within a native image. This code block has been
commented out to ensure that the build passes after the change in this
commit, but if you reinstate that code block without the change the
build would pass even though the test class failed.

Fixes #153