### PR TITLE
Rework how disabling of toolchain detection works

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -20,7 +20,7 @@ If you are interested in contributing, please refer to our https://github.com/gr
 ==== Gradle plugin
 
 * Fixed resource inference not working on custom binaries
-* Fixed `disableToolchainDetection` not working if a GraalVM installation isn't present. Please use `graalvmNative.disableToolchainDetection()` instead.
+* Fixed `disableToolchainDetection` not working if a GraalVM installation isn't present. Please use `graalvmNative.toolchainDetection.set(false)` instead.
 
 === Release 0.9.8
 

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -20,6 +20,7 @@ If you are interested in contributing, please refer to our https://github.com/gr
 ==== Gradle plugin
 
 * Fixed resource inference not working on custom binaries
+* Fixed `disableToolchainDetection` not working if a GraalVM installation isn't present. Please use `graalvmNative.disableToolchainDetection()` instead.
 
 === Release 0.9.8
 

--- a/docs/src/docs/snippets/gradle/groovy/build.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/build.gradle
@@ -59,8 +59,8 @@ graalvmNative {
 
 if (providers.environmentVariable("DISABLE_TOOLCHAIN").isPresent()) {
 // tag::disabling-toolchain[]
-    tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
-        disableToolchainDetection = true
+    graalvmNative {
+        disableToolchainDetection()
     }
 // end::disabling-toolchain[]
 }

--- a/docs/src/docs/snippets/gradle/groovy/build.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/build.gradle
@@ -60,7 +60,7 @@ graalvmNative {
 if (providers.environmentVariable("DISABLE_TOOLCHAIN").isPresent()) {
 // tag::disabling-toolchain[]
     graalvmNative {
-        disableToolchainDetection()
+        toolchainDetection = false
     }
 // end::disabling-toolchain[]
 }

--- a/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
+++ b/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
@@ -61,7 +61,7 @@ graalvmNative {
 if (providers.environmentVariable("DISABLE_TOOLCHAIN").isPresent()) {
 // tag::disabling-toolchain[]
     graalvmNative {
-        disableToolchainDetection()
+        toolchainDetection.set(false)
     }
 // end::disabling-toolchain[]
 }

--- a/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
+++ b/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
@@ -60,8 +60,8 @@ graalvmNative {
 
 if (providers.environmentVariable("DISABLE_TOOLCHAIN").isPresent()) {
 // tag::disabling-toolchain[]
-    tasks.withType<org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask>().configureEach {
-        disableToolchainDetection.set(true)
+    graalvmNative {
+        disableToolchainDetection()
     }
 // end::disabling-toolchain[]
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
@@ -85,16 +85,11 @@ public interface GraalVMExtension {
     void registerTestBinary(String name, Action<? super TestBinaryConfig> spec);
 
     /**
-     * Enables detection of toolchains which support building native images.
-     * This is the default unless {@link #disableToolchainDetection()} was called.
+     * Property driving the detection of toolchains which support building native images.
+     * The default is true.
      */
-    void enableToolchainDetection();
+    Property<Boolean> getToolchainDetection();
 
-    /**
-     * Disables detection of toolchains, which is useful when the default detection
-     * mechanism isn't capable of handling your toolchain.
-     */
-    void disableToolchainDetection();
 
     interface TestBinaryConfig {
         /**

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
@@ -84,6 +84,18 @@ public interface GraalVMExtension {
      */
     void registerTestBinary(String name, Action<? super TestBinaryConfig> spec);
 
+    /**
+     * Enables detection of toolchains which support building native images.
+     * This is the default unless {@link #disableToolchainDetection()} was called.
+     */
+    void enableToolchainDetection();
+
+    /**
+     * Disables detection of toolchains, which is useful when the default detection
+     * mechanism isn't capable of handling your toolchain.
+     */
+    void disableToolchainDetection();
+
     interface TestBinaryConfig {
         /**
          * Sets the JVM test task which corresponds to the

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -45,7 +45,6 @@ import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.dsl.NativeResourcesOptions;
 import org.graalvm.buildtools.utils.SharedConstants;
 import org.gradle.api.Action;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
@@ -60,10 +59,8 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskContainer;
-import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
-import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 import javax.inject.Inject;
 import java.util.Arrays;
@@ -185,6 +182,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
      * to a Java launcher due to Gradle limitations.
      */
     @Nested
+    @Optional
     public abstract Property<JavaLauncher> getJavaLauncher();
 
     /**
@@ -218,14 +216,6 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         getSharedLibrary().convention(false);
         getImageName().convention(defaultImageName);
         getUseFatJar().convention(SharedConstants.IS_WINDOWS);
-        getJavaLauncher().convention(
-                toolchains.launcherFor(spec -> {
-                    spec.getLanguageVersion().set(JavaLanguageVersion.of(JavaVersion.current().getMajorVersion()));
-                    if (GradleUtils.isAtLeastGradle7()) {
-                        spec.getVendor().set(JvmVendorSpec.matching("GraalVM"));
-                    }
-                })
-        );
     }
 
     private static Provider<Boolean> property(ProviderFactory providers, String name) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -70,12 +70,11 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
     @Inject
     public DefaultGraalVmExtension(NamedDomainObjectContainer<NativeImageOptions> nativeImages,
                                    NativeImagePlugin plugin,
-                                   Project project,
-                                   JavaToolchainService toolchains) {
+                                   Project project) {
         this.nativeImages = nativeImages;
         this.plugin = plugin;
         this.project = project;
-        this.toolchainService = toolchains;
+        this.toolchainService = project.getExtensions().getByType(JavaToolchainService.class);
         this.defaultJavaLauncher = project.getObjects().property(JavaLauncher.class);
         enableToolchainDetection();
         nativeImages.configureEach(options -> options.getJavaLauncher().convention(defaultJavaLauncher));

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -163,7 +163,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
             logger.lifecycle("Args are: " + args);
         }
         File executablePath = null;
-        if (getDisableToolchainDetection().get()) {
+        if (getDisableToolchainDetection().get() || !options.getJavaLauncher().isPresent()) {
             if (getGraalVMHome().isPresent()) {
                 String graalvmHome = getGraalVMHome().get();
                 getLogger().lifecycle("Toolchain detection is disabled, will use GraalVM from {}.", graalvmHome);


### PR DESCRIPTION
Disabling the toolchain detection by tasks wasn't sufficient,
because Gradle would use the nested `BaseImageOptions` as an input,
and even if the particular `JavaLauchner` input wasn't used if that
flag was disabled, it would still be used internally by Gradle to
snapshot inputs.

As a consequence, the fix only worked if Gradle actually detected
a GraalVM installation somewhere, even if it didn't use it!

To fix this, this commit introduces a top-level DSL method called
`disableToolchainDetection()` which effectively sets the toolchain
to `null` by convention. By making the toolchain optional and null
now Gradle wouldn't complain anymore.

Fixes #183