### PR TITLE
Make it possible to configure agent options in Maven plugin

### DIFF
--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -95,8 +95,10 @@ You can use development versions of the plugin by adding our snapshot repository
 [[configuration-options]]
 === Configuration options
 
-If you use Native Image Maven plugin, it will pick up all the configuration for your application stored below the `META-INF/native-image/` resource location, as described in https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/[Native Image Build Configuration].
-It is also possible to customize the plugin within a
+If you use Native Image Maven plugin, it will pick up all the configuration for your
+application stored below the `META-INF/native-image/` resource location, as described in
+https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/[Native Image
+Build Configuration]. It is also possible to customize the plugin within a
 `<configuration>` node. The following configuration options are available.
 
 `<mainClass>`::
@@ -116,6 +118,9 @@ It is also possible to customize the plugin within a
 `<skipNativeBuild>`::
    To skip generation of the native image, supply
    `<skipNativeBuild>true</skipNativeBuild>` in the configuration of the plugin.
+`<agent>`::
+   Configuration of the <<agent-support, native agent>>. See <<agent-support-enabling>>
+   and <<agent-support-configuring-options>> for details.
 
 For example, to build a native image named `executable-name` that uses
 `org.example.ClassName` as its main class with assertions enabled, add the following
@@ -130,46 +135,6 @@ For example, to build a native image named `executable-name` that uses
   </buildArgs>
 </configuration>
 ```
-[[configuration-options-agent-enabled]]
-`<agent>` -> `<enabled>`::
-   To enable the agent by default specify `<enabled>true</enabled>` as follows. The agent
-   can also be enabled or disabled via the command line. See <<agent-support-enabling>>
-   for details.
-+
-```xml
-<configuration>
-  <agent>
-    <enabled>true</enabled>
-  </agent>
-</configuration>
-```
-[[configuration-options-agent-options]]
-`<agent>` -> `<options>`::
-   If you would like to configure the options for the agent (see <<agent-support>>) --
-   for example, to configure experimental features such as `experimental-class-loader-support`
-   or advanced features such as
-   https://www.graalvm.org/reference-manual/native-image/Agent/#caller-based-filters[Caller-based Filters]
-   and https://www.graalvm.org/reference-manual/native-image/Agent/#access-filters[Access Filters] --
-   you can include `<options>` within the `<agent>` block.
-     * You can supply multiple sets of `<options>`.
-     * You may declare one unnamed `<options>` element which will always be used whenever
-       the agent is enabled. This should be used to share common options.
-     * Additional `<options>` elements must declare a unique `name` attribute.
-     * To enable a specific set of named `<options>`, supply `-DagentOptions=<NAME>` as a
-       command-line argument for Maven, where `<NAME>` corresponds to the `name` attribute
-       of the `<options>` element.
-     * If `-DagentOptions=<NAME>` is not specified, named sets of options will not be used
-       with the agent.
-     * The Native Image Maven plugin automatically configures the `config-output-dir` for
-       the agent. An attempt to provide a custom value for the `config-output-dir` option
-       will therefore result in a build failure.
-     * The following example demonstrates how to configure three sets of `<options>`, an
-       unnamed set that is always active, one for application execution (`main`) and one
-       for tests (`test`). The names `main` and `test` are for demonstration purposes
-       only: you may choose any names you wish.
-+
-[source,xml,indent=0]
-include::../../../../samples/java-application-with-reflection/pom.xml[tag=native-plugin-agent-options]
 
 NOTE: If you use GraalVM Enterprise as the `JAVA_HOME` environment, the plugin builds a native image with enterprise features enabled -- for example, an executable will automatically be built with https://medium.com/graalvm/isolates-and-compressed-references-more-flexible-and-efficient-memory-management-for-graalvm-a044cc50b67e[compressed references] and other optimizations enabled.
 
@@ -311,25 +276,92 @@ Please refer to the https://maven.apache.org/plugins/maven-shade-plugin[Maven Sh
 [[agent-support]]
 == Reflection support and running with the native agent
 
-If your project requires reflection, classpath resources, dynamic proxies or other features requiring explicit native configuration, it may prove helpful to first run your application or tests using the https://www.graalvm.org/reference-manual/native-image/Agent/[`native-image-agent`].
+If your project requires reflection, classpath resources, dynamic proxies or other
+features requiring explicit native configuration, it may prove helpful to first run your
+application or tests using the
+https://www.graalvm.org/reference-manual/native-image/Agent/[`native-image-agent`].
 
-The Native Image Maven plugin simplifies generation of the required configuration files by injecting the agent automatically for you (this includes, but is not limited to the reflection file).
+The Native Image Maven plugin simplifies generation of the required configuration files by
+injecting the agent automatically for you (this includes, but is not limited to the
+reflection file).
 
-The agent generates the native configuration files in a subdirectory of `target/native/agent-output`. Although those files will be automatically used if you run your build with the agent enabled, you should consider reviewing the generated files and adding them to your sources instead.
+The agent generates the native configuration files in a subdirectory of
+`target/native/agent-output`. Although those files will be automatically used if you run
+your build with the agent enabled, you should consider reviewing the generated files and
+adding them to your sources instead.
 
 [[agent-support-enabling]]
-==== Enabling the agent
+=== Enabling the agent
 
-The agent is disabled by default, but it can be enabled within your `pom.xml` file or via the command line.
+The agent is disabled by default, but it can be enabled within your `pom.xml` file or via
+the command line.
 
-The documentation for <<configuration-options-agent-enabled, agent configuration>> demonstrates how to enable the agent within your POM.
+To enable the agent by default, specify `<enabled>true</enabled>` as follows in the
+configuration of the `native-maven-plugin` in your POM.
 
-To enable the agent via the command line, supply the `-Dagent=true` flag when running Maven. The examples in the following sections demonstrate how to do this for your application and for tests.
+```xml
+<configuration>
+  <agent>
+    <enabled>true</enabled>
+  </agent>
+</configuration>
+```
+
+To enable the agent via the command line, supply the `-Dagent=true` flag when running
+Maven. The examples in the following sections demonstrate how to do this for your
+application and for tests.
 
 [TIP]
 ====
-If you have enabled the agent within your POM, you can still disable it via the command line by supplying the `-Dagent=false` flag.
+If you have enabled the agent within your POM, you can still disable it via the command
+line by supplying the `-Dagent=false` flag.
 ====
+
+[[agent-support-configuring-options]]
+=== Configuring agent options
+
+If you would like to configure the options for the agent -- for example, to configure
+experimental features such as `experimental-class-loader-support` or advanced features
+such as
+https://www.graalvm.org/reference-manual/native-image/Agent/#caller-based-filters[Caller-based Filters]
+and https://www.graalvm.org/reference-manual/native-image/Agent/#access-filters[Access Filters]
+-- you can include `<options>` within the `<agent>` block of the configuration of the
+`native-maven-plugin` in your POM.
+
+* You can supply multiple sets of `<options>`.
+* You can declare an unnamed `<options>` element which will always be used whenever the
+  agent is enabled. This should be used to declare common options that will be used for
+  all executions with the agent.
+* Additional `<options>` elements must declare a unique `name` attribute.
+    - To configure options for your application, use the name `main`.
+    - To configure options for your tests, use the name `test`.
+    - To configure additional sets of options, declare each with a unique name other than
+      `main` or `test`.
+* The `main` options are enabled automatically whenever your application is run with the
+  agent.
+* The `test` options are enabled automatically whenever your tests are run with the agent.
+* To enable any other set of named `<options>`, supply `-DagentOptions=<NAME>` as a
+  command-line argument for Maven, where `<NAME>` corresponds to the `name` attribute of
+  the `<options>` element.
+
+[WARNING]
+====
+The Native Image Maven plugin automatically configures the `config-output-dir` for the
+agent. An attempt to configure a custom value for the `config-output-dir` option will
+therefore result in a build failure.
+====
+
+The following example is likely more complex than anything you would do in your own
+projects, but it demonstrates how to configure four sets of `<options>`.
+
+* The unnamed set is always active.
+* The `main` set is automatically active for application execution.
+* The `test` set is automatically active for test execution.
+* The `periodic-config` set is never active by default, but it can be enabled via
+  `-DagentOptions=periodic-config` on the command line.
+
+[source,xml,indent=0]
+include::../../../../samples/java-application-with-reflection/pom.xml[tag=native-plugin-agent-options]
 
 [[agent-support-running-tests]]
 === Running tests with the agent
@@ -342,20 +374,27 @@ Run your test suite with:
 mvn -Pnative -Dagent=true test
 ```
 
