### PR TITLE
Do not filter out entry values starting with `java.` in the metadata post-processing action

### DIFF
--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -81,7 +81,7 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
         agentOpts.getEnabled().convention(false);
         agentOpts.getModes().getConditional().getParallel().convention(true);
         agentOpts.getMetadataCopy().getMergeWithExisting().convention(false);
-        agentOpts.getFilterableEntries().convention(Arrays.asList("org.gradle.", "java.", "org.junit."));
+        agentOpts.getFilterableEntries().convention(Arrays.asList("org.gradle.", "org.junit."));
         agentOpts.getBuiltinHeuristicFilter().convention(true);
         agentOpts.getBuiltinCallerFilter().convention(true);
         agentOpts.getEnableExperimentalPredefinedClasses().convention(false);


### PR DESCRIPTION
We should not filter entry values starting with `java.` by default from generated metadata. These types are valid arguments to methods.