### PR TITLE
Add support for `test-jar` artifacts

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        graalvm-version: [ dev ]
+        graalvm-version: [ latest ]
         java-version: [ 11 ]
         os: [ ubuntu-20.04 ]
     steps:

--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        graalvm-version: [ dev ]
+        graalvm-version: [ latest ]
         java-version: [ 11 ]
         os: [ ubuntu-20.04 ]
     steps:

--- a/.github/workflows/test-native-gradle-plugin.yml
+++ b/.github/workflows/test-native-gradle-plugin.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        graalvm-version: [ dev ]
+        graalvm-version: [ latest ] # dev
         java-version: [ 11 ]
         os: [ ubuntu-20.04 ]
     steps:
@@ -53,8 +53,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradle-version: ["current", "7.3.3", "7.2", "7.1", "6.8.3", "6.7.1"]
-        graalvm-version: [ dev ]
+        gradle-version: ["current", "6.7.1"]
+        # Following versions are disabled temporarily in order to speed up PR testing
+        # "7.3.3", "7.2", "7.1", "6.8.3"
+        graalvm-version: [ latest ] # dev
         java-version: [ 11 ]
         os: [ ubuntu-20.04 ]
     steps:
@@ -81,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        graalvm-version: [ dev ]
+        graalvm-version: [ latest ]
         java-version: [ 11 ]
         os: [ windows-latest ]
     steps:

--- a/.github/workflows/test-native-maven-plugin.yml
+++ b/.github/workflows/test-native-maven-plugin.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        graalvm-version: [ dev ]
+        graalvm-version: [ latest ] # dev
         java-version: [ 11 ]
         os: [ ubuntu-20.04 ]
     steps:
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        graalvm-version: [ dev ]
+        graalvm-version: [ latest ] # dev
         java-version: [ 11 ]
         os: [ windows-latest ]
     steps:

--- a/docs/src/docs/asciidoc/announcement.adoc
+++ b/docs/src/docs/asciidoc/announcement.adoc
@@ -144,7 +144,7 @@ Adding our new plugin to the existing _Maven_ project requires adding the follow
             <execution>
               <id>build-native</id>
               <goals>
-                <goal>build</goal>
+                <goal>compile-no-fork</goal>
               </goals>
               <phase>package</phase>
             </execution>

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -40,7 +40,7 @@ Add the following profile to your `pom.xml` file to register the `native-maven-p
               <execution>
                 <id>build-native</id>
                 <goals>
-                  <goal>build</goal>
+                  <goal>compile-no-fork</goal>
                 </goals>
                 <phase>package</phase>
               </execution>

--- a/native-maven-plugin/reproducers/issue-144/pom.xml
+++ b/native-maven-plugin/reproducers/issue-144/pom.xml
@@ -92,7 +92,7 @@
                             <execution>
                                 <id>build-native</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
@@ -49,13 +49,13 @@ class JavaApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
 
         when:
         mvn '-Pnative', '-DskipTests', '-DnativeDryRun', '-DuseArgFile=false',
-                '-Dclasspath=/testcp', '-Ddebug', '-Dfallback=false', '-Dverbose', '-DsharedLibrary',
+                '-Dclasspath=/', '-Ddebug', '-Dfallback=false', '-Dverbose', '-DsharedLibrary',
                 '-DquickBuild',
                 'package'
 
         then:
         buildSucceeded
-        outputContains "native-image -cp /testcp -g --no-fallback --verbose --shared -Ob"
+        outputContains "native-image -cp / -g --no-fallback --verbose --shared -Ob"
     }
 
     def "can build and execute a native image with the Maven plugin"() {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/DeprecatedNativeBuildMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/DeprecatedNativeBuildMojo.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * Mojo used to invoke native image building by attaching it to a phase.
+ * Deprecated in favor of compile-no-fork goal.
+ */
+@Deprecated
+@Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE,
+        requiresDependencyResolution = ResolutionScope.RUNTIME,
+        requiresDependencyCollection = ResolutionScope.RUNTIME)
+public class DeprecatedNativeBuildMojo extends NativeCompileNoForkMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        logger.warn("'native:build' goal is deprecated. Use 'native:compile-no-fork' instead.");
+        super.execute();
+    }
+
+}

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeCompileNoForkMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeCompileNoForkMojo.java
@@ -63,7 +63,7 @@ import java.util.function.BiFunction;
  * This goal runs native builds. It functions the same as the native:compile goal, but it
  * does not fork the build, so it is suitable for attaching to the build lifecycle.
  */
-@Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE,
+@Mojo(name = "compile-no-fork", defaultPhase = LifecyclePhase.PACKAGE,
         requiresDependencyResolution = ResolutionScope.RUNTIME,
         requiresDependencyCollection = ResolutionScope.RUNTIME)
 public class NativeCompileNoForkMojo extends AbstractNativeMojo {

--- a/samples/java-application-with-reflection/pom.xml
+++ b/samples/java-application-with-reflection/pom.xml
@@ -131,7 +131,7 @@
                             <execution>
                                 <id>build-native</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>

--- a/samples/java-application-with-resources/pom.xml
+++ b/samples/java-application-with-resources/pom.xml
@@ -100,7 +100,7 @@
                                 <id>build-native</id>
                                 <goals>
                                     <goal>generateResourceConfig</goal>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>

--- a/samples/java-application-with-tests/pom.xml
+++ b/samples/java-application-with-tests/pom.xml
@@ -95,7 +95,7 @@
                             <execution>
                                 <id>build-native</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>
@@ -191,7 +191,7 @@
                             <execution>
                                 <id>build-native</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                                 <configuration>

--- a/samples/java-application/pom.xml
+++ b/samples/java-application/pom.xml
@@ -79,7 +79,7 @@
                             <execution>
                                 <id>build-native</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>
@@ -126,7 +126,7 @@
                             <execution>
                                 <id>build-native</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>

--- a/samples/java-library/pom.xml
+++ b/samples/java-library/pom.xml
@@ -79,7 +79,7 @@
                             <execution>
                                 <id>build-native</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>

--- a/samples/metadata-repo-integration/pom.xml
+++ b/samples/metadata-repo-integration/pom.xml
@@ -80,7 +80,7 @@
                             <execution>
                                 <id>build-native</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>
@@ -109,7 +109,7 @@
                             <execution>
                                 <id>build-native</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>

--- a/samples/native-config-integration/pom.xml
+++ b/samples/native-config-integration/pom.xml
@@ -84,7 +84,7 @@
                             <execution>
                                 <id>build-native</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>
@@ -128,7 +128,7 @@
                             <execution>
                                 <id>build-native</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>compile-no-fork</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>


### PR DESCRIPTION
- Add support for `test-jar` artifacts (fixes #279)
- Deprecate `native:build` goal in favor of `native:compile-no-fork` (fixes #273) 