-When the `agent` system property is set to `true`, the agent will be automatically attached to your Maven Surefire test execution, and the generated files can be found in the `target/native/agent-output/test` directory.
+When the `agent` system property is set to `true` (or when the agent is
+<<agent-support-enabling, enabled in the POM>>), the agent will be automatically attached
+to your Maven Surefire test execution, and the generated files can be found in the
+`target/native/agent-output/test` directory.
 
-To run your tests with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the documentation for <<configuration-options-agent-options, agent options>> for details.
+To run your tests with custom agent options, supply the `-DagentOptions=<NAME>`
+command-line argument to Maven as follows. See the documentation for
+<<agent-support-configuring-options, agent options>> for details.
 
 ```bash
-mvn -Pnative -Dagent=true -DagentOptions=test test
+mvn -Pnative -Dagent=true -DagentOptions=periodic-config test
 ```
 
-WARNING: If the agent is enabled, the `--allow-incomplete-classpath` option is automatically added to your native build options.
+WARNING: If the agent is enabled, the `--allow-incomplete-classpath` option is
+automatically added to your native build options.
 
 [[agent-support-running-application]]
 === Running your application with the agent
 
-Executing your application with the agent is more involved and requires you to configure a separate mojo execution which allows forking the Java process.
+Executing your application with the agent is more involved and requires you to configure a
+separate mojo execution which allows forking the Java process.
 
 In your `native` Maven profile section, add the following:
 
