### PR TITLE
Rename `agentOptions` -> `agent`

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -244,7 +244,7 @@ The generated configuration files will be found in the `${buildDir}/native/agent
 ==== Configuring agent options
 
 The native agent can be configured https://www.graalvm.org/reference-manual/native-image/Agent/[with additional options].
-This can be done using the `agentOptions` configuration block:
+This can be done using the `agent` configuration block:
 
 .Configuring agent options for every binary
 [source, groovy, role="multi-language-sample"]

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -19,6 +19,7 @@ If you are interested in contributing, please refer to our https://github.com/gr
 
 ==== Gradle plugin
 
+* [Breaking change] The `agent` option is now replaced with an `agent { ... }` configuration block which includes an `enabled` property.
 * Add an option to disable toolchain support altogether, which can be useful to use GraalVM Enterprise Edition, for example.
 * Fixed a bug when using a _fat jar_ which assumed that all entries to be repackaged were jars.
 * Made agent options configurable. Note that the `experimental-class-loader-support` agent option is no longer added by default.

--- a/docs/src/docs/snippets/gradle/groovy/build.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/build.gradle
@@ -88,7 +88,9 @@ graalvmNative {
             runtimeArgs.add('--help') // Passes '--help' to built image, during "nativeRun" task
 
             // Development options
-            agent = true // Enables the reflection agent. Can be also set on command line using '-Pagent'
+            agent {
+                enabled = true // Enables the reflection agent. Can be also set on command line using '-Pagent'
+            }
 
             useFatJar = true // Instead of passing each jar individually, builds a fat jar
         }
@@ -123,8 +125,8 @@ graalvmNative {
 // tag::add-agent-options[]
 graalvmNative {
     binaries.configureEach {
-        agentOptions {
-            args.add("experimental-class-loader-support")
+        agent {
+            options.add("experimental-class-loader-support")
         }
     }
 }
@@ -134,13 +136,13 @@ graalvmNative {
 graalvmNative {
     binaries {
         main {
-            agentOptions {
-                args.add("experimental-class-loader-support")
+            agent {
+                options.add("experimental-class-loader-support")
             }
         }
         test {
-            agentOptions {
-                args.add("access-filter-file=${projectDir}/src/test/resources/access-filter.json")
+            agent {
+                options.add("access-filter-file=${projectDir}/src/test/resources/access-filter.json")
             }
         }
     }

--- a/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
+++ b/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
@@ -89,7 +89,9 @@ graalvmNative {
             runtimeArgs.add("--help") // Passes '--help' to built image, during "nativeRun" task
 
             // Development options
-            agent.set(true) // Enables the reflection agent. Can be also set on command line using '-Pagent'
+            agent {
+                enabled.set(true) // Enables the reflection agent. Can be also set on command line using '-Pagent'
+            }
 
             useFatJar.set(true) // Instead of passing each jar individually, builds a fat jar
         }
@@ -136,8 +138,8 @@ graalvmNative {
 // tag::add-agent-options[]
 graalvmNative {
     binaries.configureEach {
-        agentOptions {
-            args.add("experimental-class-loader-support")
+        agent {
+            options.add("experimental-class-loader-support")
         }
     }
 }
@@ -147,13 +149,13 @@ graalvmNative {
 graalvmNative {
     binaries {
         named("main") {
-            agentOptions {
-                args.add("experimental-class-loader-support")
+            agent {
+                options.add("experimental-class-loader-support")
             }
         }
         named("test") {
-            agentOptions {
-                args.add("access-filter-file=${projectDir}/src/test/resources/access-filter.json")
+            agent {
+                options.add("access-filter-file=${projectDir}/src/test/resources/access-filter.json")
             }
         }
     }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/AgentConfiguration.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/AgentConfiguration.java
@@ -48,7 +48,7 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.process.JavaForkOptions;
 
-public interface AgentOptions {
+public interface AgentConfiguration {
     /**
      * Gets the value which toggles the native-image-agent usage.
      *
@@ -58,12 +58,12 @@ public interface AgentOptions {
     Property<Boolean> getEnabled();
 
     /**
-     * Gets the native agent arguments. Only used when {@link #getEnabled()} is true.
+     * Gets the native agent options. Only used when {@link #getEnabled()} is true.
      * @return the native agent options.
      */
     @Input
     @Optional
-    ListProperty<String> getArgs();
+    ListProperty<String> getOptions();
 
     /**
      * Configures the task which needs to be instrumented.

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
@@ -154,27 +154,18 @@ public interface NativeImageOptions extends Named {
     Property<Boolean> getVerbose();
 
     /**
-     * Gets the value which toggles the native-image-agent usage.
-     * This is a convenience method for calling <code>getAgentOptions().getEnabled()</code>.
-     *
-     * @return The value which toggles the native-image-agent usage.
-     */
-    @Input
-    Property<Boolean> getAgent();
-
-    /**
-     * Returns the GraalVM agent options.
-     * @return the options.
+     * Returns the GraalVM agent configuration.
+     * @return the configuration.
      */
     @Nested
-    AgentOptions getAgentOptions();
+    AgentConfiguration getAgent();
 
     /**
      * Configures the GraalVM agent options.
      * @param spec the agent configuration.
      */
-    default void agentOptions(Action<? super AgentOptions> spec) {
-        spec.execute(getAgentOptions());
+    default void agent(Action<? super AgentConfiguration> spec) {
+        spec.execute(getAgent());
     }
 
     /**

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -171,15 +171,6 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
     @Input
     public abstract Property<Boolean> getVerbose();
 
-    /**
-     * Gets the value which toggles the native-image-agent usage.
-     *
-     * @return The value which toggles the native-image-agent usage.
-     */
-    @Input
-    public Property<Boolean> getAgent() {
-        return getAgentOptions().getEnabled();
-    }
 
     /**
      * Gets the value which determines if shared library is being built.
@@ -223,7 +214,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         getDebug().convention(false);
         getFallback().convention(false);
         getVerbose().convention(false);
-        getAgent().convention(false);
+        getAgent().getEnabled().convention(false);
         getSharedLibrary().convention(false);
         getImageName().convention(defaultImageName);
         getUseFatJar().convention(SharedConstants.IS_WINDOWS);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
@@ -40,7 +40,7 @@
  */
 package org.graalvm.buildtools.gradle.internal;
 
-import org.graalvm.buildtools.gradle.dsl.AgentOptions;
+import org.graalvm.buildtools.gradle.dsl.AgentConfiguration;
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.dsl.NativeResourcesOptions;
 import org.gradle.api.Action;
@@ -167,15 +167,9 @@ public abstract class DeprecatedNativeImageOptions implements NativeImageOptions
     }
 
     @Override
-    @Input
-    public Property<Boolean> getAgent() {
-        return warnAboutDeprecation(delegate::getAgent);
-    }
-
-    @Override
     @Nested
-    public AgentOptions getAgentOptions() {
-        return warnAboutDeprecation(delegate::getAgentOptions);
+    public AgentConfiguration getAgent() {
+        return warnAboutDeprecation(delegate::getAgent);
     }
 
     @Override

--- a/samples/java-application-with-reflection/build.gradle
+++ b/samples/java-application-with-reflection/build.gradle
@@ -69,9 +69,9 @@ graalvmNative {
     binaries {
         test {
             verbose = true
-            agentOptions {
+            agent {
                 enabled = true
-                args.add(providers.systemProperty("agentOptions").forUseAtConfigurationTime())
+                options.add(providers.systemProperty("agentOptions").forUseAtConfigurationTime())
             }
         }
     }


### PR DESCRIPTION
In order to be more consistent with the actual naming in GraalVM,
the `agentOptions` block which was effectively agent configuration
is renamed to `agent`, at the cost of a breaking change: the
`agent` property was removed from the extension and now returns
the agent configuration.