### PR TITLE
Rename `metadataRepository` and document feature

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -335,6 +335,85 @@ include::../snippets/gradle/groovy/build.gradle[tags=add-agent-options-individua
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=add-agent-options-individual]
 ----
 
+[[metadata-support]]
+== JVM Reachability Metadata support
+
+Since release 0.9.11, the plugin adds experimental support for the https://github.com/graalvm/jvm-reachability-metadata/[JVM reachability metadata repository].
+This repository provides GraalVM configuration for libraries which do not officially support GraalVM native.
+
+=== Enabling the metadata repository
+
+Support needs to be enabled explicitly:
+
+.Enabling the metadata repository
+[source, groovy, role="multi-language-sample"]
+----
+include::../snippets/gradle/groovy/build.gradle[tags=enable-metadata-repository]
+----
+
+[source, kotlin, role="multi-language-sample"]
+----
+include::../snippets/gradle/kotlin/build.gradle.kts[tags=enable-metadata-repository]
+----
+
+A metadata repository consists of configuration files for GraalVM.
+The plugin will automatically download the configuration metadata from the official repository if you supply the version of the repository you want to use:
+
+.Enabling the metadata repository
+[source, groovy, role="multi-language-sample"]
+----
+include::../snippets/gradle/groovy/build.gradle[tags=specify-metadata-repository-version]
+----
+
+[source, kotlin, role="multi-language-sample"]
+----
+include::../snippets/gradle/kotlin/build.gradle.kts[tags=specify-metadata-repository-version]
+----
+
+Alternatively, it is possible to use a _local repository_, in which case you can specify the path to the repository:
+
+.Using a local repository
+[source, groovy, role="multi-language-sample"]
+----
+include::../snippets/gradle/groovy/build.gradle[tags=specify-metadata-repository-file]
+----
+
+[source, kotlin, role="multi-language-sample"]
+----
+include::../snippets/gradle/kotlin/build.gradle.kts[tags=specify-metadata-repository-file]
+----
+
+=== Configuring the metadata repository
+
+Once activated, for each library included in the native image, the plugin will automatically search for GraalVM JVM reachability metadata in the repository.
+In some cases, you may need to exclude a particular module from the search.
+This can be done by adding it to the exclude list:
+
+.Excluding a module from search
+[source, groovy, role="multi-language-sample"]
+----
+include::../snippets/gradle/groovy/build.gradle[tags=exclude-module-from-metadata-repo]
+----
+
+[source, kotlin, role="multi-language-sample"]
+----
+include::../snippets/gradle/kotlin/build.gradle.kts[tags=exclude-module-from-metadata-repo]
+----
+
+Last, it is possible for you to override the _metadata version_ of a particular module.
+This may be interesting if there's no specific metadata available for the particular version of the library that you use, but that you know that a version works:
+
+.Specifying the metadata version to use for a particular library
+[source, groovy, role="multi-language-sample"]
+----
+include::../snippets/gradle/groovy/build.gradle[tags=specify-metadata-version-for-library]
+----
+
+[source, kotlin, role="multi-language-sample"]
+----
+include::../snippets/gradle/kotlin/build.gradle.kts[tags=specify-metadata-version-for-library]
+----
+
 [[plugin-configurations]]
 == Configurations defined by the plugin
 

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -20,10 +20,13 @@ If you are interested in contributing, please refer to our https://github.com/gr
 
 * Fix long classpath issue under Windows when running native tests
 * Inherit environment variables and system properties from the surefire plugin configuration when executing tests
+* Fix invocation of `native-image` when classpath contains spaces
 
 ==== Gradle plugin
 
 * Add support for environment variables in native test execution
+* Fix invocation of `native-image` when classpath contains spaces
+* Add experimental support for the JVM reachability metadata repository
 
 === Release 0.9.10
 

--- a/docs/src/docs/snippets/gradle/groovy/build.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/build.gradle
@@ -149,3 +149,46 @@ graalvmNative {
     }
 }
 // end::add-agent-options-individual[]
