### PR TITLE
Maven agent modes support work

### DIFF
--- a/native-maven-plugin/build.gradle.kts
+++ b/native-maven-plugin/build.gradle.kts
@@ -64,11 +64,11 @@ dependencies {
     implementation(libs.jackson.databind)
     implementation(libs.jvmReachabilityMetadata)
     implementation(libs.graalvm.svm)
+    implementation(libs.maven.pluginAnnotations)
 
     compileOnly(libs.maven.pluginApi)
     compileOnly(libs.maven.core)
     compileOnly(libs.maven.artifact)
-    compileOnly(libs.maven.pluginAnnotations)
 
     mavenEmbedder(libs.maven.embedder)
     mavenEmbedder(libs.maven.aether.connector)

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -55,6 +55,7 @@ import org.codehaus.plexus.logging.Logger;
 import org.graalvm.buildtools.Utils;
 import org.graalvm.buildtools.maven.config.ExcludeConfigConfiguration;
 import org.graalvm.buildtools.maven.config.MetadataRepositoryConfiguration;
+import org.graalvm.buildtools.maven.config.agent.AgentConfiguration;
 import org.graalvm.buildtools.utils.FileUtils;
 import org.graalvm.buildtools.utils.NativeImageUtils;
 import org.graalvm.buildtools.utils.SharedConstants;
@@ -182,6 +183,9 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
 
     @Parameter(property = NATIVE_IMAGE_DRY_RUN, defaultValue = "false")
     protected boolean dryRun;
+
+    @Parameter(property = "agent")
+    protected AgentConfiguration agent;
 
     protected GraalVMReachabilityMetadataRepository metadataRepository;
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
@@ -53,6 +53,7 @@ import org.codehaus.plexus.logging.LogEnabled;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.graalvm.buildtools.Utils;
+import org.graalvm.buildtools.maven.config.ExtensionTimeConfigurationUtility;
 import org.graalvm.buildtools.utils.SharedConstants;
 
 import java.io.File;
@@ -172,6 +173,10 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                             })
                     );
                     updatePluginConfiguration(nativePlugin, (exec, configuration) -> {
+                        AbstractNativeMojo mojo = new NativeCompileMojo();
+                        ExtensionTimeConfigurationUtility.loadFromXml(configuration, mojo);
+                        ExtensionTimeConfigurationUtility.debugPrint(mojo);
+                        System.out.println("HERE!");
                         Context context = exec.getGoals().stream().anyMatch("test"::equals) ? Context.test : Context.main;
                         Xpp3Dom agentResourceDirectory = findOrAppend(configuration, "agentResourceDirectory");
                         agentResourceDirectory.setValue(agentOutputDirectoryFor(target, context));
@@ -204,6 +209,7 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
     private static boolean isAgentEnabled(MavenSession session, Plugin nativePlugin) {
         String systemProperty = session.getSystemProperties().getProperty("agent");
         if (systemProperty != null) {
+            System.clearProperty("agent");
             // -Dagent=[true|false] overrides configuration in the POM.
             return parseBoolean("agent system property", systemProperty);
         }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/ExtensionTimeConfigurationUtility.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/ExtensionTimeConfigurationUtility.java
@@ -1,0 +1,256 @@
+package org.graalvm.buildtools.maven.config;
+
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptorBuilder;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.plexus.configuration.PlexusConfigurationException;
+import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+import java.beans.PropertyEditor;
+import java.beans.PropertyEditorManager;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This is utility class that provides a way to parse and/or persist configuration options
+ * during the extension time.
+ * Normally in Maven, the parameters are bound from XML to values during the Mojo creation and there is no way
+ * to access / modify those values other than manually traversing DOM tree.
+ * .
+ * TBH, this should probably be a part of a separate utility library.
+ */
+public class ExtensionTimeConfigurationUtility {
+
+    public final String PLUGIN_DESCRIPTOR_LOCATION = "/META-INF/maven/plugin.xml";
+    public final PluginDescriptorBuilder builder = new PluginDescriptorBuilder();
+
+    /**
+     * As Maven loves to complicate things, the @Parameter annotation isn't preserved until runtime :)
+     * The idea is that there is а plugin descriptor XML file that is generated during plugin publishing and embedded into
+     * each plugin jar. That file - when parsed - is later used (among other things) to map `pom.xml` parameters to Mojos.
+     *
+     * @return plugin descriptor
+     */
+    public PluginDescriptor parsePluginDescriptor() {
+        try (InputStream xmlDescriptor = ClassLoader.class.getResourceAsStream(PLUGIN_DESCRIPTOR_LOCATION)) {
+            Reader reader = ReaderFactory.newXmlReader(xmlDescriptor);
+            return builder.build(reader, null);
+        } catch (IOException | PlexusConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Object populateMojo(Xpp3Dom configuration, Class<?> mojoClass) {
+        PluginDescriptor pd = parsePluginDescriptor();
+        MojoDescriptor descriptor = pd.getMojos().stream()
+                .filter(mojoDescriptor ->
+                        mojoDescriptor.getImplementationClass().getCanonicalName().equals(mojoClass.getCanonicalName()))
+                .findFirst().orElse(null);
+        if (descriptor == null) {
+            return null;
+        }
+
+        Object instance;
+        try {
+            instance = mojoClass.getConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException |
+                 InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+
+        Map<String, org.apache.maven.plugin.descriptor.Parameter> paramMap
+                = descriptor.getParameterMap();
+
+        getAllFields(mojoClass).forEach(field -> {
+            if (!paramMap.containsKey(field.getName())) {
+                return;
+            }
+
+            field.setAccessible(true);
+
+            /*
+                TODO:
+                 ... aaand here we should try to map types from the plugin descriptor to the fields
+                and then map everything to the plugin configuration block, and then convert all the
+                values from the plugin configuration block to their respective types (possibly using
+                similar idea as the one present in the `loadFromXml` method)...
+             */
+
+        });
+        return instance;
+    }
+
+    /**
+     * Given XML configuration and class instance injects values in @Parameter annotated fields.
+     * .
+     * IGNORE THIS METHOD. This approach doesn't work since Parameter annotation isn't retained
+     * until the runtime... I didn't remove this since it might contain some useful snippets for
+     * implementation of the `populateMojo` method.
+     *
+     * @param configuration XML configuration node
+     * @param instance      class instance
+     */
+    public static void loadFromXml(Xpp3Dom configuration, Object instance) {
+        getAllFields(instance.getClass()).forEach(field -> {
+            Parameter annotation = field.getAnnotation(Parameter.class);
+            if (annotation == null) {
+                return;
+            }
+
+            String property = annotation.property().isEmpty() ? field.getName() : annotation.property();
+            String alias = annotation.alias();
+            Xpp3Dom element = configuration.getChild(property);
+            if (element == null && alias != null) {
+                element = configuration.getChild(alias);
+            }
+            if (element == null) {
+                return;
+            }
+
+            field.setAccessible(true);
+
+            if (element.getChildCount() == 0) {
+                // Now we've found the value, so we need to convert it, and inject it into field of a corresponding class.
+                injectValueToField(element, instance, field);
+                return;
+            }
+
+            if (List.class.isAssignableFrom(field.getType())) {
+                ParameterizedType listType = (ParameterizedType) field.getGenericType();
+                Class<?> listElementType = (Class<?>) listType.getActualTypeArguments()[0];
+
+                ArrayList<Object> list = new ArrayList<>();
+                Arrays.stream(element.getChildren()).forEach(entry -> {
+                    list.add(convertFromString(listElementType, entry.getValue()));
+                });
+                setFieldValue(instance, field, list);
+            } else if (Map.class.isAssignableFrom(field.getType())) {
+                ParameterizedType mapType = (ParameterizedType) field.getGenericType();
+                Class<?> mapKeyType = (Class<?>) mapType.getActualTypeArguments()[0];
+                Class<?> mapValueType = (Class<?>) mapType.getActualTypeArguments()[1];
+
+                HashMap<Object, Object> map = new HashMap<>();
+                Arrays.stream(element.getChildren()).forEach(entry -> {
+                    map.put(convertFromString(mapKeyType, entry.getName()),
+                            convertFromString(mapValueType, entry.getValue()));
+                });
+                setFieldValue(instance, field, map);
+            } else {
+                // This is probably a complex type, so we should try going in recursively.
+                try {
+                    Object nested = field.getType().getConstructor().newInstance();
+                    loadFromXml(element, nested);
+                    setFieldValue(instance, field, nested);
+                } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                         NoSuchMethodException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+
+    /**
+     * Sets a field in a given instance to a given value
+     *
+     * @param instance target instance
+     * @param field    field of instance class
+     * @param value    value to be set
+     */
+    public static void setFieldValue(Object instance, Field field, Object value) {
+        try {
+            field.set(instance, value);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * A utility method that consumes a string and returns an object of a given class.
+     *
+     * @param targetType class for resulting object
+     * @param text       string content
+     * @return resulting object
+     */
+    public static Object convertFromString(Class<?> targetType, String text) {
+        // Yes, we are using java.beans utility classes here.
+        PropertyEditor editor = PropertyEditorManager.findEditor(targetType);
+        if (editor == null) {
+            if (File.class.isAssignableFrom(targetType)) {
+                return Paths.get(text).toFile();
+            }
+            if (Path.class.isAssignableFrom(targetType)) {
+                return Paths.get(text);
+            }
+            if (URL.class.isAssignableFrom(targetType)) {
+                try {
+                    return new URL(text);
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return null;
+        }
+        editor.setAsText(text);
+        return editor.getValue();
+    }
+
+    /**
+     * Given XML element, instance and its field, injects converted value into field.
+     *
+     * @param element  XML node containing string
+     * @param instance object of that class
+     * @param field    field in
+     */
+    public static void injectValueToField(Xpp3Dom element, Object instance, Field field) {
+        field.setAccessible(true);
+        Object parsed = convertFromString(field.getType(), element.getValue());
+        if (parsed != null) {
+            setFieldValue(instance, field, parsed);
+        }
+    }
+
+    private static List<Field> getAllFields(Class<?> target) {
+        List<Field> fields = new ArrayList<>();
+        Class<?> clazz = target;
+        while (clazz != Object.class) {
+            fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
+            clazz = clazz.getSuperclass();
+        }
+        return fields;
+    }
+
+    public static void debugPrint(Object instance) {
+        System.out.println("IN HERE " + instance.getClass().getCanonicalName());
+        getAllFields(instance.getClass()).forEach(field -> {
+            System.out.println("GET FIELD: " + field.getName());
+            Parameter annotation = field.getAnnotation(Parameter.class);
+            if (annotation == null) {
+                System.out.println("skipped" + field.getAnnotations().length);
+                Arrays.stream(field.getAnnotations()).forEach(System.out::println);
+                return;
+            }
+            try {
+                System.out.println(field.getName() + ": " + field.get(instance));
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+}

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/agent/AgentConfiguration.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/agent/AgentConfiguration.java
@@ -1,0 +1,51 @@
+package org.graalvm.buildtools.maven.config.agent;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.util.List;
+
+public class AgentConfiguration {
+    @Parameter(property = "enabled", defaultValue = "false")
+    protected boolean enabled;
+
+    @Parameter(property = "defaultMode", defaultValue = "standard")
+    protected String defaultMode;
+
+    @Parameter(property = "disabledPhases")
+    protected List<String> disabledPhases;
+
+    @Parameter(property = "modes")
+    protected AgentModeConfiguration modes;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getDefaultMode() {
+        return defaultMode;
+    }
+
+    public void setDefaultMode(String defaultMode) {
+        this.defaultMode = defaultMode;
+    }
+
+    public List<String> getDisabledPhases() {
+        return disabledPhases;
+    }
+
+    public void setDisabledPhases(List<String> disabledPhases) {
+        this.disabledPhases = disabledPhases;
+    }
+
+    public AgentModeConfiguration getModes() {
+        return modes;
+    }
+
+    public void setModes(AgentModeConfiguration modes) {
+        this.modes = modes;
+    }
+}

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/agent/AgentModeConfiguration.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/agent/AgentModeConfiguration.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, 2022 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.maven.config.agent;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+public class AgentModeConfiguration {
+    @Parameter(property = "standard")
+    protected StandardAgentModeConfiguration standard;
+
+    @Parameter(property = "conditional")
+    protected ConditionalAgentModeConfiguration conditional;
+
+    @Parameter(property = "direct")
+    protected DirectAgentModeConfiguration direct;
+
+    public StandardAgentModeConfiguration getStandard() {
+        return standard;
+    }
+
+    public void setStandard(StandardAgentModeConfiguration standard) {
+        this.standard = standard;
+    }
+
+    public ConditionalAgentModeConfiguration getConditional() {
+        return conditional;
+    }
+
+    public void setConditional(ConditionalAgentModeConfiguration conditional) {
+        this.conditional = conditional;
+    }
+
+    public DirectAgentModeConfiguration getDirect() {
+        return direct;
+    }
+
+    public void setDirect(DirectAgentModeConfiguration direct) {
+        this.direct = direct;
+    }
+}

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/agent/ConditionalAgentModeConfiguration.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/agent/ConditionalAgentModeConfiguration.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, 2022 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.maven.config.agent;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+public class ConditionalAgentModeConfiguration {
+    @Parameter(property = "userCodeFilterPath")
+    protected String userCodeFilterPath;
+
+    @Parameter(property = "extraFilterPath")
+    protected String extraFilterPath;
+
+    @Parameter(property = "parallel")
+    protected Boolean parallel; // TODO: Check if this is needed!
+
+    public String getUserCodeFilterPath() {
+        return userCodeFilterPath;
+    }
+
+    public void setUserCodeFilterPath(String userCodeFilterPath) {
+        this.userCodeFilterPath = userCodeFilterPath;
+    }
+
+    public String getExtraFilterPath() {
+        return extraFilterPath;
+    }
+
+    public void setExtraFilterPath(String extraFilterPath) {
+        this.extraFilterPath = extraFilterPath;
+    }
+
+    public Boolean getParallel() {
+        return parallel;
+    }
+
+    public void setParallel(Boolean parallel) {
+        this.parallel = parallel;
+    }
+}

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/agent/DirectAgentModeConfiguration.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/agent/DirectAgentModeConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, 2022 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.maven.config.agent;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.util.List;
+
+public class DirectAgentModeConfiguration {
+    @Parameter(property = "options")
+    protected List<String> options;
+
+    public List<String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(List<String> options) {
+        this.options = options;
+    }
+}

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/agent/StandardAgentModeConfiguration.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/agent/StandardAgentModeConfiguration.java
@@ -1,0 +1,4 @@
+package org.graalvm.buildtools.maven.config.agent;
+
+public class StandardAgentModeConfiguration {
+}

--- a/samples/java-application-with-reflection/pom.xml
+++ b/samples/java-application-with-reflection/pom.xml
@@ -146,19 +146,10 @@
                                 <!-- end::native-plugin-agent-options[] -->
                                 <enabled>true</enabled>
                                 <!-- tag::native-plugin-agent-options[] -->
-                                <options><!-- shared options -->
-                                    <option>experimental-class-loader-support</option>
-                                </options>
-                                <options name="main"><!-- main options -->
-                                    <option>access-filter-file=${basedir}/src/main/resources/access-filter.json</option>
-                                </options>
-                                <options name="test"><!-- test options -->
-                                    <option>access-filter-file=${basedir}/src/test/resources/access-filter.json</option>
-                                </options>
-                                <options name="periodic-config"><!-- periodic-config options -->
-                                    <option>config-write-period-secs=30</option>
-                                    <option>config-write-initial-delay-secs=5</option>
-                                </options>
+                                <defaultMode>standard</defaultMode>
+                                <disabledPhases>
+                                    <phase>test</phase>
+                                </disabledPhases>
                             </agent>
                         </configuration>
                         <!-- end::native-plugin-agent-options[] -->


### PR DESCRIPTION
This draft PR is a result of many of my attempts at getting Maven to bind values from `pom.xml` to the Mojo `@Parameter` annotated fields while `NativeExtension` is being run.

Currently, the only way to access configuration values during extension time is to manually traverse the DOM tree. I strongly believe that this approach is fundamentally wrong and that there should be a better way - a 2 way binding between Mojo fields that are annotated as `@Parameter` and a corresponding `String` value that is loaded from the effective `pom.xml`. IMO this was a prerequisite for #260 since the shear amount of nested parameters would soon become unmanageable.

I tried to look up a way to utilize existing Maven internal code, however I was unable to decouple the parameter binding logic from the rest of the code. This effectively means that the only way forward is to reinvent the wheel.

My original idea then was to reflecively introspect the Mojos in order to lookup `Parameter` annotations and then use them to bind values from the plugin's `configuration` block to the Mojo fields. Unfortunately this doesn't work since `Retention` parameter of the `@Parameter` annotation is set to `RetentionPolicy.CLASS`...

Unfortunately this leaves only the hard way: simulate what Maven does by doing the following steps:
- Parse `PluginDescriptor` and get a ParameterMap.
- Find all fields in the given Mojo, making sure that `private` fields are included
- Try binding entries in the parameter map to the Mojo class fields
- Try binding `configuration` entries to the PluginDescriptor
- Try converting String values from the configuration to the target type

The last point is problematic since annotated types can be generics, or even classes with nested parameters. In the `ExtensionTimeConfigurationUtility` you can find my attempt at tackling this without external dependencies.

This is where I have ran out of time. This was a much bigger challenge than I originally anticipated.
IMO if somebody decides to properly solve this issue, the code for it should definitely be published as a standalone dependency (as opposed to some utility package in this plugin) as many plugins could benefit from it.

With this experience, as a path forward for solving #260 I suggest extracting `maven/config/agent` classes, integrating them into that new PR as dummy values, and proceeding to parse XML by hand. That is exactly what I wanted to avoid, but it is the only way to deliver this feature in real time (unless some Maven wizard creates some way to do what I attempted to implement). 
After fetching the values, following things should be done:
- Use `AgentConfiguration.getAgentCommandLine` in the `NativeExtension` in order to configure the agent invocation.
- Configure Mojos for merging generated metadata.
- Add a Mojo that copies the resulting metadata (say `mvn native:metadataCopy`).

None of these should be particularly difficult.

cc: @sdeleuze @alvarosanchez 