### PR TITLE
Add .sdkmanrc

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=22.2.r11-grl


### PR DESCRIPTION
This commit adds a `.sdkmanrc` file to the root of the project so that users of https://sdkman.io/ don't need to remember to switch VMs when working on the project.