### PR TITLE
Do not fail if a classpath entry is missing

### DIFF
--- a/common/utils/build.gradle.kts
+++ b/common/utils/build.gradle.kts
@@ -52,6 +52,12 @@ maven {
 
 dependencies {
     implementation(libs.jackson.databind)
+    implementation(platform(libs.test.junit.bom))
+    implementation(libs.test.junit.jupiter.core)
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }
 
 val generateVersionInfo = tasks.register("generateVersionInfo", org.graalvm.build.GenerateVersionClass::class.java) {

--- a/common/utils/src/main/java/org/graalvm/buildtools/model/resources/ClassPathDirectoryAnalyzer.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/model/resources/ClassPathDirectoryAnalyzer.java
@@ -64,9 +64,14 @@ class ClassPathDirectoryAnalyzer extends ClassPathEntryAnalyzer {
     }
 
     protected List<String> initialize() throws IOException {
-        DirectoryVisitor visitor = new DirectoryVisitor();
-        Files.walkFileTree(root, visitor);
-        return visitor.hasNativeImageResourceFile && !ignoreExistingResourcesConfig ? Collections.emptyList() : visitor.resources;
+        if (Files.exists(root)) {
+            DirectoryVisitor visitor = new DirectoryVisitor();
+            Files.walkFileTree(root, visitor);
+            return visitor.hasNativeImageResourceFile && !ignoreExistingResourcesConfig ? Collections.emptyList() : visitor.resources;
+        }
+        else {
+            return Collections.emptyList();
+        }
     }
 
     private class DirectoryVisitor extends SimpleFileVisitor<Path> {


### PR DESCRIPTION
The resource detection mechanism should be lenient with regards to
entries which might be missing from the classpath. For example, in
case of an empty `src/test/resources` directory, the Gradle test
process resources task would not create a `build/test/resources`
directory, which causes a failure.

Fixes #175