### PR TITLE
Set `useArgFile` to be true by default only on Windows

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -23,6 +23,10 @@ If you are interested in contributing, please refer to our https://github.com/gr
 * Introduced the `metadataCopy` task.
 * Introduced the concept of agent modes.
 ** Under the hood, the agent mode dictates what options are passed to the agent and how metadata produced by multiple runs get merged.
+* `useArgFile` is now set to true by default only on Windows.
+
+==== Maven plugin
+* `useArgFile` is now set to true by default only on Windows.
 
 === Release 0.9.11
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -126,6 +126,7 @@ import java.util.stream.Collectors;
 import static org.graalvm.buildtools.gradle.internal.GradleUtils.transitiveProjectArtifacts;
 import static org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator.graalvmHomeProvider;
 import static org.graalvm.buildtools.utils.SharedConstants.AGENT_PROPERTY;
+import static org.graalvm.buildtools.utils.SharedConstants.IS_WINDOWS;
 
 /**
  * Gradle plugin for GraalVM Native Image.
@@ -170,7 +171,7 @@ public class NativeImagePlugin implements Plugin<Project> {
 
         logger = GraalVMLogger.of(project.getLogger());
         DefaultGraalVmExtension graalExtension = (DefaultGraalVmExtension) registerGraalVMExtension(project);
-        graalExtension.getUseArgFile().convention(true);
+        graalExtension.getUseArgFile().convention(IS_WINDOWS);
         project.getPlugins()
                 .withType(JavaPlugin.class, javaPlugin -> configureJavaProject(project, nativeImageServiceProvider, graalExtension));
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
@@ -99,7 +99,7 @@ public interface GraalVMExtension {
 
     /**
      * Property driving the use of @-arg files when invoking native image.
-     * This is enabled by default. For older native-image versions, this
+     * This is enabled by default on Windows. For older native-image versions, this
      * needs to be disabled.
      *
      * @return the argument file property

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildMojo.java
@@ -81,6 +81,8 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.graalvm.buildtools.utils.SharedConstants.IS_WINDOWS;
+
 @Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE)
 public class NativeBuildMojo extends AbstractNativeMojo {
 
@@ -108,8 +110,8 @@ public class NativeBuildMojo extends AbstractNativeMojo {
     @Parameter(property = "classpath")
     private List<String> classpath;
 
-    @Parameter(property = "useArgFile", defaultValue = "true")
-    private boolean useArgFile;
+    @Parameter(property = "useArgFile")
+    private Boolean useArgFile;
 
     @Parameter(alias = "metadataRepository")
     private MetadataRepositoryConfiguration metadataRepositoryConfiguration;
@@ -159,6 +161,9 @@ public class NativeBuildMojo extends AbstractNativeMojo {
             cliArgs.add("-cp");
             cliArgs.add(classpathStr);
             cliArgs.addAll(getBuildArgs());
+            if (useArgFile == null) {
+                useArgFile = IS_WINDOWS;
+            }
             if (useArgFile) {
                 cliArgs = NativeImageUtils.convertToArgsFile(cliArgs);
             }


### PR DESCRIPTION
Since argument files make native-image invocation non-transparent
we disable them by default except on Windows (where they are needed
in order to avoid errors due to limitation on number of characters).

Fixes #243 