### PR TITLE
Let resources autodetection work if file contains native-image config

### DIFF
--- a/.github/workflows/junit-platform-native-feature.yml
+++ b/.github/workflows/junit-platform-native-feature.yml
@@ -41,3 +41,9 @@ jobs:
           pushd common/junit-platform-native
             ./gradlew nativeTest
           popd
+      - name: Tests results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: tests-results
+          path: common/junit-platform-native/build/reports/tests/

--- a/.github/workflows/native-gradle-plugin.yml
+++ b/.github/workflows/native-gradle-plugin.yml
@@ -38,12 +38,14 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: unit-tests-results
-          path: native-gradle-plugin/build/reports/tests/test/index.html
+          path: native-gradle-plugin/build/reports/tests/test/
   functional-testing-gradle-plugin:
     name: Functional testing
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
+      matrix:
+        gradle-version: ["current", "7.3", "7.2", "7.1", "6.8.3","6.7.1"]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -57,35 +59,11 @@ jobs:
       - name: Check and test the plugin
         run: |
           pushd native-gradle-plugin
-            ./gradlew functionalTest
+            ./gradlew functionalTest -DgradleVersion=${{ matrix.gradle-version }}
           popd
       - name: Functional tests results
-        uses: actions/upload-artifact@v1
+        if: always()
+        uses: actions/upload-artifact@v2
         with:
-          name: functional-tests-results
-          path: native-gradle-plugin/build/reports/tests/functionalTest/index.html
-  full-functional-testing-gradle-plugin:
-    name: Full functional testing
-    runs-on: ubuntu-18.04
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - name: Get GraalVM Nightly
-        run: |
-          source common/scripts/downloadGraalVM.sh
-          echo "$GRAALVM_HOME/bin" >> $GITHUB_PATH
-          echo "JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
-          echo "GRAALVM_HOME=$GRAALVM_HOME" >> $GITHUB_ENV
-      - name: Verifies plugin on multiple Gradle versions
-        run: |
-          pushd native-gradle-plugin
-            ./gradlew fullFunctionalTest
-          popd
-      - name: Full functional tests results
-        uses: actions/upload-artifact@v1
-        with:
-          name: full-functional-tests-results
-          path: native-gradle-plugin/build/reports/tests/fullFunctionalTest/index.html
+          name: functional-tests-results-${{ matrix.gradle-version }}
+          path: native-gradle-plugin/build/reports/tests/functionalTest/

--- a/.github/workflows/native-gradle-plugin.yml
+++ b/.github/workflows/native-gradle-plugin.yml
@@ -34,6 +34,11 @@ jobs:
           pushd native-gradle-plugin
             ./gradlew test inspections
           popd
+      - name: Unit tests results
+        uses: actions/upload-artifact@v1
+        with:
+          name: unit-tests-results
+          path: native-gradle-plugin/build/reports/tests/test/index.html
   functional-testing-gradle-plugin:
     name: Functional testing
     runs-on: ubuntu-18.04
@@ -54,6 +59,11 @@ jobs:
           pushd native-gradle-plugin
             ./gradlew functionalTest
           popd
+      - name: Functional tests results
+        uses: actions/upload-artifact@v1
+        with:
+          name: functional-tests-results
+          path: native-gradle-plugin/build/reports/tests/functionalTest/index.html
   full-functional-testing-gradle-plugin:
     name: Full functional testing
     runs-on: ubuntu-18.04
@@ -74,3 +84,8 @@ jobs:
           pushd native-gradle-plugin
             ./gradlew fullFunctionalTest
           popd
+      - name: Full functional tests results
+        uses: actions/upload-artifact@v1
+        with:
+          name: full-functional-tests-results
+          path: native-gradle-plugin/build/reports/tests/fullFunctionalTest/index.html

--- a/.github/workflows/native-maven-plugin.yml
+++ b/.github/workflows/native-maven-plugin.yml
@@ -34,3 +34,9 @@ jobs:
           pushd native-maven-plugin
             ./gradlew check --no-daemon
           popd
+      - name: Tests results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: functional-tests-results-${{ matrix.gradle-version }}
+          path: native-maven-plugin/build/reports/tests/