@@ -368,20 +407,24 @@ Then you can execute your application with the agent by running:
 mvn -Pnative -Dagent=true -DskipTests=true -DskipNativeBuild=true package exec:exec@java-agent
 ```
 
-To execute your application with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the To execute your application with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the documentation for <<configuration-options-agent-options, agent options>> for details.
+To execute your application with custom agent options, supply the `-DagentOptions=<NAME>`
+command-line argument to Maven as follows. See the documentation for
+<<agent-support-configuring-options, agent options>> for details.
 
 ```bash
-mvn -Pnative -Dagent=true -DagentOptions=main -DskipTests=true -DskipNativeBuild=true package exec:exec@java-agent
+mvn -Pnative -Dagent=true -DagentOptions=periodic-config -DskipTests=true -DskipNativeBuild=true package exec:exec@java-agent
 ```
 
-Both of the above commands will generate configuration files in the `target/native/agent-output/exec` directory.
-If you want to run your native application with those configuration files, you then need to execute the following command:
+Both of the above commands will generate configuration files in the
+`target/native/agent-output/main` directory. If you want to run your native application
+with those configuration files, you then need to execute the following command:
 
 ```bash
 mvn -Pnative -Dagent=true -DskipTests=true package exec:exec@native
 ```
 
-WARNING: If the agent is enabled, the `--allow-incomplete-classpath` option is automatically added to your native build options.
+WARNING: If the agent is enabled, the `--allow-incomplete-classpath` option is
+automatically added to your native build options.
 
 [[javadocs]]
 == Javadocs

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -130,26 +130,38 @@ For example, to build a native image named `executable-name` that uses
   </buildArgs>
 </configuration>
 ```
+[[configuration-options-agent-enabled]]
+`<agent>` -> `<enabled>`::
+   To enable the agent by default specify `<enabled>true</enabled>` as follows. The agent
+   can also be enabled or disabled via the command line. See <<agent-support-enabling>>
+   for details.
++
+```xml
+<configuration>
+  <agent>
+    <enabled>true</enabled>
+  </agent>
+</configuration>
+```
 [[configuration-options-agent-options]]
-`<agentOptions>`::
+`<agent>` -> `<options>`::
    If you would like to configure the options for the agent (see <<agent-support>>) --
    for example, to configure experimental features such as `experimental-class-loader-support`
    or advanced features such as
    https://www.graalvm.org/reference-manual/native-image/Agent/#caller-based-filters[Caller-based Filters]
    and https://www.graalvm.org/reference-manual/native-image/Agent/#access-filters[Access Filters] --
-   you can include `<agentOptions>` within the `<configuration>` block
-   for the Native Image Maven plugin.
-     * You can supply multiple sets of `<agentOptions>`.
-     * Each `<agentOptions>` element must declare a unique `name` attribute.
-     * To enable a specific set of `<agentOptions>`, supply `-DagentOptions=<NAME>` as a command-line
-       argument for Maven, where `<NAME>` corresponds to the `name` attribute of the `<agentOptions>`
+   you can include `<options>` within the `<agent>` block.
+     * You can supply multiple sets of `<options>`.
+     * Each `<options>` element must declare a unique `name` attribute.
+     * To enable a specific set of `<options>`, supply `-DagentOptions=<NAME>` as a command-line
+       argument for Maven, where `<NAME>` corresponds to the `name` attribute of the `<options>`
        element.
      * If `-DagentOptions=<NAME>` is not specified, custom options will not be used with the agent.
      * The Native Image Maven plugin automatically configures the `config-output-dir` for the agent.
        An attempt to provide a custom value for the `config-output-dir` option will therefore result
        in a build failure.
