### PR TITLE
Warn about deprecated agent DSL

### DIFF
--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -176,7 +176,15 @@ public class NativeImagePlugin implements Plugin<Project> {
 
         project.getPlugins().withType(JavaLibraryPlugin.class, javaLibraryPlugin -> graalExtension.getAgent().getDefaultMode().convention("conditional"));
 
-        project.afterEvaluate(p -> instrumentTasksWithAgent(project, graalExtension));
+        project.afterEvaluate(p -> {
+            instrumentTasksWithAgent(project, graalExtension);
+            for (NativeImageOptions options : graalExtension.getBinaries()) {
+                if (options.getAgent().getOptions().get().size() > 0 || options.getAgent().getEnabled().isPresent()) {
+                    logger.warn("The agent block in binary configuration '" + options.getName() + "' is deprecated.");
+                    logger.warn("Such agent configuration has no effect and will become an error in the future.");
+                }
+            }
+        });
     }
 
     private void instrumentTasksWithAgent(Project project, DefaultGraalVmExtension graalExtension) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
@@ -41,6 +41,7 @@
 
 package org.graalvm.buildtools.gradle.dsl;
 
+import org.graalvm.buildtools.gradle.dsl.agent.DeprecatedAgentOptions;
 import org.gradle.api.Action;
 import org.gradle.api.Named;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -267,4 +268,9 @@ public interface NativeImageOptions extends Named {
      */
     @Input
     Property<Boolean> getUseFatJar();
+
+    @Nested
+    DeprecatedAgentOptions getAgent();
+
+    void agent(Action<? super DeprecatedAgentOptions> spec);
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/agent/DeprecatedAgentOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/agent/DeprecatedAgentOptions.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, 2022 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.dsl.agent;
+
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+
+public interface DeprecatedAgentOptions {
+
+    @Input
+    @Optional
+    Property<Boolean> getEnabled();
+
+    @Input
+    @Optional
+    ListProperty<String> getOptions();
+
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -43,6 +43,7 @@ package org.graalvm.buildtools.gradle.internal;
 
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.dsl.NativeResourcesOptions;
+import org.graalvm.buildtools.gradle.dsl.agent.DeprecatedAgentOptions;
 import org.gradle.api.Action;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.model.ObjectFactory;
@@ -339,5 +340,14 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
                         .collect(Collectors.toList())
         );
         return this;
+    }
+
+    @Override
+    @Nested
+    public abstract DeprecatedAgentOptions getAgent();
+
+    @Override
+    public void agent(Action<? super DeprecatedAgentOptions> spec) {
+        spec.execute(getAgent());
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DeprecatedNativeImageOptions.java
@@ -42,6 +42,7 @@ package org.graalvm.buildtools.gradle.internal;
 
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.dsl.NativeResourcesOptions;
+import org.graalvm.buildtools.gradle.dsl.agent.DeprecatedAgentOptions;
 import org.gradle.api.Action;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.ListProperty;
@@ -236,6 +237,16 @@ public abstract class DeprecatedNativeImageOptions implements NativeImageOptions
 
     @Override
     public NativeImageOptions runtimeArgs(Iterable<?> arguments) {
-        return warnAboutDeprecation(() ->delegate.runtimeArgs(arguments));
+        return warnAboutDeprecation(() -> delegate.runtimeArgs(arguments));
+    }
+
+    @Override
+    public DeprecatedAgentOptions getAgent() {
+        return warnAboutDeprecation(delegate::getAgent);
+    }
+
+    @Override
+    public void agent(Action<? super DeprecatedAgentOptions> spec) {
+        warnAboutDeprecation(() -> delegate.agent(spec));
     }
 }


### PR DESCRIPTION
This PR warns users that the deprecated agent DSL block will have no effect on agent configuration and will result an error in the future