### PR TITLE
Fix how the GRAALVM_QUICK_BUILD env var is read

### DIFF
--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -663,15 +663,16 @@ public class NativeImagePlugin implements Plugin<Project> {
                                 FileSystemOperations fileOperations,
                                 Task taskToInstrument,
                                 JavaForkOptions javaForkOptions) {
+        Provider<AgentConfiguration> agentConfiguration = AgentConfigurationFactory.getAgentConfiguration(agentMode, graalExtension.getAgent());
         //noinspection Convert2Lambda
         taskToInstrument.doFirst(new Action<Task>() {
             @Override
             public void execute(Task task) {
-                logger.logOnce("Instrumenting task with the native-image-agent: " + task.getName());
+                if (agentConfiguration.get().isEnabled()) {
+                    logger.logOnce("Instrumenting task with the native-image-agent: " + task.getName());
+                }
             }
         });
-        Provider<AgentConfiguration> agentConfiguration = AgentConfigurationFactory.getAgentConfiguration(agentMode, graalExtension.getAgent());
-
         AgentCommandLineProvider cliProvider = project.getObjects().newInstance(AgentCommandLineProvider.class);
         cliProvider.getInputFiles().from(agentConfiguration.map(AgentConfiguration::getAgentFiles));
         cliProvider.getEnabled().set(agentConfiguration.map(AgentConfiguration::isEnabled));

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -663,7 +663,13 @@ public class NativeImagePlugin implements Plugin<Project> {
                                 FileSystemOperations fileOperations,
                                 Task taskToInstrument,
                                 JavaForkOptions javaForkOptions) {
-        logger.lifecycle("Instrumenting task with the native-image-agent: " + taskToInstrument.getName());
+        //noinspection Convert2Lambda
+        taskToInstrument.doFirst(new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                logger.logOnce("Instrumenting task with the native-image-agent: " + task.getName());
+            }
+        });
         Provider<AgentConfiguration> agentConfiguration = AgentConfigurationFactory.getAgentConfiguration(agentMode, graalExtension.getAgent());
 
         AgentCommandLineProvider cliProvider = project.getObjects().newInstance(AgentCommandLineProvider.class);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImageService.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImageService.java
@@ -41,6 +41,7 @@
 
 package org.graalvm.buildtools.gradle;
 
+import org.graalvm.buildtools.gradle.internal.GraalVMLogger;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
@@ -52,7 +53,9 @@ public abstract class NativeImageService implements BuildService<BuildServicePar
         return project.getGradle()
                 .getSharedServices()
                 .registerIfAbsent("nativeImage", NativeImageService.class,
-                        spec -> spec.getMaxParallelUsages().set(1 + Runtime.getRuntime().availableProcessors() / 16));
-
+                        spec -> {
+                            GraalVMLogger.newBuild();
+                            spec.getMaxParallelUsages().set(1 + Runtime.getRuntime().availableProcessors() / 16);
+                        });
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -244,7 +244,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         getFallback().convention(false);
         getVerbose().convention(false);
         getQuickBuild().convention(providers.environmentVariable("GRAALVM_QUICK_BUILD").map(env -> {
-            LOGGER.warn("Quick build environment variable is set.");
+            LOGGER.logOnce("Quick build environment variable is set.");
             if (env.isEmpty()) {
                 return true;
             }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -47,6 +47,7 @@ import org.graalvm.buildtools.gradle.dsl.agent.DeprecatedAgentOptions;
 import org.graalvm.buildtools.utils.SharedConstants;
 import org.gradle.api.Action;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
@@ -78,6 +79,8 @@ import java.util.stream.StreamSupport;
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public abstract class BaseNativeImageOptions implements NativeImageOptions {
+    private static final GraalVMLogger LOGGER = GraalVMLogger.of(Logging.getLogger(BaseNativeImageOptions.class));
+
     private final String name;
 
     @Override
@@ -240,7 +243,13 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         getDebug().convention(false);
         getFallback().convention(false);
         getVerbose().convention(false);
-        getQuickBuild().convention(false);
+        getQuickBuild().convention(providers.environmentVariable("GRAALVM_QUICK_BUILD").map(env -> {
+            LOGGER.warn("Quick build environment variable is set.");
+            if (env.isEmpty()) {
+                return true;
+            }
+            return Boolean.parseBoolean(env);
+        }).orElse(false));
         getRichOutput().convention(!SharedConstants.IS_CI && !SharedConstants.IS_WINDOWS && !SharedConstants.IS_DUMB_TERM && !SharedConstants.NO_COLOR);
         getSharedLibrary().convention(false);
         getImageName().convention(defaultImageName);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/GraalVMLogger.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/GraalVMLogger.java
@@ -43,10 +43,21 @@ package org.graalvm.buildtools.gradle.internal;
 
 import org.gradle.api.logging.Logger;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Wraps the Gradle logger with a minimal API surface.
  */
 public final class GraalVMLogger {
+    private static final Set<String> LOGGED_MESSAGES = new HashSet<>();
+
+    public static void newBuild() {
+        synchronized (LOGGED_MESSAGES) {
+            LOGGED_MESSAGES.clear();
+        }
+    }
+
     private final Logger delegate;
 
     public static GraalVMLogger of(Logger delegate) {
@@ -79,5 +90,13 @@ public final class GraalVMLogger {
 
     public void warn(String s) {
         delegate.warn("[native-image-plugin] {}", s);
+    }
+
+    public void logOnce(String message) {
+        synchronized (LOGGED_MESSAGES) {
+            if (LOGGED_MESSAGES.add(message)) {
+                lifecycle(message);
+            }
+        }
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -169,12 +169,6 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         NativeImageOptions options = getOptions().get();
         GraalVMLogger logger = GraalVMLogger.of(getLogger());
 
-        String quickBuildEnv = System.getenv("GRAALVM_QUICK_BUILD");
-        if (quickBuildEnv != null) {
-            logger.warn("Quick build environment variable is set.");
-            options.getQuickBuild().set(quickBuildEnv.isEmpty() || Boolean.parseBoolean(quickBuildEnv));
-        }
-
         List<String> args = buildActualCommandLineArgs();
         if (options.getVerbose().get()) {
             logger.lifecycle("Args are: " + args);


### PR DESCRIPTION
It was being mutated at execution time, instead of read at configuration
time, which causes an error (see https://github.com/micronaut-projects/micronaut-sql/runs/7538645832?check_suite_focus=true#step:6:907).

Fixes #277