-     * The following example demonstrates how to configure two sets of `<agentOptions>`, one for
-       application execution (`exec`) and one for tests (`test`). The names `exec` and `test` are
+     * The following example demonstrates how to configure two sets of `<options>`, one for
+       application execution (`main`) and one for tests (`test`). The names `main` and `test` are
        for demonstration: you may choose any names you wish.
 +
 [source,xml,indent=0]
@@ -299,7 +311,21 @@ If your project requires reflection, classpath resources, dynamic proxies or oth
 
 The Native Image Maven plugin simplifies generation of the required configuration files by injecting the agent automatically for you (this includes, but is not limited to the reflection file).
 
-This agent will generate the native configuration files in a subdirectory of `target/native/agent-output`. Although those files will be automatically used if you run your build with the `-Dagent=true` flag, you should consider reviewing them and adding them to your sources instead.
+The agent generates the native configuration files in a subdirectory of `target/native/agent-output`. Although those files will be automatically used if you run your build with the agent enabled, you should consider reviewing the generated files and adding them to your sources instead.
+
+[[agent-support-enabling]]
+==== Enabling the agent
+
+The agent is disabled by default, but it can be enabled within your `pom.xml` file or via the command line.
+
+The documentation for <<configuration-options-agent-enabled, agent configuration>> demonstrates how to enable the agent within your POM.
+
+To enable the agent via the command line, supply the `-Dagent=true` flag when running Maven. The examples in the following sections demonstrate how to do this for your application and for tests.
+
+[TIP]
+====
+If you have enabled the agent within your POM, you can still disable it via the command line by supplying the `-Dagent=false` flag.
+====
 
 [[agent-support-running-tests]]
 === Running tests with the agent
@@ -314,7 +340,7 @@ mvn -Pnative -Dagent=true test
 
 When the `agent` system property is set to `true`, the agent will be automatically attached to your Maven Surefire test execution, and the generated files can be found in the `target/native/agent-output/test` directory.
 
-To run your tests with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the <<configuration-options-agent-options, documentation for +++agentOptions+++>> for details.
+To run your tests with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the <<configuration-options-agent-options, documentation for agent options>> for details.
 
 ```bash
 mvn -Pnative -Dagent=true -DagentOptions=test test
@@ -338,10 +364,10 @@ Then you can execute your application with the agent by running:
 mvn -Pnative -Dagent=true -DskipTests=true -DskipNativeBuild=true package exec:exec@java-agent
 ```
 
-To execute your application with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the <<configuration-options-agent-options, documentation for +++agentOptions+++>> for details.
+To execute your application with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the <<configuration-options-agent-options, documentation for agent options>> for details.
 
 ```bash
-mvn -Pnative -Dagent=true -DagentOptions=exec -DskipTests=true -DskipNativeBuild=true package exec:exec@java-agent
+mvn -Pnative -Dagent=true -DagentOptions=main -DskipTests=true -DskipNativeBuild=true package exec:exec@java-agent
 ```
 
 Both of the above commands will generate configuration files in the `target/native/agent-output/exec` directory.

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -152,17 +152,21 @@ For example, to build a native image named `executable-name` that uses
    and https://www.graalvm.org/reference-manual/native-image/Agent/#access-filters[Access Filters] --
    you can include `<options>` within the `<agent>` block.
      * You can supply multiple sets of `<options>`.
