### PR TITLE
Try to fix snapshot publishing

### DIFF
--- a/build-logic/aggregator/build.gradle.kts
+++ b/build-logic/aggregator/build.gradle.kts
@@ -47,8 +47,3 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
 }
-
-dependencies {
-    implementation(libs.jgit)
-    implementation(libs.jsch)
-}

--- a/build-logic/aggregator/src/main/kotlin/org/graalvm/build/tasks/GitAdd.kt
+++ b/build-logic/aggregator/src/main/kotlin/org/graalvm/build/tasks/GitAdd.kt
@@ -41,7 +41,6 @@
 
 package org.graalvm.build.tasks
 
-import org.eclipse.jgit.api.Git
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
@@ -52,8 +51,6 @@ abstract class GitAdd : AbstractGitTask() {
 
     @TaskAction
     fun execute() {
-        Git.open(repositoryDirectory.asFile.get()).use {
-            it.add().addFilepattern(pattern.get()).call()
-        }
+        runGit("add", pattern.get())
     }
 }

--- a/build-logic/aggregator/src/main/kotlin/org/graalvm/build/tasks/GitCommit.kt
+++ b/build-logic/aggregator/src/main/kotlin/org/graalvm/build/tasks/GitCommit.kt
@@ -41,7 +41,6 @@
 
 package org.graalvm.build.tasks
 
-import org.eclipse.jgit.api.Git
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
@@ -55,13 +54,10 @@ abstract class GitCommit : AbstractGitTask() {
 
     @TaskAction
     fun execute() {
-        Git.open(repositoryDirectory.asFile.get()).use {
-            it.commit()
-                    .setAll(true)
-                    .setMessage(message.get())
-                    .setAmend(amend.get())
-                    .setSign(false)
-                    .call()
+        val cmd = arrayListOf("commit", "-a", "-m", message.get())
+        if (amend.get()) {
+            cmd.add("--amend")
         }
+        runGit(cmd)
     }
 }

--- a/build-logic/aggregator/src/main/kotlin/org/graalvm/build/tasks/GitPush.kt
+++ b/build-logic/aggregator/src/main/kotlin/org/graalvm/build/tasks/GitPush.kt
@@ -41,8 +41,6 @@
 
 package org.graalvm.build.tasks
 
-import org.eclipse.jgit.api.Git
-import org.eclipse.jgit.transport.SshTransport
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
@@ -53,14 +51,11 @@ abstract class GitPush : AbstractGitTask() {
 
     @TaskAction
     fun execute() {
-        Git.open(repositoryDirectory.asFile.get()).use {
-            it.push()
-                    .setTransportConfigCallback { transport ->
-                        val sshTransport: SshTransport = transport as SshTransport
-                        sshTransport.sshSessionFactory = sshSessionFactory
-                    }
-                    .setForce(force.get())
-                    .call()
+        val cmd = arrayListOf("push")
+        if (force.get()) {
+            cmd.add("-f")
         }
+        println("Pushing to remote Git repository")
+        runGit(cmd)
     }
 }

--- a/build-logic/aggregator/src/main/kotlin/org/graalvm/build/tasks/GitReset.kt
+++ b/build-logic/aggregator/src/main/kotlin/org/graalvm/build/tasks/GitReset.kt
@@ -41,8 +41,6 @@
 
 package org.graalvm.build.tasks
 
-import org.eclipse.jgit.api.Git
-import org.eclipse.jgit.api.ResetCommand
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
@@ -52,15 +50,16 @@ abstract class GitReset : AbstractGitTask() {
     abstract val ref: Property<String>
 
     @get:Input
-    abstract val mode: Property<ResetCommand.ResetType>
+    abstract val mode: Property<String>
+
 
     @TaskAction
     fun execute() {
-        Git.open(repositoryDirectory.asFile.get()).use {
-            it.reset()
-                    .setRef(ref.get())
-                    .setMode(mode.get())
-                    .call()
+        val cmd = arrayListOf("reset")
+        if (mode.isPresent) {
+            cmd.add("--${mode.get().toLowerCase()}")
         }
+        cmd.add(ref.get())
+        runGit(cmd)
     }
 }

--- a/build-logic/common-plugins/src/main/kotlin/org.graalvm.build.publishing.gradle.kts
+++ b/build-logic/common-plugins/src/main/kotlin/org.graalvm.build.publishing.gradle.kts
@@ -153,6 +153,6 @@ plugins.withId("java-test-fixtures") {
 
 // Get a handle on the software component factory
 interface Services {
-    @javax.inject.Inject
+    @Inject
     fun getSoftwareComponentFactory(): SoftwareComponentFactory
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ junitJupiter = "5.8.1"
 aether = "1.1.0"
 slf4j = "1.7.9"
 groovy = "3.0.11"
-jgit = "5.12.0.202106070339-r"
 jetty = "11.0.11"
 
 [libraries]
@@ -53,8 +52,5 @@ maven-wagon-http = { module = "org.apache.maven.wagon:wagon-http", version.ref =
 maven-wagon-provider = { module = "org.apache.maven.wagon:wagon-provider-api", version.ref = "mavenWagon" }
 
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
-
-jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
-jsch = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.jsch", version.ref="jgit" }
 
 jetty-server = { module = "org.eclipse.jetty:jetty-server", version.ref = "jetty" }


### PR DESCRIPTION
This is a draft PR that tries to tackle fixing of snapshot publishing. 
I replaced `jgit` dependency with shell invocation of `git` executable itself in order to workaround issues with public keys on existing back-ends. We can do this since it is reasonable to assume that every machine that runs this code has `git` properly setup.

There seem to be several task scheduling issues that prevent this PR from "just working". They exhibit as `deleteRecursively` command failing several times in a row, and other tasks continuing to run when `cloneSnapshot` task fails even when `--no-parallel` option is set.
My guess is that some task dependencies and inputs/outputs are incorrectly setup but ATM I don't have enough time to debug this. If anyone has some ideas, please yell.