--- a/common/utils/src/main/java/org/graalvm/buildtools/model/resources/ClassPathDirectoryAnalyzer.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/model/resources/ClassPathDirectoryAnalyzer.java
@@ -55,16 +55,18 @@ import java.util.function.Function;
 
 class ClassPathDirectoryAnalyzer extends ClassPathEntryAnalyzer {
     private final Path root;
+    private final boolean ignoreExistingResourcesConfig;
 
-    ClassPathDirectoryAnalyzer(Path root, Function<String, Boolean> resourceFilter) {
+    ClassPathDirectoryAnalyzer(Path root, Function<String, Boolean> resourceFilter, boolean ignoreExistingResourcesConfig) {
         super(resourceFilter);
         this.root = root;
+        this.ignoreExistingResourcesConfig = ignoreExistingResourcesConfig;
     }
 
     protected List<String> initialize() throws IOException {
         DirectoryVisitor visitor = new DirectoryVisitor();
         Files.walkFileTree(root, visitor);
-        return visitor.hasNativeImageResourceFile ? Collections.emptyList() : visitor.resources;
+        return visitor.hasNativeImageResourceFile && !ignoreExistingResourcesConfig ? Collections.emptyList() : visitor.resources;
     }
 
     private class DirectoryVisitor extends SimpleFileVisitor<Path> {

--- a/common/utils/src/main/java/org/graalvm/buildtools/model/resources/ClassPathEntryAnalyzer.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/model/resources/ClassPathEntryAnalyzer.java
@@ -50,11 +50,11 @@ public abstract class ClassPathEntryAnalyzer {
 
     private List<String> resources;
 
-    public static ClassPathEntryAnalyzer of(File file, Function<String, Boolean> resourceFilter) {
+    public static ClassPathEntryAnalyzer of(File file, Function<String, Boolean> resourceFilter, boolean ignoreExistingResourcesConfig) {
         if (file.getName().endsWith(".jar")) {
-            return new JarAnalyzer(file, resourceFilter);
+            return new JarAnalyzer(file, resourceFilter, ignoreExistingResourcesConfig);
         }
-        return new ClassPathDirectoryAnalyzer(file.toPath(), resourceFilter);
+        return new ClassPathDirectoryAnalyzer(file.toPath(), resourceFilter, ignoreExistingResourcesConfig);
     }
 
     protected ClassPathEntryAnalyzer(Function<String, Boolean> resourceFilter) {

--- a/common/utils/src/main/java/org/graalvm/buildtools/model/resources/JarAnalyzer.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/model/resources/JarAnalyzer.java
@@ -54,10 +54,12 @@ import java.util.zip.ZipEntry;
 
 class JarAnalyzer extends ClassPathEntryAnalyzer {
     private final File jarFile;
+    private final boolean ignoreExistingResourcesConfig;
 
-    JarAnalyzer(File jarFile, Function<String, Boolean> resourceFilter) {
+    JarAnalyzer(File jarFile, Function<String, Boolean> resourceFilter, boolean ignoreExistingResourcesConfig) {
         super(resourceFilter);
         this.jarFile = jarFile;
+        this.ignoreExistingResourcesConfig = ignoreExistingResourcesConfig;
     }
 
     protected List<String> initialize() throws IOException {
@@ -69,7 +71,7 @@ class JarAnalyzer extends ClassPathEntryAnalyzer {
                 hasNativeImageResourceFile = FileUtils.normalizePathSeparators(entry.getName()).startsWith(Helper.META_INF_NATIVE_IMAGE + "/")
                     && entry.getName().endsWith("resource-config.json");
 
-                if (hasNativeImageResourceFile) {
+                if (hasNativeImageResourceFile && !ignoreExistingResourcesConfig) {
                     break;
                 }
                 if (!entry.isDirectory()) {

--- a/common/utils/src/main/java/org/graalvm/buildtools/model/resources/JarAnalyzer.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/model/resources/JarAnalyzer.java
@@ -79,6 +79,6 @@ class JarAnalyzer extends ClassPathEntryAnalyzer {
                 }
             }
         }
-        return hasNativeImageResourceFile ? Collections.emptyList() : resources;
+        return hasNativeImageResourceFile && !ignoreExistingResourcesConfig ? Collections.emptyList() : resources;
     }
 }

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -26,6 +26,7 @@ If you are interested in contributing, please refer to our https://github.com/gr
 * Agent options are now configurable.
    - Note that the `experimental-class-loader-support` agent option is no longer added by default.
    - See <<gradle-plugin.adoc#agent-support-configuring-options, Configuring agent options>> for details.
+* Added an option to perform resource detection in classpath entries which contain a `native-image/resource-config.json` file.
 
 ==== Maven plugin
 
@@ -34,6 +35,7 @@ If you are interested in contributing, please refer to our https://github.com/gr
 * Agent options are now configurable.
    - Note that the `experimental-class-loader-support` agent option is no longer added by default.
    - See <<maven-plugin.adoc#agent-support-configuring-options, Configuring agent options>> for details.
+* Added an option to perform resource detection in classpath entries which contain a `native-image/resource-config.json` file.
 
 ==== JUnit Platform Native
 

--- a/native-gradle-plugin/buildSrc/src/main/groovy/org.graalvm.build.functional-testing.gradle
+++ b/native-gradle-plugin/buildSrc/src/main/groovy/org.graalvm.build.functional-testing.gradle
@@ -78,32 +78,38 @@ def graalVm = javaToolchains.launcherFor {
     vendor.set(JvmVendorSpec.matching("GraalVM"))
 }
 
-['functionalTest', 'fullFunctionalTest', 'configCacheFunctionalTest'].each {
-    // Add a task to run the functional tests
-    tasks.register(it, Test) {
-        // Any change to samples invalidates functional tests
-        inputs.files(files("../samples"))
-        inputs.files(configurations.functionalTestCommonRepository)
-        systemProperty('common.repo.url', configurations.functionalTestCommonRepository.incoming.files.files[0])
-        systemProperty('versions.junit', libs.versions.junitJupiter.get())
-        environment('GRAALVM_HOME', graalVm.forUseAtConfigurationTime().get().metadata.installationPath.asFile.absolutePath)
-        testClassesDirs = sourceSets.functionalTest.output.classesDirs
-        classpath = sourceSets.functionalTest.runtimeClasspath
-        javaLauncher.set(graalVm)
+def fullFunctionalTest = tasks.register("fullFunctionalTest")
+
+['functionalTest', 'configCacheFunctionalTest'].each { baseName ->
+    ["current", "7.3", "7.2", "7.1", "6.8.3", "6.7.1"].each { gradleVersion ->
+        String taskName = gradleVersion == 'current' ? baseName : "gradle${gradleVersion}${baseName.capitalize()}"
+        // Add a task to run the functional tests
+        def testTask = tasks.register(taskName, Test) {
+            String effectiveVersion = gradleVersion
+            def versionProvider = providers.systemProperty('gradleVersion').forUseAtConfigurationTime()
+            if (effectiveVersion == 'current' && versionProvider.isPresent()) {
+                effectiveVersion = versionProvider.get()
+            }
+            group = "Verification"
+            description = "Runs functional tests for Gradle $effectiveVersion"
+            // Any change to samples invalidates functional tests
+            inputs.files(files("../samples"))
+            inputs.files(configurations.functionalTestCommonRepository)
+            systemProperty('common.repo.url', configurations.functionalTestCommonRepository.incoming.files.files[0])
+            systemProperty('gradle.test.version', effectiveVersion)
+            systemProperty('versions.junit', libs.versions.junitJupiter.get())
+            environment('GRAALVM_HOME', graalVm.forUseAtConfigurationTime().get().metadata.installationPath.asFile.absolutePath)
+            testClassesDirs = sourceSets.functionalTest.output.classesDirs
+            classpath = sourceSets.functionalTest.runtimeClasspath
+            javaLauncher.set(graalVm)
+            if (baseName == 'configCacheFunctionalTest') {
+                systemProperty('config.cache', 'true')
+            }
+        }
+        fullFunctionalTest.configure {
+            it.dependsOn(testTask)
+        }
     }
-}
-
-tasks.named('fullFunctionalTest') {
-    systemProperty('full.coverage', 'true')
-}
-
-tasks.named('configCacheFunctionalTest') {
-    systemProperty('config.cache', 'true')
-}
-
-tasks.named('check') {
-    // Run the functional tests as part of `check`
-    dependsOn(tasks.fullFunctionalTest)
 }
 
 tasks.withType(Test).configureEach {

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/DeprecatedExtensionFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/DeprecatedExtensionFunctionalTest.groovy
@@ -74,8 +74,6 @@ class DeprecatedExtensionFunctionalTest extends AbstractFunctionalTest {
     }
 
     def "calling the deprecated nativeBuild task triggers a warning and execution of the native image task"() {
-        gradleVersion = version
-
         given:
         withSample("java-application")
 
@@ -90,8 +88,5 @@ class DeprecatedExtensionFunctionalTest extends AbstractFunctionalTest {
 
         and:
         outputContains 'Task nativeBuild is deprecated. Use nativeCompile instead.'
-
-        where:
-        version << TESTED_GRADLE_VERSIONS
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -48,7 +48,6 @@ import spock.lang.Requires
 
 class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
     def "can build a native image for a simple application"() {
-        gradleVersion = version
         def nativeApp = file("build/native/nativeCompile/java-application")
         debug = true
 
@@ -79,13 +78,10 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         then:
         process.output.contains "Hello, native!"
 
-        where:
-        version << TESTED_GRADLE_VERSIONS
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/129")
     def "can build a native image with dependencies only needed by native image"() {
-        gradleVersion = version
         def nativeApp = file("build/native/nativeCompile/java-application")
 
         given:
@@ -112,8 +108,6 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         then:
         process.output.contains "Hello, native!"
 
-        where:
-        version << TESTED_GRADLE_VERSIONS
     }
 
     @Requires({
@@ -121,7 +115,6 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         graalvmHome != null
     })
     def "can override toolchain selection"() {
-        gradleVersion = version
         def nativeApp = file("build/native/nativeCompile/java-application")
         boolean dummyToolchain = GradleVersion.version(gradleVersion).compareTo(GradleVersion.version("7.0")) >= 0
 
@@ -160,8 +153,6 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         then:
         process.output.contains "Hello, native!"
 
-        where:
-        version << TESTED_GRADLE_VERSIONS
     }
 
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -47,9 +47,8 @@ import spock.lang.Unroll
 
 class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
 
-    @Unroll("agent is passed and generates resources files on Gradle #version with JUnit Platform #junitVersion")
+    @Unroll("agent is passed and generates resources files with JUnit Platform #junitVersion")
     def "agent is passed"() {
-        gradleVersion = version
         debug = true
         given:
         withSample("java-application-with-reflection")
@@ -87,14 +86,11 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         }
 
         where:
-        version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
 
-    @Unroll("agent property takes precedence on Gradle #version with JUnit Platform #junitVersion")
+    @Unroll("agent property takes precedence with JUnit Platform #junitVersion")
     def "agent property takes precedence"() {
-        gradleVersion = version
-
         given:
         withSample("java-application-with-reflection")
 
@@ -105,14 +101,12 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         outputContains """org.graalvm.demo.ApplicationTest > message is hello native FAILED"""
 
         where:
-        version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/134")
-    @Unroll("generated agent files are added when building native image on Gradle #version with JUnit Platform #junitVersion")
+    @Unroll("generated agent files are added when building native image with JUnit Platform #junitVersion")
     def "generated agent files are used when building native image"() {
-        gradleVersion = version
         debug = true
         given:
         withSample("java-application-with-reflection")
@@ -138,12 +132,10 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         outputContains "Application message: Hello, native!"
 
         where:
-        version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
 
     def "can configure extra options to the agent"() {
-        gradleVersion = version
         debug = true
         given:
         withSample("java-application-with-reflection")
@@ -155,12 +147,10 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         errorOutputContains "native-image-agent: unknown option: 'will-fail'."
 
         where:
-        version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
 
     def "reasonable error message if the user provides themselves an output directory"() {
-        gradleVersion = version
         debug = true
         given:
         withSample("java-application-with-reflection")
@@ -172,12 +162,10 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         errorOutputContains "config-output-dir cannot be supplied as an agent option"
 
         where:
-        version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
 
     def "reasonable error message if the user provides themselves an output directory value"() {
-        gradleVersion = version
         debug = true
         given:
         withSample("java-application-with-reflection")
@@ -189,7 +177,6 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         errorOutputContains "config-output-dir cannot be supplied as an agent option"
 
         where:
-        version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -53,8 +53,8 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
 
         buildFile << config
         buildFile << """
-            nativeBuild {
-                verbose = true
+            graalvmNative {
+                binaries.all { verbose = true }
             }
         """
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -44,9 +44,8 @@ import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 import spock.lang.Unroll
 
 class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest {
-    @Unroll("can build an application which uses resources using #pattern on Gradle #version with JUnit Platform #junitVersion")
+    @Unroll("can build an application which uses resources using #pattern with JUnit Platform #junitVersion")
     def "can build an application which uses resources"() {
-        gradleVersion = version
         def nativeApp = file("build/native/nativeCompile/java-application")
         debug = true
         given:
@@ -90,8 +89,7 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest 
 
         where:
         junitVersion = System.getProperty('versions.junit')
-        [version, [pattern, config]] << [TESTED_GRADLE_VERSIONS,
-                                         [["explicit resource declaration", """
+        [pattern, config] << [["explicit resource declaration", """
 graalvmNative {
     binaries {
         main {
@@ -132,14 +130,12 @@ graalvmNative {
     }
 }
 """
-                                          ]]
-        ].combinations()
+                                          ]
+        ]
     }
 
-    @Unroll("can run native tests which uses resources using #pattern on Gradle #version with JUnit Platform #junitVersion")
+    @Unroll("can run native tests which uses resources using #pattern with JUnit Platform #junitVersion")
     def "can run native tests which uses resources"() {
-        gradleVersion = version
-
         given:
         withSample("java-application-with-resources")
 
@@ -169,8 +165,7 @@ graalvmNative {
 
         where:
         junitVersion = System.getProperty('versions.junit')
-        [version, [pattern, config]] << [TESTED_GRADLE_VERSIONS,
-                                         [["explicit resource declaration", """
+        [pattern, config] << [["explicit resource declaration", """
 graalvmNative {
     binaries {
         test {
@@ -196,12 +191,11 @@ graalvmNative {
     }
 }
 """
-                                          ]]
-        ].combinations()
+                                          ]
+        ]
     }
 
     def "scans resources of jar file even if it includes a native-image/resources-config.json file"() {
-        gradleVersion = version
         def nativeApp = file("build/native/nativeCompile/java-application")
         debug = true
         given:
@@ -266,6 +260,5 @@ graalvmNative {
 
         where:
         junitVersion = System.getProperty('versions.junit')
-        version << TESTED_GRADLE_VERSIONS
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
@@ -47,9 +47,8 @@ import spock.lang.Issue
 import spock.lang.Unroll
 
 class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
-    @Unroll("can execute tests in a native image on Gradle #version with JUnit Platform #junitVersion")
+    @Unroll("can execute tests in a native image with JUnit Platform #junitVersion")
     def "can build a native image and run it"() {
-        gradleVersion = version
         def nativeTestsApp = file("build/native/nativeTestCompile/java-application-tests")
 
         given:
@@ -89,14 +88,11 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
 """.trim()
 
         where:
-        version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
 
-    @Unroll("can execute tests in a native image directly on Gradle #version with JUnit Platform #junitVersion")
+    @Unroll("can execute tests in a native image directly with JUnit Platform #junitVersion")
     def "can execute tests in a native image directly"() {
-        gradleVersion = version
-
         given:
         withSample("java-application-with-tests")
 
@@ -144,15 +140,12 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         }
 
         where:
-        version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/133")
-    @Unroll("can disable test support on Gradle #version with JUnit Platform #junitVersion")
+    @Unroll("can disable test support with JUnit Platform #junitVersion")
     def "can disable test support"() {
-        gradleVersion = version
-
         given:
         withSample("java-application-with-tests")
 
@@ -173,15 +166,12 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         }
 
         where:
-        version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/77")
-    @Unroll("can register a custom test image on Gradle #version with JUnit Platform #junitVersion")
+    @Unroll("can register a custom test image with JUnit Platform #junitVersion")
     def "can register a custom test image"() {
-        gradleVersion = version
-
         given:
         withSample("java-application-with-custom-tests")
 
@@ -229,7 +219,6 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         }
 
         where:
-        version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaLibraryFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaLibraryFunctionalTest.groovy
@@ -46,8 +46,6 @@ import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 class JavaLibraryFunctionalTest extends AbstractFunctionalTest {
 
     def "can build a native image for a simple library"() {
-        gradleVersion = version
-
         def libExt = ""
         if (IS_LINUX) {
             libExt = ".so"
@@ -76,8 +74,5 @@ class JavaLibraryFunctionalTest extends AbstractFunctionalTest {
 
         and:
         library.exists()
-
-        where:
-        version << TESTED_GRADLE_VERSIONS
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/KotlinApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/KotlinApplicationWithTestsFunctionalTest.groovy
@@ -47,10 +47,8 @@ import spock.lang.Unroll
 
 class KotlinApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
 
-    @Unroll("can execute Kotlin tests in a native image directly on Gradle #version with JUnit Platform #junitVersion")
+    @Unroll("can execute Kotlin tests in a native image directly with JUnit Platform #junitVersion")
     def "can execute Kotlin tests in a native image directly"() {
-        gradleVersion = version
-
         given:
         withSample("kotlin-application-with-tests")
 
@@ -99,7 +97,6 @@ class KotlinApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         }
 
         where:
-        version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/MultiProjectJavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/MultiProjectJavaApplicationWithTestsFunctionalTest.groovy
@@ -45,10 +45,8 @@ import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 import spock.lang.Unroll
 
 class MultiProjectJavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
-    @Unroll("transitive dependencies are included when testing on Gradle #version with JUnit Platform #junitVersion")
+    @Unroll("transitive dependencies are included when testing with JUnit Platform #junitVersion")
     def "transitive dependencies are included when testing"() {
-        gradleVersion = version
-
         given:
         withSample("multi-project-with-tests")
 
@@ -81,7 +79,6 @@ class MultiProjectJavaApplicationWithTestsFunctionalTest extends AbstractFunctio
 """.trim()
 
         where:
-        version << TESTED_GRADLE_VERSIONS
         junitVersion = System.getProperty('versions.junit')
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/ResourceDetectionOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/ResourceDetectionOptions.java
@@ -64,6 +64,17 @@ public abstract class ResourceDetectionOptions {
     public abstract Property<Boolean> getRestrictToProjectDependencies();
 
     /**
+     * If set to true, then if a classpath entry contains a META-INF/native-image
+     * resources file, then we would still try to detect resources contained in
+     * that classpath entry (e.g jar). By default, this behavior is set to false,
+     * meaning that if such a file is present, detection is disabled for this
+     * particular classpath entry.
+     * @return the ignore property
+     */
+    @Input
+    public abstract Property<Boolean> getIgnoreExistingResourcesConfigFile();
+
+    /**
      * Returns the list of regular expressions which will be used to exclude
      * resources from detection.
      */
@@ -84,6 +95,7 @@ public abstract class ResourceDetectionOptions {
     public ResourceDetectionOptions() {
         getEnabled().convention(false);
         getRestrictToProjectDependencies().convention(true);
+        getIgnoreExistingResourcesConfigFile().convention(false);
         getDetectionExclusionPatterns().convention(SharedConstants.DEFAULT_EXCLUDES_FOR_RESOURCE_DETECTION);
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/GenerateResourcesConfigFile.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/GenerateResourcesConfigFile.java
@@ -114,7 +114,7 @@ public abstract class GenerateResourcesConfigFile extends DefaultTask {
             }
             // todo: ideally we should try to find a way for Gradle to cache the analysis per jar
             // which should be doable via artifact transforms instead
-            detectResourcesFromClasspathEntry(filter, detectedResources, file);
+            detectResourcesFromClasspathEntry(filter, detectedResources, file, detectionOptions.getIgnoreExistingResourcesConfigFile().get());
         }
         if (!detectedResources.isEmpty()) {
             output.addAll(
@@ -131,8 +131,11 @@ public abstract class GenerateResourcesConfigFile extends DefaultTask {
      * If it's a directory, we will walk the directory and collect resources found in
      * the directory. If it's a jar we do the same but with jar entries instead.
      */
-    private void detectResourcesFromClasspathEntry(ResourceFilter filter, Set<String> detectedResources, File file) throws IOException {
-        ClassPathEntryAnalyzer analyzer = ClassPathEntryAnalyzer.of(file, filter::shouldIncludeResource);
+    private void detectResourcesFromClasspathEntry(ResourceFilter filter,
+                                                   Set<String> detectedResources,
+                                                   File file,
+                                                   boolean ignoreExistingResourcesConfig) throws IOException {
+        ClassPathEntryAnalyzer analyzer = ClassPathEntryAnalyzer.of(file, filter::shouldIncludeResource, ignoreExistingResourcesConfig);
         List<String> resources = analyzer.getResources();
         GraalVMLogger.of(getLogger()).log("Detected resources for {} are {}", file, resources);
         detectedResources.addAll(resources);

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -52,23 +52,10 @@ import spock.lang.TempDir
 import java.nio.file.Path
 
 abstract class AbstractFunctionalTest extends Specification {
-    private static final Set<String> MINIMAL_COVERAGE = [
-            GradleVersion.current().version // Only current Gradle version
-    ]
-    private static final Set<String> FULL_COVERAGE = MINIMAL_COVERAGE + [
-            '7.2',
-            '7.1',
-            '6.8.3',
-            '6.7.1'
-    ]
-    static final List<String> TESTED_GRADLE_VERSIONS =
-            (Boolean.getBoolean('full.coverage') ?
-                    FULL_COVERAGE : MINIMAL_COVERAGE) as List<String>
-
     @TempDir
     Path testDirectory
 
-    String gradleVersion
+    String gradleVersion = testGradleVersion()
     boolean debug
 
     boolean IS_WINDOWS = System.getProperty("os.name", "unknown").contains("Windows");
@@ -82,6 +69,14 @@ abstract class AbstractFunctionalTest extends Specification {
     private File initScript
 
     BuildResult result
+
+    private static String testGradleVersion() {
+        String version = System.getProperty("gradle.test.version", GradleVersion.current().version)
+        if ("current" == version) {
+            version = GradleVersion.current().version
+        }
+        version
+    }
 
     Path path(String... pathElements) {
         Path cur = testDirectory

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractResourceConfigMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractResourceConfigMojo.java
@@ -104,6 +104,9 @@ public abstract class AbstractResourceConfigMojo extends AbstractMojo {
     @Parameter(property = "resources.autodetection.detectionExclusionPatterns")
     private List<String> detectionExclusionPatterns;
 
+    @Parameter(property = "resources.autodetection.ignoreExistingResourcesConfig", defaultValue = "false")
+    private boolean ignoreExistingResourcesConfig;
+
     @Override
     public void execute() throws MojoExecutionException {
         Set<PatternValue> includes = asPatternValues(resourceIncludedPatterns);
@@ -197,7 +200,7 @@ public abstract class AbstractResourceConfigMojo extends AbstractMojo {
      * the directory. If it's a jar we do the same but with jar entries instead.
      */
     private void detectResourcesFromClasspathEntry(ResourceFilter filter, Set<String> detectedResources, File file) throws IOException {
-        ClassPathEntryAnalyzer analyzer = ClassPathEntryAnalyzer.of(file, filter::shouldIncludeResource);
+        ClassPathEntryAnalyzer analyzer = ClassPathEntryAnalyzer.of(file, filter::shouldIncludeResource, ignoreExistingResourcesConfig);
         List<String> resources = analyzer.getResources();
         getLog().info(String.format("Detected resources for %s are %s", file, resources));
         detectedResources.addAll(resources);


### PR DESCRIPTION
Previously to this commit, resources autodetection was disabled if a
classpath entry (directory or jar file) contained a `META-INF/native-image/xxx/resource-config.json`
file. This was done assuming that if that file was present, then it
_should_ contain all the appropriate entries already. However, this
is not the case in Micronaut where an annotation processor is
generating such a file, but doesn't include _all_ the resources of the
application.

As a workaround, it's now possible to ask the scanner to detect
resources even if that file is present.

See https://github.com/micronaut-projects/micronaut-gradle-plugin/issues/327