### PR TITLE
Fix javadoc and warnings

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,9 +4,9 @@ nativeBuildTools = "0.9.14-SNAPSHOT"
 
 # External dependencies
 spock = "2.1-groovy-3.0"
-maven = "3.8.5"
+maven = "3.8.6"
 mavenAnnotations = "3.6.4"
-mavenEmbedder = "3.8.3"
+mavenEmbedder = "3.8.6"
 mavenWagon = "3.4.3"
 graalvm = "22.0.0"
 jackson = "2.13.3"

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
@@ -62,6 +62,8 @@ public interface GraalVMExtension {
      * to disable automatic test support, especially in cases
      * where the test framework doesn't allow testing within
      * a native image.
+     *
+     * @return is the test support active
      */
     Property<Boolean> getTestSupport();
 
@@ -76,17 +78,22 @@ public interface GraalVMExtension {
      * Returns the native image configurations used to generate images.
      * By default, this plugin creates two images, one called "main" for
      * the main application and another one called "test" for tests.
+     *
+     * @return configuration for binaries
      */
     NamedDomainObjectContainer<NativeImageOptions> getBinaries();
 
     /**
      * Configures the native image options.
+     *
+     * @param spec specification for binary
      */
     void binaries(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec);
 
     /**
      * Registers a new native image binary with testing support.
      *
+     * @param name the name of the binary
      * @param spec the test image configuration
      */
     void registerTestBinary(String name, Action<? super TestBinaryConfig> spec);
@@ -94,6 +101,8 @@ public interface GraalVMExtension {
     /**
      * Property driving the detection of toolchains which support building native images.
      * The default is true.
+     *
+     * @return is toolchain detection on
      */
     Property<Boolean> getToolchainDetection();
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMReachabilityMetadataRepositoryExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMReachabilityMetadataRepositoryExtension.java
@@ -55,6 +55,7 @@ public interface GraalVMReachabilityMetadataRepositoryExtension {
     /**
      * Property used to determine if the reachability metadata
      * repository should be used.
+     *
      * @return the enabled property
      */
     Property<Boolean> getEnabled();
@@ -81,6 +82,7 @@ public interface GraalVMReachabilityMetadataRepositoryExtension {
      * The set of modules for which we don't want to use the
      * configuration found in the repository. Modules must be
      * declared with the `groupId:artifactId` syntax.
+     *
      * @return the set of excluded modules
      */
     SetProperty<String> getExcludedModules();
@@ -88,6 +90,7 @@ public interface GraalVMReachabilityMetadataRepositoryExtension {
     /**
      * A map from a module (org.group:artifact) to configuration
      * repository config version.
+     *
      * @return the map of modules to forced configuration versions
      */
     MapProperty<String, String> getModuleToConfigVersion();
@@ -95,7 +98,9 @@ public interface GraalVMReachabilityMetadataRepositoryExtension {
     /**
      * Convenience method to use a String for the URI
      * property.
+     *
      * @param uri the URI
+     * @throws URISyntaxException if URL is malformed
      */
     default void uri(String uri) throws URISyntaxException {
         getUri().set(new URI(uri));
@@ -103,6 +108,7 @@ public interface GraalVMReachabilityMetadataRepositoryExtension {
 
     /**
      * Convenience method to use a URI for the property.
+     *
      * @param file a file
      */
     default void uri(File file) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
@@ -191,6 +191,8 @@ public interface NativeImageOptions extends Named {
     /**
      * Returns the toolchain used to invoke native-image. Currently pointing
      * to a Java launcher due to Gradle limitations.
+     *
+     * @return the detected java launcher
      */
     @Nested
     @Optional

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeResourcesOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeResourcesOptions.java
@@ -66,6 +66,8 @@ public abstract class NativeResourcesOptions {
      * The list of bundles to include in the generated resources file.
      * The contents of this property is used to generate the "bundles"
      * section of the resource-config.json file
+     *
+     * @return the list of bundles
      */
     @Input
     public abstract ListProperty<String> getBundles();
@@ -74,9 +76,9 @@ public abstract class NativeResourcesOptions {
      * The list of resources to include, as Java regular expressions.
      * The contents of this property is used to generate the "resources" : "includes"
      * section of the resource-config.json file.
-     *
      * It will be merged with detected resources, if any.
      *
+     * @return the list of resources to include
      */
     @Input
     public abstract ListProperty<String> getIncludedPatterns();
@@ -85,9 +87,9 @@ public abstract class NativeResourcesOptions {
      * The list of resources to exclude, as Java regular expressions.
      * The contents of this property is used to generate the "resources" : "excludes"
      * section of the resource-config.json file.
-     *
      * It will be merged with detected resources, if any.
      *
+     * @return the list of resources to exclude
      */
     @Input
     public abstract ListProperty<String> getExcludedPatterns();

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/ResourceDetectionOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/ResourceDetectionOptions.java
@@ -50,6 +50,8 @@ public abstract class ResourceDetectionOptions {
      * Determines if the resources should be detected from classpath.
      * If this property is set to true, then Gradle will automatically
      * detect resources to include from conventional places like src/main/resources.
+     *
+     * @return if resources should be detected from the classpath
      */
     @Input
     public abstract Property<Boolean> getEnabled();
@@ -57,8 +59,9 @@ public abstract class ResourceDetectionOptions {
     /**
      * Determines if detection should be limited to project dependencies, in
      * which case external dependencies will not be scanned.
-     *
      * Default value is true.
+     *
+     * @return if detection should be limited to the project dependencies
      */
     @Input
     public abstract Property<Boolean> getRestrictToProjectDependencies();
@@ -69,6 +72,7 @@ public abstract class ResourceDetectionOptions {
      * that classpath entry (e.g jar). By default, this behavior is set to false,
      * meaning that if such a file is present, detection is disabled for this
      * particular classpath entry.
+     *
      * @return the ignore property
      */
     @Input
@@ -77,6 +81,8 @@ public abstract class ResourceDetectionOptions {
     /**
      * Returns the list of regular expressions which will be used to exclude
      * resources from detection.
+     *
+     * @return a list of regular expressions for resources exclusion
      */
     @Input
     public abstract SetProperty<String> getDetectionExclusionPatterns();
@@ -85,6 +91,8 @@ public abstract class ResourceDetectionOptions {
      * Adds the default resource excludes for detection, which can be useful if
      * you want to add more excludes but still want the conventional ones to be
      * added.
+     *
+     * @return resource detection options
      */
     public ResourceDetectionOptions addDefaultDetectionExclusions() {
         getDetectionExclusionPatterns().addAll(SharedConstants.DEFAULT_EXCLUDES_FOR_RESOURCE_DETECTION);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/agent/AgentOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/agent/AgentOptions.java
@@ -57,6 +57,7 @@ import java.util.function.Predicate;
 public interface AgentOptions {
     /**
      * Contains configuration of supported agent modes.
+     * @return agent modes
      */
     @Nested
     AgentModeOptions getModes();
@@ -67,6 +68,7 @@ public interface AgentOptions {
 
     /**
      * The default agent mode name when the agent is in use.
+     * @return default agent mode
      */
     @Input
     @Optional
@@ -74,6 +76,7 @@ public interface AgentOptions {
 
     /**
      * Enables the agent.
+     * @return is the agent enabled
      */
     @Input
     @Optional
@@ -81,6 +84,7 @@ public interface AgentOptions {
 
     /**
      * Caller-filter files that will be passed to the agent.
+     * @return caller filter files
      */
     @InputFiles
     @Optional
@@ -88,6 +92,7 @@ public interface AgentOptions {
 
     /**
      * Access-filter files that will be passed to the agent.
+     * @return access filter files
      */
     @InputFiles
     @Optional
@@ -95,12 +100,14 @@ public interface AgentOptions {
 
     /**
      * Toggles the builtin agent caller filter.
+     * @return builtin caller filter
      */
     @Optional
     Property<Boolean> getBuiltinCallerFilter();
 
     /**
      * Toggles the builtin agent heuristic filter.
+     * @return is builtin heuristic filter enabled
      */
     @Optional
     Property<Boolean> getBuiltinHeuristicFilter();
@@ -108,6 +115,7 @@ public interface AgentOptions {
 
     /**
      * Toggles the experimental support for predefined classes.
+     * @return is experimental support for predefined classes enabled
      */
     @Optional
     Property<Boolean> getEnableExperimentalPredefinedClasses();
@@ -115,6 +123,7 @@ public interface AgentOptions {
 
     /**
      * Toggles the experimental support for unsafe allocation tracing.
+     * @return is experimental support for unsafe allocation tracing enabled
      */
     @Optional
     Property<Boolean> getEnableExperimentalUnsafeAllocationTracing();
@@ -122,12 +131,14 @@ public interface AgentOptions {
 
     /**
      * Toggles the distinction between queried and used metadata.
+     * @return queried or used metadata
      */
     @Optional
     Property<Boolean> getTrackReflectionMetadata();
 
     /**
      * Configuration of the metadata copy task.
+     * @return configuration of the metadata copy task
      */
     @Nested
     MetadataCopyOptions getMetadataCopy();
@@ -138,6 +149,7 @@ public interface AgentOptions {
 
     /**
      * Specifies prefixes that will be used to further filter files produced by the agent.
+     * @return filterable entries
      */
     @Input
     @Optional


### PR DESCRIPTION
This PR fixes warnings that were produced both during the plugin building and IDE usage due to missing JavaDoc entries and misc other non-critical issues.