-     * Each `<options>` element must declare a unique `name` attribute.
-     * To enable a specific set of `<options>`, supply `-DagentOptions=<NAME>` as a command-line
-       argument for Maven, where `<NAME>` corresponds to the `name` attribute of the `<options>`
-       element.
-     * If `-DagentOptions=<NAME>` is not specified, custom options will not be used with the agent.
-     * The Native Image Maven plugin automatically configures the `config-output-dir` for the agent.
-       An attempt to provide a custom value for the `config-output-dir` option will therefore result
-       in a build failure.
-     * The following example demonstrates how to configure two sets of `<options>`, one for
-       application execution (`main`) and one for tests (`test`). The names `main` and `test` are
-       for demonstration: you may choose any names you wish.
+     * You may declare one unnamed `<options>` element which will always be used whenever
+       the agent is enabled. This should be used to share common options.
+     * Additional `<options>` elements must declare a unique `name` attribute.
+     * To enable a specific set of named `<options>`, supply `-DagentOptions=<NAME>` as a
+       command-line argument for Maven, where `<NAME>` corresponds to the `name` attribute
+       of the `<options>` element.
+     * If `-DagentOptions=<NAME>` is not specified, named sets of options will not be used
+       with the agent.
+     * The Native Image Maven plugin automatically configures the `config-output-dir` for
+       the agent. An attempt to provide a custom value for the `config-output-dir` option
+       will therefore result in a build failure.
+     * The following example demonstrates how to configure three sets of `<options>`, an
+       unnamed set that is always active, one for application execution (`main`) and one
+       for tests (`test`). The names `main` and `test` are for demonstration purposes
+       only: you may choose any names you wish.
 +
 [source,xml,indent=0]
 include::../../../../samples/java-application-with-reflection/pom.xml[tag=native-plugin-agent-options]
@@ -340,7 +344,7 @@ mvn -Pnative -Dagent=true test
 
 When the `agent` system property is set to `true`, the agent will be automatically attached to your Maven Surefire test execution, and the generated files can be found in the `target/native/agent-output/test` directory.
 
-To run your tests with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the <<configuration-options-agent-options, documentation for agent options>> for details.
+To run your tests with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the documentation for <<configuration-options-agent-options, agent options>> for details.
 
 ```bash
 mvn -Pnative -Dagent=true -DagentOptions=test test
@@ -364,7 +368,7 @@ Then you can execute your application with the agent by running:
 mvn -Pnative -Dagent=true -DskipTests=true -DskipNativeBuild=true package exec:exec@java-agent
 ```
 
-To execute your application with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the <<configuration-options-agent-options, documentation for agent options>> for details.
+To execute your application with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the To execute your application with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the documentation for <<configuration-options-agent-options, agent options>> for details.
 
 ```bash
 mvn -Pnative -Dagent=true -DagentOptions=main -DskipTests=true -DskipNativeBuild=true package exec:exec@java-agent

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -130,6 +130,30 @@ For example, to build a native image named `executable-name` that uses
   </buildArgs>
 </configuration>
 ```
+[[configuration-options-agent-options]]
+`<agentOptions>`::
+   If you would like to configure the options for the agent (see <<agent-support>>) --
+   for example, to configure experimental features such as `experimental-class-loader-support`
+   or advanced features such as
+   https://www.graalvm.org/reference-manual/native-image/Agent/#caller-based-filters[Caller-based Filters]
+   and https://www.graalvm.org/reference-manual/native-image/Agent/#access-filters[Access Filters] --
+   you can include `<agentOptions>` within the `<configuration>` block
+   for the Native Image Maven plugin.
+     * You can supply multiple sets of `<agentOptions>`.
+     * Each `<agentOptions>` element must declare a unique `name` attribute.
+     * To enable a specific set of `<agentOptions>`, supply `-DagentOptions=<NAME>` as a command-line
+       argument for Maven, where `<NAME>` corresponds to the `name` attribute of the `<agentOptions>`
+       element.
+     * If `-DagentOptions=<NAME>` is not specified, custom options will not be used with the agent.
+     * The Native Image Maven plugin automatically configures the `config-output-dir` for the agent.
+       An attempt to provide a custom value for the `config-output-dir` option will therefore result
+       in a build failure.
+     * The following example demonstrates how to configure two sets of `<agentOptions>`, one for
+       application execution (`exec`) and one for tests (`test`). The names `exec` and `test` are
+       for demonstration: you may choose any names you wish.
++
+[source,xml,indent=0]
+include::../../../../samples/java-application-with-reflection/pom.xml[tag=native-plugin-agent-options]
 
 NOTE: If you use GraalVM Enterprise as the `JAVA_HOME` environment, the plugin builds a native image with enterprise features enabled -- for example, an executable will automatically be built with https://medium.com/graalvm/isolates-and-compressed-references-more-flexible-and-efficient-memory-management-for-graalvm-a044cc50b67e[compressed references] and other optimizations enabled.
 
@@ -290,6 +314,12 @@ mvn -Pnative -Dagent=true test
 
 When the `agent` system property is set to `true`, the agent will be automatically attached to your Maven Surefire test execution, and the generated files can be found in the `target/native/agent-output/test` directory.
 