+
+// tag::enable-metadata-repository[]
+graalvmNative {
+    metadataRepository {
+        enabled = true
+    }
+}
+// end::enable-metadata-repository[]
+
+// tag::specify-metadata-repository-version[]
+graalvmNative {
+    metadataRepository {
+        version = "1.0.0"
+    }
+}
+// end::specify-metadata-repository-version[]
+
+// tag::specify-metadata-repository-file[]
+graalvmNative {
+    metadataRepository {
+        uri(file("metadata-repository"))
+    }
+}
+// end::specify-metadata-repository-file[]
+
+// tag::exclude-module-from-metadata-repo[]
+graalvmNative {
+    metadataRepository {
+        // Exclude this library from automatic metadata
+        // repository search
+        excludes.add("com.company:some-library")
+    }
+}
+// end::exclude-module-from-metadata-repo[]
+
+// tag::specify-metadata-version-for-library[]
+graalvmNative {
+    metadataRepository {
+        // Force the version of the metadata for a particular library
+        moduleToConfigVersion.put("com.company:some-library", "3")
+    }
+}
+// end::specify-metadata-version-for-library[]

--- a/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
+++ b/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
@@ -162,3 +162,47 @@ graalvmNative {
     }
 }
 // end::add-agent-options-individual[]
+
+// tag::enable-metadata-repository[]
+graalvmNative {
+    metadataRepository {
+        enabled.set(true)
+    }
+}
+// end::enable-metadata-repository[]
+
+// tag::specify-metadata-repository-version[]
+graalvmNative {
+    metadataRepository {
+        version.set("1.0.0")
+    }
+}
+// end::specify-metadata-repository-version[]
+
+
+// tag::specify-metadata-repository-file[]
+graalvmNative {
+    metadataRepository {
+        uri(file("metadata-repository"))
+    }
+}
+// end::specify-metadata-repository-file[]
+
+// tag::exclude-module-from-metadata-repo[]
+graalvmNative {
+    metadataRepository {
+        // Exclude this library from automatic metadata
+        // repository search
+        excludes.add("com.company:some-library")
+    }
+}
+// end::exclude-module-from-metadata-repo[]
+
+// tag::specify-metadata-version-for-library[]
+graalvmNative {
+    metadataRepository {
+        // Force the version of the metadata for a particular library
+        moduleToConfigVersion.put("com.company:some-library", "3")
+    }
+}
+// end::specify-metadata-version-for-library[]

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
@@ -94,7 +94,7 @@ class NativeConfigRepoFunctionalTest extends AbstractFunctionalTest {
 
         buildFile << """
 graalvmNative {
-    jvmReachabilityMetadataRepository {
+    metadataRepository {
         excludedModules.add("org.graalvm.internal:library-with-reflection")
     }
 }
@@ -121,7 +121,7 @@ graalvmNative {
 
         buildFile << """
 graalvmNative {
-    jvmReachabilityMetadataRepository {
+    metadataRepository {
         moduleToConfigVersion.put("org.graalvm.internal:library-with-reflection", "2")
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -406,7 +406,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     }
 
     private void configureNativeConfigurationRepo(ExtensionAware graalvmNative) {
-        JvmReachabilityMetadataRepositoryExtension configurationRepository = graalvmNative.getExtensions().create("jvmReachabilityMetadataRepository", JvmReachabilityMetadataRepositoryExtension.class);
+        JvmReachabilityMetadataRepositoryExtension configurationRepository = graalvmNative.getExtensions().create("metadataRepository", JvmReachabilityMetadataRepositoryExtension.class);
         configurationRepository.getEnabled().convention(false);
         configurationRepository.getUri().convention(configurationRepository.getVersion().map(v -> {
             try {

--- a/samples/native-config-integration/build.gradle
+++ b/samples/native-config-integration/build.gradle
@@ -68,7 +68,7 @@ tasks.withType(Test).configureEach {
 }
 
 graalvmNative {
-    jvmReachabilityMetadataRepository {
+    metadataRepository {
         enabled = true
         def extension = System.getProperty("extension", '')
         def repo = file("config-directory${extension ? '.' + extension : ''}")


### PR DESCRIPTION
This commit renames `jvmReachabilityMetadataRepository` to `metadataRepository`
in the DSL. It also adds minimal documentation for this feature.