### PR TITLE
Relocate TestIdentifier build-time init to PlatformConfigProvider

### DIFF
--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/JUnitPlatformFeature.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/JUnitPlatformFeature.java
@@ -86,7 +86,6 @@ public final class JUnitPlatformFeature implements Feature {
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
         RuntimeClassInitialization.initializeAtBuildTime(NativeImageJUnitLauncher.class);
-        RuntimeClassInitialization.initializeAtBuildTime(TestIdentifier.class);
 
         List<Path> classpathRoots = access.getApplicationClassPath();
         List<? extends DiscoverySelector> selectors = getSelectors(classpathRoots);

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/platform/PlatformConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/platform/PlatformConfigProvider.java
@@ -41,14 +41,15 @@
 
 package org.graalvm.junit.platform.config.platform;
 
-import org.graalvm.junit.platform.config.core.PluginConfigProvider;
 import org.graalvm.junit.platform.config.core.NativeImageConfiguration;
+import org.graalvm.junit.platform.config.core.PluginConfigProvider;
 
 public class PlatformConfigProvider implements PluginConfigProvider {
 
     @Override
     public void onLoad(NativeImageConfiguration config) {
-        String[] buildTimeInitializedClasses = new String[]{
+        String[] buildTimeInitializedClasses = new String[] {
+                "org.junit.platform.launcher.TestIdentifier",
                 "org.junit.platform.launcher.core.InternalTestPlan",
                 "org.junit.platform.commons.util.StringUtils",
                 "org.junit.platform.launcher.core.TestExecutionListenerRegistry",


### PR DESCRIPTION
Prior to this commit, the build-time initialization for the JUnit
Platform TestIdentifier type was registered directly in the
JUnitPlatformFeature. This works fine; however the configuration
for the JUnit Platform, Jupiter, and Vintage projects each has its own
dedicated PluginConfigProvider implementation.

For the sake of consistency, this commit therefore relocates the
TestIdentifier build-time init registration to the PlatformConfigProvider.

Fixes #150