+To run your tests with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the <<configuration-options-agent-options, documentation for +++agentOptions+++>> for details.
+
+```bash
+mvn -Pnative -Dagent=true -DagentOptions=test test
+```
+
 WARNING: If the agent is enabled, the `--allow-incomplete-classpath` option is automatically added to your native build options.
 
 [[agent-support-running-application]]
@@ -308,8 +338,14 @@ Then you can execute your application with the agent by running:
 mvn -Pnative -Dagent=true -DskipTests=true -DskipNativeBuild=true package exec:exec@java-agent
 ```
 
-This will generate configuration files at `target/native/agent-output/exec`.
-If you want to run your native application with those configuration files, you then need to execute this command line:
+To execute your application with custom agent options, supply the `-DagentOptions=<NAME>` command-line argument to Maven as follows. See the <<configuration-options-agent-options, documentation for +++agentOptions+++>> for details.
+
+```bash
+mvn -Pnative -Dagent=true -DagentOptions=exec -DskipTests=true -DskipNativeBuild=true package exec:exec@java-agent
+```
+
+Both of the above commands will generate configuration files in the `target/native/agent-output/exec` directory.
+If you want to run your native application with those configuration files, you then need to execute the following command:
 
 ```bash
 mvn -Pnative -Dagent=true -DskipTests=true package exec:exec@native

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -135,7 +135,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         run '-Pagent=true', 'nativeRun'
 
         then:
-        outputContains "Hello, native!"
+        outputContains "Application message: Hello, native!"
 
         where:
         version << TESTED_GRADLE_VERSIONS

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
@@ -46,7 +46,7 @@ import spock.lang.Unroll
 
 class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
 
