### PR TITLE
Support applications with custom packaging types

### DIFF
--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
@@ -82,4 +82,16 @@ class JavaApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
         argFile << [true, false]
     }
 
+    def "can build and execute a native image with the Maven plugin when the application has a custom packaging type"() {
+        withSample("java-application-with-custom-packaging")
+
+        when:
+        mvn 'package', '-Dpackaging=native-image', 'exec:exec@native'
+
+        then:
+        buildSucceeded
+        outputContains "ImageClasspath Entry: org.graalvm.buildtools.examples:java-application-with-custom-packaging:native-image:0.1"
+        outputContains "Hello, native!"
+    }
+
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildMojo.java
@@ -123,7 +123,7 @@ public class NativeBuildMojo extends AbstractNativeMojo {
             for (Artifact dependency : project.getArtifacts()) {
                 addClasspath(dependency);
             }
-            addClasspath(project.getArtifact());
+            addClasspath(project.getArtifact(), project.getPackaging());
         }
         String classpathStr = imageClasspath.stream().map(Path::toString).collect(Collectors.joining(File.pathSeparator));
 
@@ -156,7 +156,11 @@ public class NativeBuildMojo extends AbstractNativeMojo {
     }
 
     private void addClasspath(Artifact artifact) throws MojoExecutionException {
-        if (!"jar".equals(artifact.getType())) {
+        addClasspath(artifact, "jar");
+    }
+
+    private void addClasspath(Artifact artifact, String artifactType) throws MojoExecutionException {
+        if (!artifactType.equals(artifact.getType())) {
             getLog().warn("Ignoring non-jar type ImageClasspath Entry " + artifact);
             return;
         }

--- a/samples/java-application-with-custom-packaging/pom.xml
+++ b/samples/java-application-with-custom-packaging/pom.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    The Universal Permissive License (UPL), Version 1.0
+
+    Subject to the condition set forth below, permission is hereby granted to any
+    person obtaining a copy of this software, associated documentation and/or
+    data (collectively the "Software"), free of charge and under any and all
+    copyright rights in the Software, and any and all patent rights owned or
+    freely licensable by each licensor hereunder covering either (i) the
+    unmodified Software as contributed to or provided by such licensor, or (ii)
+    the Larger Works (as defined below), to deal in both
+
+    (a) the Software, and
+
+    (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+    one is included with the Software each a "Larger Work" to which the Software
+    is contributed by such licensors),
+
+    without restriction, including without limitation the rights to copy, create
+    derivative works of, display, perform, and distribute the Software and make,
+    use, sell, offer for sale, import, export, have made, and have sold the
+    Software and the Larger Work(s), and to sublicense the foregoing rights on
+    either these or other terms.
+
+    This license is subject to the following condition:
+
+    The above copyright notice and either this complete permission notice or at a
+    minimum a reference to the UPL must be included in all copies or substantial
+    portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.graalvm.buildtools.examples</groupId>
+    <artifactId>java-application-with-custom-packaging</artifactId>
+    <version>0.1</version>
+    <packaging>${packaging}</packaging>
+
+    <parent>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-parent</artifactId>
+        <version>3.3.4</version>
+    </parent>
+
+    <properties>
+        <packaging>jar</packaging>
+        <jdk.version>11</jdk.version>
+        <release.version>11</release.version>
+        <micronaut.version>3.3.4</micronaut.version>
+        <exec.mainClass>org.graalvm.demo.Application</exec.mainClass>
+        <micronaut.runtime>netty</micronaut.runtime>
+        <maven.native.plugin.version>0.9.11-SNAPSHOT</maven.native.plugin.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-inject</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-validation</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-http-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.test</groupId>
+            <artifactId>micronaut-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-jackson-databind</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-runtime</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.picocli</groupId>
+            <artifactId>micronaut-picocli</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.micronaut.build</groupId>
+                <artifactId>micronaut-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- Uncomment to enable incremental compilation -->
+                    <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+
+                    <annotationProcessorPaths combine.children="append">
+                        <path>
+                            <groupId>info.picocli</groupId>
+                            <artifactId>picocli-codegen</artifactId>
+                            <version>${picocli.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-Amicronaut.processing.group=org.graalvm.demo</arg>
+                        <arg>-Amicronaut.processing.module=demo</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/samples/java-application-with-custom-packaging/src/main/java/org/graalvm/demo/Application.java
+++ b/samples/java-application-with-custom-packaging/src/main/java/org/graalvm/demo/Application.java
@@ -1,0 +1,16 @@
+package org.graalvm.demo;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import picocli.CommandLine.Command;
+
+@Command(name = "demo", description = "...", mixinStandardHelpOptions = true)
+public class Application implements Runnable {
+
+    public static void main(String[] args) {
+        PicocliRunner.run(Application.class, args);
+    }
+
+    public void run() {
+        System.out.println("Hello, native!");
+    }
+}

--- a/samples/java-application-with-custom-packaging/src/main/resources/application.yml
+++ b/samples/java-application-with-custom-packaging/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+micronaut:
+  application:
+    name: java-application-with-custom-packaging

--- a/samples/java-application-with-custom-packaging/src/main/resources/logback.xml
+++ b/samples/java-application-with-custom-packaging/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <withJansi>true</withJansi>
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
If an application has a custom packaging type, but its artefact is really a JAR file,
I will be skipped by the classpath calculation algorithm.

This PR allows the main project artifact to have a different packaging type, which is
the case of Micronaut applications packaged as native images (`<packaging>native-image</packaging>`).