### PR TITLE
Fix resource inference not working on custom binaries

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -15,6 +15,12 @@ If you are interested in contributing, please refer to our https://github.com/gr
 [[changelog]]
 == Changelog
 
+=== Release 0.9.9
+
+==== Gradle plugin
+
+* Fixed resource inference not working on custom binaries
+
 === Release 0.9.8
 
 ==== Gradle plugin


### PR DESCRIPTION
Before this commit, resource inference was only wired for the main
and test binaries. Now each custom binary will have a proper native
inference task associated with it.

This bug was discovered during the Micronaut AOT work, where resources
were missing from the optimized AOT binary.