### PR TITLE
Ensure native test image exit code is in range 0-255

### DIFF
--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/NativeImageJUnitLauncher.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/NativeImageJUnitLauncher.java
@@ -135,6 +135,6 @@ public class NativeImageJUnitLauncher {
         }
 
         long failedCount = summary.getTestsFailedCount() + summary.getTestsAbortedCount();
-        System.exit((int) failedCount);
+        System.exit(failedCount > 0 ? 1 : 0);
     }
 }


### PR DESCRIPTION
Prior to this commit, the exit code for the native test image was based
on the number of test failures. For a small number of failures, this is
not an issue; however, if there is a large number of failures the exit
code can problematic for shell scripts processing the exit code.

In order to make the exit code more user friendly for shell scripts,
this commit returns an exit code of 1 if there are any test failures.

The actual number of failed tests and containers can be viewed in the
summary printed to STD_OUT, and the full details can be obtained in
the generated XML test reports.

Fixes #154