### PR TITLE
Add Gradle CLI options for quick build and debugging

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -37,6 +37,8 @@ plugins {
 }
 ----
 
+NOTE: This plugin supplements and heavily relies on regular Java plugins (e.g. `application`, `java-library`, `java` etc). Not having them included in your project will most probably cause errors.
+
 The plugin isn't available on the https://plugins.gradle.org[Gradle Plugin Portal] yet, so you will need to declare a plugin repository in addition:
 
 Add the following to your `settings.gradle` / `settings.gradle.kts`:
@@ -52,8 +54,9 @@ include::../snippets/gradle/groovy/settings.gradle[tags=plugin-management]
 include::../snippets/gradle/kotlin/settings.gradle.kts[tags=plugin-management]
 ----
 
+
 [TIP]
-.Testing pre-releases
+.Testing pre-releases (BROKEN AT THE MOMENT!)
 ====
 You can use development versions of the plugin by adding our snapshot repository instead. Pre-releases are provided for convenience, without any guarantee.
 [source, groovy, role="multi-language-sample"]

--- a/docs/src/docs/snippets/gradle/groovy/build.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/build.gradle
@@ -115,11 +115,11 @@ graalvmNative {
             // Main options
             imageName = 'application' // The name of the native image, defaults to the project name
             mainClass = 'org.test.Main' // The main class to use, defaults to the application.mainClass
-            debug = true // Determines if debug info should be generated, defaults to false
+            debug = true // Determines if debug info should be generated, defaults to false (alternatively add --debug-native to the CLI)
             verbose = true // Add verbose output, defaults to false
             fallback = true // Sets the fallback mode of native-image, defaults to false
             sharedLibrary = false // Determines if image is a shared library, defaults to false if `java-library` plugin isn't included
-            quickBuild = false // Determines if image is being built in quick build mode (alternatively use GRAALVM_QUICK_BUILD environment variable)
+            quickBuild = false // Determines if image is being built in quick build mode (alternatively use GRAALVM_QUICK_BUILD environment variable, or add --native-quick-build to the CLI)
             richOutput = false // Determines if native-image building should be done with rich output
 
             systemProperties = [name1: 'value1', name2: 'value2'] // Sets the system properties to use for the native image builder

--- a/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
+++ b/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
@@ -116,11 +116,11 @@ graalvmNative {
             // Main options
             imageName.set("application") // The name of the native image, defaults to the project name
             mainClass.set("org.test.Main") // The main class to use, defaults to the application.mainClass
-            debug.set(true) // Determines if debug info should be generated, defaults to false
+            debug.set(true) // Determines if debug info should be generated, defaults to false (alternatively add --debug-native to the CLI)
             verbose.set(true) // Add verbose output, defaults to false
             fallback.set(true) // Sets the fallback mode of native-image, defaults to false
             sharedLibrary.set(false) // Determines if image is a shared library, defaults to false if `java-library` plugin isn't included
-            quickBuild.set(false) // Determines if image is being built in quick build mode (alternatively use GRAALVM_QUICK_BUILD environment variable)
+            quickBuild.set(false) // Determines if image is being built in quick build mode (alternatively use GRAALVM_QUICK_BUILD environment variable, or add --native-quick-build to the CLI)
             richOutput.set(false) // Determines if native-image building should be done with rich output
 
             systemProperties.putAll(mapOf("name1" to "value1", "name2" to "value2")) // Sets the system properties to use for the native image builder

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -65,6 +65,7 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
 import org.gradle.process.ExecOperations;
 
 import javax.inject.Inject;
@@ -83,6 +84,16 @@ public abstract class BuildNativeImageTask extends DefaultTask {
 
     @Nested
     public abstract Property<NativeImageOptions> getOptions();
+
+    @Option(option = "quick-build-native", description = "Enables quick build mode")
+    public void overrideQuickBuild() {
+        getOptions().get().getQuickBuild().set(true);
+    }
+
+    @Option(option = "debug-native", description = "Enables debug mode")
+    public void overrideDebugBuild() {
+        getOptions().get().getDebug().set(true);
+    }
 
     @Inject
     protected abstract ExecOperations getExecOperations();


### PR DESCRIPTION
- Introduces flags to activate native debugging and quick build (fixes #267)
- Clarifies relationship between base Java plugins and Native Gradle Plugin (fixes #210)