### PR TITLE
Make it possible to use environment variables in native tests

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -14,6 +14,16 @@ If you are interested in contributing, please refer to our https://github.com/gr
 
 [[changelog]]
 == Changelog
+=== Release 0.9.11
+
+==== Maven plugin
+
+* Fix long classpath issue under Windows when running native tests
+* Inherit environment variables and system properties from the surefire plugin configuration when executing tests
+
+==== Gradle plugin
+
+* Add support for environment variables in native test execution
 
 === Release 0.9.10
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/NativeRunTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/NativeRunTask.java
@@ -45,12 +45,15 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.plugins.ApplicationPlugin;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 
 import javax.inject.Inject;
+import java.util.Map;
 
 @SuppressWarnings("unused")
 public abstract class NativeRunTask extends DefaultTask {
@@ -61,6 +64,10 @@ public abstract class NativeRunTask extends DefaultTask {
 
     @Input
     public abstract ListProperty<String> getRuntimeArgs();
+
+    @Input
+    @Optional
+    public abstract MapProperty<String, String> getEnvironment();
 
     @Inject
     protected abstract ExecOperations getExecOperations();
@@ -76,6 +83,12 @@ public abstract class NativeRunTask extends DefaultTask {
         getExecOperations().exec(spec -> {
             spec.setExecutable(getImage().get().getAsFile().getAbsolutePath());
             spec.args(getRuntimeArgs().get());
+            if (getEnvironment().isPresent()) {
+                Map<String, String> env = (Map<String, String>) getEnvironment().get();
+                for (Map.Entry<String, String> entry : env.entrySet()) {
+                    spec.environment(entry.getKey(), entry.getValue());
+                }
+            }
         });
     }
 }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
@@ -123,4 +123,21 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractGraalVMMavenFunctio
         outputDoesNotContain "containers found"
     }
 
+    @Issue("https://github.com/graalvm/native-build-tools/issues/215")
+    def "can pass environment variables to native test execution"() {
+        given:
+        withSample("java-application-with-tests")
+
+        when:
+        mvn '-Pnative', '-Ptest-variables', 'test'
+
+        then:
+        buildSucceeded
+        outputContains "[junit-platform-native] Running in 'test listener' mode"
+        def nativeImageExecResult = after("JUnit Platform on Native Image - report")
+        nativeImageExecResult.contains "TEST_ENV = test-value"
+        nativeImageExecResult.contains "test-property = test-value"
+
+    }
+
 }

--- a/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/AbstractGraalVMMavenFunctionalTest.groovy
+++ b/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/AbstractGraalVMMavenFunctionalTest.groovy
@@ -134,6 +134,11 @@ abstract class AbstractGraalVMMavenFunctionalTest extends Specification {
         normalizeString(result.stdOut).contains(normalizeString(text))
     }
 
+    String after(String text) {
+        def out = normalizeString(result.stdOut)
+        out.substring(out.indexOf(normalizeString(text)))
+    }
+
     boolean outputDoesNotContain(String text) {
         !normalizeString(result.stdOut).contains(normalizeString(text))
     }

--- a/samples/java-application-with-tests/pom.xml
+++ b/samples/java-application-with-tests/pom.xml
@@ -83,7 +83,7 @@
                         <artifactId>native-maven-plugin</artifactId>
                         <version>${native.maven.plugin.version}</version>
                         <extensions>true</extensions>
-                    <!-- end::native-plugin-extensions[] -->
+                        <!-- end::native-plugin-extensions[] -->
                         <executions>
                             <execution>
                                 <id>test-native</id>
@@ -213,6 +213,26 @@
                         </configuration>
                     </plugin>
                     <!-- end::native-plugin[] -->
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-variables</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                        <configuration>
+                            <environmentVariables>
+                                <TEST_ENV>test-value</TEST_ENV>
+                            </environmentVariables>
+                            <systemPropertyVariables>
+                                <test-property>test-value</test-property>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/samples/java-application-with-tests/src/main/java/org/graalvm/demo/Calculator.java
+++ b/samples/java-application-with-tests/src/main/java/org/graalvm/demo/Calculator.java
@@ -2,6 +2,15 @@ package org.graalvm.demo;
 
 public class Calculator {
 
+    public Calculator() {
+        if (System.getenv("TEST_ENV") != null) {
+            System.out.println("TEST_ENV = " + System.getenv("TEST_ENV"));
+        }
+        if (System.getProperty("test-property") != null) {
+            System.out.println("test-property = " + System.getProperty("test-property"));
+        }
+    }
+
     public int add(int a, int b) {
         return a + b;
     }


### PR DESCRIPTION
Prior to this commit, it wasn't possible to expose environment variables
(both Maven and Gradle) or system properties (Maven) to the native test
execution. This commit makes it possible to use both.

For Gradle, tests can be configured to use environment variables by
using `tasks.named("nativeTest") { environment.put(...) }`.
For Maven, environment variables and system properties are inherted
from the surefire mojo.

It's worth noting that the executable generated by native-image does
not support @arg files itself. This means that if there are too many
system properties, Windows users could have difficulties running
native tests (because of long CLI issues).

Fixes #215
Fixes #196