-    def "agent is passed"() {
+    def "agent is used without custom options"() {
         given:
         withSample("java-application-with-reflection")
 
@@ -73,21 +73,107 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
         ['jni', 'proxy', 'reflect', 'resource', 'serialization'].each { name ->
             assert file("target/native/agent-output/test/${name}-config.json").exists()
         }
+
+        // If the custom access-filter.json is NOT applied, we should see a warning similar to the following.
+        // Warning: Could not resolve org.apache.maven.surefire.junitplatform.JUnitPlatformProvider for reflection configuration. Reason: java.lang.ClassNotFoundException: org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.
+        and:
+        outputContains 'Warning: Could not resolve org.apache.maven.surefire'
+    }
+
+    def "agent is used with custom options"() {
+        given:
+        withSample("java-application-with-reflection")
+
+        when:
+        // Run Maven in debug mode (-X) in order to capture the command line arguments
+        // used to launch Surefire with the agent.
+        mvn '-X', '-Pnative', '-Dagent=true', '-DagentOptions=test', 'test'
+
+        then:
+        outputContains """
+[         4 containers found      ]
+[         0 containers skipped    ]
+[         4 containers started    ]
+[         0 containers aborted    ]
+[         4 containers successful ]
+[         0 containers failed     ]
+[         7 tests found           ]
+[         0 tests skipped         ]
+[         7 tests started         ]
+[         0 tests aborted         ]
+[         7 tests successful      ]
+[         0 tests failed          ]
+""".trim()
+
+        and:
+        ['jni', 'proxy', 'reflect', 'resource', 'serialization'].each { name ->
+            assert file("target/native/agent-output/test/${name}-config.json").exists()
+        }
+
+        and:
+        // If custom agent options are processed, the debug output for Surefire
+        // should include the following segments of the agent command line argument.
+        // -agentlib:native-image-agent=experimental-class-loader-support,access-filter-file=<BUILD_DIR>/src/test/resources/access-filter.json,config-output-dir=<BUILD_DIR>/target/native/agent-output/test
+        outputContains '-agentlib:native-image-agent=experimental-class-loader-support,access-filter-file='
+        outputContains '/src/test/resources/access-filter.json'.replace('/', java.io.File.separator)
+        outputContains ',config-output-dir='
+        outputContains '/target/native/agent-output/test'.replace("/", java.io.File.separator)
+
+        and:
+        // If the custom access-filter.json is applied, we should not see any warnings about Surefire types.
+        // The actual warning would be something like:
+        // Warning: Could not resolve org.apache.maven.surefire.junitplatform.JUnitPlatformProvider for reflection configuration. Reason: java.lang.ClassNotFoundException: org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.
+        outputDoesNotContain 'Warning: Could not resolve org.apache.maven.surefire'
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/134")
-    @Unroll("generated agent files are added when building native image on Gradle #version with JUnit Platform #junitVersion")
+    @Unroll("generated agent files are added when building native image on Maven #version with JUnit Platform #junitVersion")
     def "generated agent files are used when building native image"() {
         given:
         withSample("java-application-with-reflection")
 
         when:
-        mvn '-Pnative', '-Dagent=true', '-DskipTests=true', '-DskipNativeBuild=true', 'package', 'exec:exec@java-agent'
+        mvn '-X', '-Pnative', '-Dagent=true', '-DskipTests=true', '-DskipNativeBuild=true', 'package', 'exec:exec@java-agent'
 
         then:
         ['jni', 'proxy', 'reflect', 'resource', 'serialization'].each { name ->
             assert file("target/native/agent-output/exec/${name}-config.json").exists()
         }
+
+        and:
+        // If custom agent options are not used, the Maven debug output should include
+        // the following segments of the agent command line argument.
+        // -agentlib:native-image-agent=config-output-dir=<BUILD_DIR>/target/native/agent-output/exec
+        outputContains '-agentlib:native-image-agent=config-output-dir='
+        outputContains '/target/native/agent-output/exec'.replace("/", java.io.File.separator)
+        outputDoesNotContain 'experimental-class-loader-support'
+
+        when:
+        mvn '-Pnative', '-Dagent=true', '-DskipTests=true', 'package', 'exec:exec@native'
+
+        then:
+        outputContains "Hello, native!"
+    }
+
+    def "custom options and generated agent files are used when building native image"() {
+        given:
+        withSample("java-application-with-reflection")
+
+        when:
+        mvn '-X', '-Pnative', '-Dagent=true', '-DagentOptions=exec', '-DskipTests=true', '-DskipNativeBuild=true', 'package', 'exec:exec@java-agent'
+
+        then:
+        ['jni', 'proxy', 'reflect', 'resource', 'serialization'].each { name ->
+            assert file("target/native/agent-output/exec/${name}-config.json").exists()
+        }
+
+        and:
+        // If custom agent options are used, the Maven debug output should include
+        // the following segments of the agent command line argument.
+        // -agentlib:native-image-agent=experimental-class-loader-support,config-output-dir=<BUILD_DIR>/target/native/agent-output/exec
+        outputContains '-agentlib:native-image-agent=experimental-class-loader-support,config-output-dir='
+        outputContains '/target/native/agent-output/exec'.replace("/", java.io.File.separator)
+        outputDoesNotContain 'access-filter-file='
 
         when:
         mvn '-Pnative', '-Dagent=true', '-DskipTests=true', 'package', 'exec:exec@native'

--- a/samples/java-application-with-reflection/pom.xml
+++ b/samples/java-application-with-reflection/pom.xml
@@ -136,12 +136,23 @@
                                 <phase>package</phase>
                             </execution>
                         </executions>
+                        <!-- tag::native-plugin-agent-options[] -->
                         <configuration>
+                            <!-- end::native-plugin-agent-options[] -->
                             <imageName>${imageName}</imageName>
                             <buildArgs>
                                 <buildArg>--no-fallback</buildArg>
                             </buildArgs>
+                            <!-- tag::native-plugin-agent-options[] -->
+                            <agentOptions name="exec">
+                                <agentOption>experimental-class-loader-support</agentOption>
+                            </agentOptions>
+                            <agentOptions name="test">
+                                <agentOption>experimental-class-loader-support</agentOption>
+                                <agentOption>access-filter-file=${basedir}/src/test/resources/access-filter.json</agentOption>
+                            </agentOptions>
                         </configuration>
+                        <!-- end::native-plugin-agent-options[] -->
                     </plugin>
                 </plugins>
             </build>

--- a/samples/java-application-with-reflection/pom.xml
+++ b/samples/java-application-with-reflection/pom.xml
@@ -144,13 +144,18 @@
                                 <buildArg>--no-fallback</buildArg>
                             </buildArgs>
                             <!-- tag::native-plugin-agent-options[] -->
-                            <agentOptions name="exec">
-                                <agentOption>experimental-class-loader-support</agentOption>
-                            </agentOptions>
-                            <agentOptions name="test">
-                                <agentOption>experimental-class-loader-support</agentOption>
-                                <agentOption>access-filter-file=${basedir}/src/test/resources/access-filter.json</agentOption>
-                            </agentOptions>
+                            <agent>
+                                <!-- end::native-plugin-agent-options[] -->
+                                <enabled>true</enabled>
+                                <!-- tag::native-plugin-agent-options[] -->
+                                <options name="main">
+                                    <option>experimental-class-loader-support</option>
+                                </options>
+                                <options name="test">
+                                    <option>experimental-class-loader-support</option>
+                                    <option>access-filter-file=${basedir}/src/test/resources/access-filter.json</option>
+                                </options>
+                            </agent>
                         </configuration>
                         <!-- end::native-plugin-agent-options[] -->
                     </plugin>

--- a/samples/java-application-with-reflection/pom.xml
+++ b/samples/java-application-with-reflection/pom.xml
@@ -148,15 +148,18 @@
                                 <!-- end::native-plugin-agent-options[] -->
                                 <enabled>true</enabled>
                                 <!-- tag::native-plugin-agent-options[] -->
-                                <options><!-- unnamed, shared options -->
+                                <options><!-- shared options -->
                                     <option>experimental-class-loader-support</option>
                                 </options>
                                 <options name="main"><!-- main options -->
-                                    <option>config-write-period-secs=30</option>
-                                    <option>config-write-initial-delay-secs=5</option>
+                                    <option>access-filter-file=${basedir}/src/main/resources/access-filter.json</option>
                                 </options>
                                 <options name="test"><!-- test options -->
                                     <option>access-filter-file=${basedir}/src/test/resources/access-filter.json</option>
+                                </options>
+                                <options name="periodic-config"><!-- periodic-config options -->
+                                    <option>config-write-period-secs=30</option>
+                                    <option>config-write-initial-delay-secs=5</option>
                                 </options>
                             </agent>
                         </configuration>

--- a/samples/java-application-with-reflection/pom.xml
+++ b/samples/java-application-with-reflection/pom.xml
@@ -148,11 +148,14 @@
                                 <!-- end::native-plugin-agent-options[] -->
                                 <enabled>true</enabled>
                                 <!-- tag::native-plugin-agent-options[] -->
-                                <options name="main">
+                                <options><!-- unnamed, shared options -->
                                     <option>experimental-class-loader-support</option>
                                 </options>
-                                <options name="test">
-                                    <option>experimental-class-loader-support</option>
+                                <options name="main"><!-- main options -->
+                                    <option>config-write-period-secs=30</option>
+                                    <option>config-write-initial-delay-secs=5</option>
+                                </options>
+                                <options name="test"><!-- test options -->
                                     <option>access-filter-file=${basedir}/src/test/resources/access-filter.json</option>
                                 </options>
                             </agent>

--- a/samples/java-application-with-reflection/src/main/java/org/graalvm/demo/Application.java
+++ b/samples/java-application-with-reflection/src/main/java/org/graalvm/demo/Application.java
@@ -14,6 +14,6 @@ public class Application {
     }
 
     public static void main(String[] args) {
-        System.out.println(getMessage());
+        System.out.println("Application message: " + getMessage());
     }
 }

--- a/samples/java-application-with-reflection/src/main/resources/access-filter.json
+++ b/samples/java-application-with-reflection/src/main/resources/access-filter.json
@@ -1,0 +1,7 @@
+{
+	"rules": [
+		{
+			"excludeClasses": "org.example.enigma.**"
+		}
+	]
+}

--- a/samples/java-application-with-reflection/src/test/resources/access-filter.json
+++ b/samples/java-application-with-reflection/src/test/resources/access-filter.json
@@ -1,0 +1,7 @@
+{
+	"rules": [
+		{
+			"excludeClasses": "org.apache.maven.surefire.**"
+		}
+	]
+}


### PR DESCRIPTION
Prior to this commit, users could not supply custom options to the JVM agent. In addition, the `experimental-class-loader-support` option was always supplied, which may not be desired by all users.

This commit introduces support for configuring the agent by allowing users to specify multiple sets of named `agentOptions` in the `configuration` block for the native-maven-plugin.

The following example configures two sets of agent options, one for execution of the application (exec) and one for tests (test).

```xml
<configuration>
  <agentOptions name="exec">
    <agentOption>experimental-class-loader-support</agentOption>
  </agentOptions>
  <agentOptions name="test">
    <agentOption>experimental-class-loader-support</agentOption>
    <agentOption>access-filter-file=${basedir}/src/test/resources/access-filter.json</agentOption>
  </agentOptions>
</configuration>
```

In addition, the `experimental-class-loader-support` option is no longer configured automatically by the native-maven-plugin.

See #162
