### PR TITLE
Fix metadata repository crash

### DIFF
--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -527,14 +527,11 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
 
     protected void maybeAddReachabilityMetadata(List<String> configDirs) {
         if (isMetadataRepositoryEnabled() && !metadataRepositoryPaths.isEmpty()) {
-            String arg = metadataRepositoryPaths.stream()
+            metadataRepositoryPaths.stream()
                     .map(Path::toAbsolutePath)
                     .map(Path::toFile)
                     .map(File::getAbsolutePath)
-                    .collect(Collectors.joining(","));
-            if (!arg.isEmpty()) {
-                configDirs.add(arg);
-            }
+                    .forEach(configDirs::add);
         }
     }
 


### PR DESCRIPTION
Fix issue where if multiple supported reachability-metadata entries are found, incorrect path would be generated.

Fixes: https://github.com/oracle/graalvm-reachability-metadata/issues/46

Signed-off-by: David Nestorovic <david.nestorovic@oracle.com>