### PR TITLE
Make it possible to configure agent options in Gradle plugin

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -246,7 +246,7 @@ The generated configuration files will be found in the `${buildDir}/native/agent
 The native agent can be configured https://www.graalvm.org/reference-manual/native-image/Agent/[with additional options].
 This can be done using the `agentOptions` configuration block:
 
-.Disabling the fat jar creation
+.Configuring agent options for every binary
 [source, groovy, role="multi-language-sample"]
 ----
 include::../snippets/gradle/groovy/build.gradle[tags=add-agent-options]
@@ -257,6 +257,19 @@ include::../snippets/gradle/groovy/build.gradle[tags=add-agent-options]
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=add-agent-options]
 ----
 
+You may also define distinct agent options for different images.
+In the following example, the agent used for instrumention for the main image has distinct options from the test ones:
+
+.Configuring agent options specifically
+[source, groovy, role="multi-language-sample"]
+----
+include::../snippets/gradle/groovy/build.gradle[tags=add-agent-options-individual]
+----
+
+[source, kotlin, role="multi-language-sample"]
+----
+include::../snippets/gradle/kotlin/build.gradle.kts[tags=add-agent-options-individual]
+----
 
 === Disabling test support
 

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -17,56 +17,55 @@ For upgrading please take a look at the <<changelog,changes section>>.
 Add following to `plugins` section of your project's `build.gradle` / `build.gradle.kts`:
 
 .Applying the plugin
-[subs="verbatim,attributes", role="multi-language-sample"]
-```groovy
+[source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
+----
 plugins {
   // ...
 
   // Apply GraalVM Native Image plugin
   id 'org.graalvm.buildtools.native' version '{gradle-plugin-version}'
 }
-```
+----
 
-[subs="verbatim,attributes", role="multi-language-sample"]
-```kotlin
+[source,kotlin,subs="verbatim,attributes",role="multi-language-sample"]
+----
 plugins {
   // ...
 
   // Apply GraalVM Native Image plugin
   id("org.graalvm.buildtools.native") version "{gradle-plugin-version}"
 }
-```
+----
 
 The plugin isn't available on the https://plugins.gradle.org[Gradle Plugin Portal] yet, so you will need to declare a plugin repository in addition:
 
 Add the following to your `settings.gradle` / `settings.gradle.kts`:
 
-[role="multi-language-sample"]
 .Declaring the plugin repository
-```groovy
+[source,groovy,role="multi-language-sample"]
+----
 include::../snippets/gradle/groovy/settings.gradle[tags=plugin-management]
-```
+----
 
-[role="multi-language-sample"]
-```kotlin
+[source,kotlin,role="multi-language-sample"]
+----
 include::../snippets/gradle/kotlin/settings.gradle.kts[tags=plugin-management]
-
-```
+----
 
 [TIP]
 .Testing pre-releases
 ====
 You can use the development versions of the plugin by adding our snapshot repository instead. Pre-releases are provided for convenience, without any guarantee.
-[role="multi-language-sample"]
-```groovy
+[source, groovy, role="multi-language-sample"]
+----
 include::../snippets/gradle/groovy/settings.gradle[tags=pre-release, indent=0]
+----
 
-```
-
-[role="multi-language-sample"]
-```kotlin
+[source,kotlin,role="multi-language-sample"]
+----
 include::../snippets/gradle/kotlin/settings.gradle.kts[tags=pre-release, indent=0]
-```
+----
+
 ====
 
 === Installing GraalVM native image tool
@@ -81,9 +80,9 @@ Therefore, you will need to make sure that you have executed `gu install native-
 
 If Gradle cannot find a GraalVM installation on the machine, it will fail with an error like this:
 
-```
+----
    > No compatible toolchains found for request filter: {languageVersion=11, vendor=matching('GraalVM'), implementation=vendor-specific} (auto-detect true, auto-download true)
-```
+----
 
 This happens because there's no automatic provisioning of the GraalVM toolchain available yet, so you will have to install it first.
 Follow the <<graalvm-setup.adoc#,following instructions>> to install it properly.
@@ -123,15 +122,15 @@ By default, the plugin will select a Java 11 GraalVM toolchain.
 If you want to use a different toolchain, for example a GraalVM Community Edition for Java 8, you can configure the toolchain like this:
 
 .Selecting the GraalVM toolchain
-[role="multi-language-sample"]
-```groovy
+[source, groovy, role="multi-language-sample"]
+----
 include::../snippets/gradle/groovy/build.gradle[tags=select-toolchain]
-```
+----
 
-[role="multi-language-sample"]
-```kotlin
+[source,kotlin,role="multi-language-sample"]
+----
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=select-toolchain]
-```
+----
 
 [[disabling-toolchains]]
 ==== Disabling toolchain detection
@@ -142,15 +141,15 @@ This is the case if, for example, you want to use GraalVM Enterprise or that you
 To workaround this problem, you can disable toolchain detection:
 
 .Disabling toolchain detection
-[role="multi-language-sample"]
-```groovy
+[source,groovy,role="multi-language-sample"]
+----
 include::../snippets/gradle/groovy/build.gradle[tags=disabling-toolchain, indent=0]
-```
+----
 
-[role="multi-language-sample"]
-```kotlin
+[source, kotlin, role="multi-language-sample"]
+----
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=disabling-toolchain, indent=0]
-```
+----
 
 If you do this, the plugin will search for 2 environment variables: `GRAALVM_HOME` and `JAVA_HOME` _in that order_.
 If one of them is set, it will assume that it points to a valid GraalVM installation and completely bypass toolchain selection.
@@ -161,15 +160,15 @@ Therefore, it becomes your responsibility to make sure that the JDK pointing at 
 The following configuration options are available for building images:
 
 .NativeImageOption configuration
-[role="multi-language-sample"]
-```groovy
+[source, groovy, role="multi-language-sample"]
+----
 include::../snippets/gradle/groovy/build.gradle[tags=all-config-options]
-```
+----
 
-[role="multi-language-sample"]
-```kotlin
+[source, kotlin, role="multi-language-sample"]
+----
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=all-config-options]
-```
+----
 
 NOTE: For options that can be set using command-line, if both DSL and command-line options are present, command-line options take precedence.
 
@@ -182,28 +181,28 @@ As a consequence, if you are running under Windows, the plugin will automaticall
 In case this behavior is not required, you can disable the fat jar creation by calling:
 
 .Disabling the fat jar creation
-[role="multi-language-sample"]
-```groovy
+[source, groovy, role="multi-language-sample"]
+----
 include::../snippets/gradle/groovy/build.gradle[tags=disable-fatjar]
-```
+----
 
-[role="multi-language-sample"]
-```kotlin
+[source,kotlin,role="multi-language-sample"]
+----
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=disable-fatjar]
-```
+----
 
 Alternatively, it is possible to use your own fat jar (for example created using the https://imperceptiblethoughts.com/shadow/[Shadow plugin]) by setting the `classpathJar` property directly on the _task_:
 
 .Disabling the fat jar creation
-[role="multi-language-sample"]
-```groovy
+[source, groovy, role="multi-language-sample"]
+----
 include::../snippets/gradle/groovy/build.gradle[tags=custom-fatjar]
-```
+----
 
-[role="multi-language-sample"]
-```kotlin
+[source, kotlin, role="multi-language-sample"]
+----
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=custom-fatjar]
-```
+----
 
 When the `classpathJar` property is set, the `classpath` property is _ignored_.
 
@@ -215,9 +214,10 @@ In other words, tests will be compiled and executed as native code.
 
 Currently, this feature requires the execution of the tests in the classic "JVM" mode _prior to_ the execution of tests in native mode. To execute the tests, execute:
 
-```bash
+[source,bash]
+----
 ./gradlew nativeTest
-```
+----
 
 === Reflection support and running with the native agent
 
@@ -227,18 +227,36 @@ The Gradle plugin makes it easy to generate the required configuration files by 
 
 This should be as easy as appending `-Pagent` to `run` and `nativeBuild`, or `test` and `nativeTest` task invocations:
 
-```bash
+[source,bash]
+----
 ./gradlew -Pagent run # Runs on JVM with native-image-agent.
 ./gradlew -Pagent nativeCompile # Builds image using configuration acquired by agent.
 
 # For testing
 ./gradlew -Pagent test # Runs on JVM with native-image-agent.
 ./gradlew -Pagent nativeTest # Builds image using configuration acquired by agent.
-```
+----
 
 Same can be achieved by setting corresponding DSL option, althought this isn't recommended as this is a development mode feature only.
 
 The generated configuration files will be found in the `${buildDir}/native/agent-output/${taskName}` directory, for example, `build/native/agent-output/run`.
+
+==== Configuring agent options
+
+The native agent can be configured https://www.graalvm.org/reference-manual/native-image/Agent/[with additional options].
+This can be done using the `agentOptions` configuration block:
+
+.Disabling the fat jar creation
+[source, groovy, role="multi-language-sample"]
+----
+include::../snippets/gradle/groovy/build.gradle[tags=add-agent-options]
+----
+
+[source, kotlin, role="multi-language-sample"]
+----
+include::../snippets/gradle/kotlin/build.gradle.kts[tags=add-agent-options]
+----
+
 
 === Disabling test support
 
@@ -250,15 +268,15 @@ There are cases where you might want to disable test support:
 In this case, you can disable test support by configuring the `graalvmNative` extension:
 
 .Disabling test support
-[role="multi-language-sample"]
-```groovy
+[source,groovy,role="multi-language-sample"]
+----
 include::../snippets/gradle/groovy/build.gradle[tags=disable-test-support]
-```
+----
 
-[role="multi-language-sample"]
-```kotlin
+[source,kotlin,role="multi-language-sample"]
+----
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=disable-test-support]
-```
+----
 
 [[extra-test-suites]]
 === Configuring additional test suites
@@ -271,15 +289,15 @@ For example, imagine that you have a source set named `integTest` and that its c
 In this case you can register a new native test binary via the `graalvmNative` extension:
 
 .Registering a new test suite
-[role="multi-language-sample"]
-```groovy
+[source, groovy, role="multi-language-sample"]
+----
 include::../../../../samples/java-application-with-custom-tests/build.gradle[tag=register-native-test]
-```
+----
 
-[role="multi-language-sample"]
-```kotlin
+[source, kotlin, role="multi-language-sample"]
+----
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=custom-binary]
-```
+----
 
 The plugin will then automatically create the following tasks:
 
@@ -302,15 +320,15 @@ For example, you could declare a source set which uses the GraalVM SDK to implem
 This source set would contain code which is only relevant to native images building:
 
 .Declaring a custom source set
-[role="multi-language-sample"]
-```groovy
+[source, groovy, role="multi-language-sample"]
+----
 include::../../../../samples/java-application-with-extra-sourceset/build.gradle[tag=extra-sourceset]
-```
+----
 
-[role="multi-language-sample"]
-```kotlin
+[source, kotlin, role="multi-language-sample"]
+----
 include::../../../../samples/java-application-with-extra-sourceset/build.gradle.kts[tag=extra-sourceset]
-```
+----
 
 == Javadocs
 

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -21,6 +21,7 @@ If you are interested in contributing, please refer to our https://github.com/gr
 
 * Add an option to disable toolchain support altogether, which can be useful to use GraalVM Enterprise Edition, for example.
 * Fixed a bug when using a _fat jar_ which assumed that all entries to be repackaged were jars.
+* Made agent options configurable. Note that the `experimental-class-loader-support` agent option is no longer added by default.
 
 ==== JUnit Platform Native
 

--- a/docs/src/docs/snippets/gradle/groovy/build.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/build.gradle
@@ -129,3 +129,20 @@ graalvmNative {
     }
 }
 // end::add-agent-options[]
+
+// tag::add-agent-options-individual[]
+graalvmNative {
+    binaries {
+        main {
+            agentOptions {
+                args.add("experimental-class-loader-support")
+            }
+        }
+        test {
+            agentOptions {
+                args.add("access-filter-file=${projectDir}/src/test/resources/access-filter.json")
+            }
+        }
+    }
+}
+// end::add-agent-options-individual[]

--- a/docs/src/docs/snippets/gradle/groovy/build.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/build.gradle
@@ -119,3 +119,13 @@ graalvmNative {
     testSupport = false
 }
 // end::disable-test-support[]
+
+// tag::add-agent-options[]
+graalvmNative {
+    binaries.configureEach {
+        agentOptions {
+            args.add("experimental-class-loader-support")
+        }
+    }
+}
+// end::add-agent-options[]

--- a/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
+++ b/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
@@ -97,7 +97,7 @@ graalvmNative {
 }
 // end::all-config-options[]
 
-// tag::disable-farjar[]
+// tag::disable-fatjar[]
 graalvmNative {
     binaries {
         named("main") {
@@ -132,3 +132,13 @@ graalvmNative {
     }
 }
 // end::custom-binary[]
+
+// tag::add-agent-options[]
+graalvmNative {
+    binaries.configureEach {
+        agentOptions {
+            args.add("experimental-class-loader-support")
+        }
+    }
+}
+// end::add-agent-options[]

--- a/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
+++ b/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
@@ -142,3 +142,20 @@ graalvmNative {
     }
 }
 // end::add-agent-options[]
+
+// tag::add-agent-options-individual[]
+graalvmNative {
+    binaries {
+        named("main") {
+            agentOptions {
+                args.add("experimental-class-loader-support")
+            }
+        }
+        named("test") {
+            agentOptions {
+                args.add("access-filter-file=${projectDir}/src/test/resources/access-filter.json")
+            }
+        }
+    }
+}
+// end::add-agent-options-individual[]

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -149,7 +149,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         withSample("java-application-with-reflection")
 
         when:
-        fails 'nativeTest', '-DagentOption=will-fail'
+        fails 'nativeTest', '-DagentOptions=will-fail'
 
         then:
         errorOutputContains "native-image-agent: unknown option: 'will-fail'."

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -158,4 +158,38 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
+
+    def "reasonable error message if the user provides themselves an output directory"() {
+        gradleVersion = version
+        debug = true
+        given:
+        withSample("java-application-with-reflection")
+
+        when:
+        fails 'nativeTest', '-DagentOptions=config-output-dir'
+
+        then:
+        errorOutputContains "config-output-dir cannot be supplied as an agent option"
+
+        where:
+        version << TESTED_GRADLE_VERSIONS
+        junitVersion = System.getProperty('versions.junit')
+    }
+
+    def "reasonable error message if the user provides themselves an output directory value"() {
+        gradleVersion = version
+        debug = true
+        given:
+        withSample("java-application-with-reflection")
+
+        when:
+        fails 'nativeTest', '-DagentOptions=config-output-dir=nope!'
+
+        then:
+        errorOutputContains "config-output-dir cannot be supplied as an agent option"
+
+        where:
+        version << TESTED_GRADLE_VERSIONS
+        junitVersion = System.getProperty('versions.junit')
+    }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -142,4 +142,20 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         junitVersion = System.getProperty('versions.junit')
     }
 
+    def "can configure extra options to the agent"() {
+        gradleVersion = version
+        debug = true
+        given:
+        withSample("java-application-with-reflection")
+
+        when:
+        fails 'nativeTest', '-DagentOption=will-fail'
+
+        then:
+        errorOutputContains "native-image-agent: unknown option: 'will-fail'."
+
+        where:
+        version << TESTED_GRADLE_VERSIONS
+        junitVersion = System.getProperty('versions.junit')
+    }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/AgentOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/AgentOptions.java
@@ -55,10 +55,10 @@ public interface AgentOptions {
      * @return The value which toggles the native-image-agent usage.
      */
     @Input
-    Property<Boolean> getAgent();
+    Property<Boolean> getEnabled();
 
     /**
-     * Gets the native agent arguments. Only used when {@link #getAgent()} is true.
+     * Gets the native agent arguments. Only used when {@link #getEnabled()} is true.
      * @return the native agent options.
      */
     @Input

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/AgentOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/AgentOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,53 +38,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.graalvm.buildtools.gradle.dsl;
 
-package org.graalvm.buildtools.gradle.internal;
-
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.process.JavaForkOptions;
 
-import javax.inject.Inject;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-public abstract class AgentCommandLineProvider implements CommandLineArgumentProvider {
-
-    @Inject
-    @SuppressWarnings("checkstyle:redundantmodifier")
-    public AgentCommandLineProvider() {
-
-    }
-
+public interface AgentOptions {
+    /**
+     * Gets the value which toggles the native-image-agent usage.
+     *
+     * @return The value which toggles the native-image-agent usage.
+     */
     @Input
-    public abstract Property<Boolean> getEnabled();
+    Property<Boolean> getAgent();
 
-    @OutputDirectory
-    public abstract DirectoryProperty getOutputDirectory();
-
+    /**
+     * Gets the native agent arguments. Only used when {@link #getAgent()} is true.
+     * @return the native agent options.
+     */
     @Input
     @Optional
-    public abstract ListProperty<String> getAgentOptions();
+    ListProperty<String> getArgs();
 
-    @Override
-    public Iterable<String> asArguments() {
-        if (getEnabled().get()) {
-            File outputDir = getOutputDirectory().getAsFile().get();
-            List<String> agentOptions = new ArrayList<>(getAgentOptions().getOrElse(Collections.emptyList()));
-            agentOptions.add("config-output-dir=" + outputDir.getAbsolutePath());
-            return Arrays.asList(
-                    "-agentlib:native-image-agent=" + String.join(",", agentOptions),
-                    "-Dorg.graalvm.nativeimage.imagecode=agent"
-            );
-        }
-        return Collections.emptyList();
-    }
+    /**
+     * Configures the task which needs to be instrumented.
+     * @return the instrumented task.
+     */
+    @Internal
+    Property<TaskProvider<? extends JavaForkOptions>> getInstrumentedTask();
+
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
@@ -155,7 +155,7 @@ public interface NativeImageOptions extends Named {
 
     /**
      * Gets the value which toggles the native-image-agent usage.
-     * This is a convenience method for calling <code>getAgentOptions().getAgent()</code>.
+     * This is a convenience method for calling <code>getAgentOptions().getEnabled()</code>.
      *
      * @return The value which toggles the native-image-agent usage.
      */

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
@@ -155,11 +155,27 @@ public interface NativeImageOptions extends Named {
 
     /**
      * Gets the value which toggles the native-image-agent usage.
+     * This is a convenience method for calling <code>getAgentOptions().getAgent()</code>.
      *
      * @return The value which toggles the native-image-agent usage.
      */
     @Input
     Property<Boolean> getAgent();
+
+    /**
+     * Returns the GraalVM agent options.
+     * @return the options.
+     */
+    @Nested
+    AgentOptions getAgentOptions();
+
+    /**
+     * Configures the GraalVM agent options.
+     * @param spec the agent configuration.
+     */
+    default void agentOptions(Action<? super AgentOptions> spec) {
+        spec.execute(getAgentOptions());
+    }
 
     /**
      * Gets the value which determines if shared library is being built.

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/AgentCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/AgentCommandLineProvider.java
@@ -79,6 +79,9 @@ public abstract class AgentCommandLineProvider implements CommandLineArgumentPro
         if (getEnabled().get()) {
             File outputDir = getOutputDirectory().getAsFile().get();
             List<String> agentOptions = new ArrayList<>(getAgentOptions().getOrElse(Collections.emptyList()));
+            if (agentOptions.stream().map(s -> s.split("=")[0]).anyMatch(s -> s.contains("config-output-dir"))) {
+                throw new IllegalStateException("config-output-dir cannot be supplied as an agent option");
+            }
             agentOptions.add("config-output-dir=" + outputDir.getAbsolutePath());
             return Arrays.asList(
                     "-agentlib:native-image-agent=" + String.join(",", agentOptions),

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -59,6 +59,7 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskContainer;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
@@ -176,7 +177,9 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
      * @return The value which toggles the native-image-agent usage.
      */
     @Input
-    public abstract Property<Boolean> getAgent();
+    public Property<Boolean> getAgent() {
+        return getAgentOptions().getAgent();
+    }
 
     /**
      * Gets the value which determines if shared library is being built.
@@ -214,6 +217,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
                                   ObjectFactory objectFactory,
                                   ProviderFactory providers,
                                   JavaToolchainService toolchains,
+                                  TaskContainer tasks,
                                   String defaultImageName) {
         this.name = name;
         getDebug().convention(false);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -178,7 +178,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
      */
     @Input
     public Property<Boolean> getAgent() {
-        return getAgentOptions().getAgent();
+        return getAgentOptions().getEnabled();
     }
 
     /**

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
@@ -40,6 +40,7 @@
  */
 package org.graalvm.buildtools.gradle.internal;
 
+import org.graalvm.buildtools.gradle.dsl.AgentOptions;
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.dsl.NativeResourcesOptions;
 import org.gradle.api.Action;
@@ -169,6 +170,12 @@ public abstract class DeprecatedNativeImageOptions implements NativeImageOptions
     @Input
     public Property<Boolean> getAgent() {
         return warnAboutDeprecation(delegate::getAgent);
+    }
+
+    @Override
+    @Nested
+    public AgentOptions getAgentOptions() {
+        return warnAboutDeprecation(delegate::getAgentOptions);
     }
 
     @Override

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -154,7 +154,7 @@ abstract class AbstractFunctionalTest extends Specification {
 
     private void recordOutputs() {
         output = outputWriter.toString()
-        errorOutput = errorOutput.toString()
+        errorOutput = errorOutputWriter.toString()
     }
 
     private GradleRunner newRunner(String... args) {

--- a/samples/java-application-with-reflection/build.gradle
+++ b/samples/java-application-with-reflection/build.gradle
@@ -70,7 +70,7 @@ graalvmNative {
         test {
             verbose = true
             agentOptions {
-                agent = true
+                enabled = true
                 args.add(providers.systemProperty("agentOptions").forUseAtConfigurationTime())
             }
         }

--- a/samples/java-application-with-reflection/build.gradle
+++ b/samples/java-application-with-reflection/build.gradle
@@ -71,7 +71,7 @@ graalvmNative {
             verbose = true
             agentOptions {
                 agent = true
-                args.add(providers.systemProperty("agentOption").forUseAtConfigurationTime())
+                args.add(providers.systemProperty("agentOptions").forUseAtConfigurationTime())
             }
         }
     }

--- a/samples/java-application-with-reflection/build.gradle
+++ b/samples/java-application-with-reflection/build.gradle
@@ -69,7 +69,10 @@ graalvmNative {
     binaries {
         test {
             verbose = true
-            agent = true
+            agentOptions {
+                agent = true
+                args.add(providers.systemProperty("agentOption").forUseAtConfigurationTime())
+            }
         }
     }
 }


### PR DESCRIPTION
Before this commit, the `experimental-class-loader-support` was
systematically added to the agent options and it wasn't possible
to configure the options passed to the agent.

Now, each image can configure agent options independently. As
part of this work, cleanup was done in the way agent configuration
was injected. In particular, each native image now has to explicitly
state what _task_ should be instrumented when the agent is enabled.
The plugin automatically configures the `main` image to instrument
the `run` task, while the `test` image instruments the `test` task.

The agent options are configured via a new `agentOptions` block.
The old `agent.set(true)` method is delegating to the `agentOptions`
block.

See #162

This is the Gradle plugin counterpart to #168 