### PR TITLE
Include buildtool support for bundling reachability metadata into jar files

### DIFF
--- a/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/internal/FileSystemRepository.java
+++ b/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/internal/FileSystemRepository.java
@@ -112,7 +112,7 @@ public class FileSystemRepository implements GraalVMReachabilityMetadataReposito
                                 Optional<DirectoryConfiguration> configuration = index.findConfiguration(groupId, artifactId, version);
                                 if (!configuration.isPresent() && artifactQuery.isUseLatestVersion()) {
                                     logger.log(groupId, artifactId, version, "Configuration directory not found. Trying latest version.");
-                                    configuration = index.findLatestConfigurationFor(groupId, artifactId);
+                                    configuration = index.findLatestConfigurationFor(groupId, artifactId, version);
                                     if (!configuration.isPresent()) {
                                         logger.log(groupId, artifactId, version, "Latest version not found!");
                                     }

--- a/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/internal/index/artifacts/SingleModuleJsonVersionToConfigDirectoryIndex.java
+++ b/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/internal/index/artifacts/SingleModuleJsonVersionToConfigDirectoryIndex.java
@@ -91,7 +91,13 @@ public class SingleModuleJsonVersionToConfigDirectoryIndex implements VersionToC
      */
     @Override
     public Optional<DirectoryConfiguration> findConfiguration(String groupId, String artifactId, String version) {
-        return findConfigurationFor(groupId, artifactId, artifact -> artifact.getVersions().contains(version));
+        return findConfigurationFor(groupId, artifactId, version, artifact -> artifact.getVersions().contains(version));
+    }
+
+    @Override
+    @Deprecated
+    public Optional<DirectoryConfiguration> findLatestConfigurationFor(String groupId, String artifactId) {
+        return findConfigurationFor(groupId, artifactId, null, Artifact::isLatest);
     }
 
     /**
@@ -102,11 +108,12 @@ public class SingleModuleJsonVersionToConfigDirectoryIndex implements VersionToC
      * @return a configuration directory, or empty if no configuration directory is available
      */
     @Override
-    public Optional<DirectoryConfiguration> findLatestConfigurationFor(String groupId, String artifactId) {
-        return findConfigurationFor(groupId, artifactId, Artifact::isLatest);
+    public Optional<DirectoryConfiguration> findLatestConfigurationFor(String groupId, String artifactId, String version) {
+        return findConfigurationFor(groupId, artifactId, version, Artifact::isLatest);
     }
 
-    private Optional<DirectoryConfiguration> findConfigurationFor(String groupId, String artifactId, Predicate<? super Artifact> predicate) {
+    private Optional<DirectoryConfiguration> findConfigurationFor(String groupId, String artifactId, String version,
+            Predicate<? super Artifact> predicate) {
         String module = groupId + ":" + artifactId;
         List<Artifact> artifacts = index.get(module);
         if (artifacts == null) {
@@ -116,7 +123,8 @@ public class SingleModuleJsonVersionToConfigDirectoryIndex implements VersionToC
                 .filter(artifact -> artifact.getModule().equals(module))
                 .filter(predicate)
                 .findFirst()
-                .map(artifact -> new DirectoryConfiguration(moduleRoot.resolve(artifact.getDirectory()), artifact.isOverride()));
+                .map(artifact -> new DirectoryConfiguration(groupId, artifactId, version,
+                        moduleRoot.resolve(artifact.getDirectory()), artifact.isOverride()));
     }
 
 }

--- a/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/internal/index/artifacts/VersionToConfigDirectoryIndex.java
+++ b/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/internal/index/artifacts/VersionToConfigDirectoryIndex.java
@@ -60,6 +60,17 @@ public interface VersionToConfigDirectoryIndex {
      * @param groupId the group ID of the artifact
      * @param artifactId the artifact ID of the artifact
      * @return a configuration, or empty if no configuration directory is available
+     * @deprecated in favor of {@link #findLatestConfigurationFor(String, String, String)}
      */
+    @Deprecated
     Optional<DirectoryConfiguration> findLatestConfigurationFor(String groupId, String artifactId);
+
+    /**
+     * Returns the latest configuration for the requested artifact.
+     * @param groupId the group ID of the artifact
+     * @param artifactId the artifact ID of the artifact
+     * @param version the version of the artifact
+     * @return a configuration, or empty if no configuration directory is available
+     */
+    Optional<DirectoryConfiguration> findLatestConfigurationFor(String groupId, String artifactId, String version);
 }

--- a/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/DirectoryConfigurationTest.java
+++ b/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/DirectoryConfigurationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.reachability;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DirectoryConfigurationTest {
+
+    @TempDir
+    Path temp;
+
+    @Test
+    void copyCopiesFiles() throws IOException {
+        Path directory = temp.resolve("source/com.example.group/artifact/123");
+        Path target = temp.resolve("target");
+        createJsonFiles(directory);
+        DirectoryConfiguration configuration = new DirectoryConfiguration("com.example.group", "artifact", "123", directory, false);
+        DirectoryConfiguration.copy(Arrays.asList(configuration), target);
+        assertTrue(Files.exists(target.resolve("META-INF/native-image/com.example.group/artifact/123/reflect-config.json")));
+        assertTrue(Files.exists(target.resolve("META-INF/native-image/com.example.group/artifact/123/other.json")));
+        assertFalse(Files.exists(target.resolve("META-INF/native-image/com.example.group/artifact/123/index.json")));
+        assertFalse(Files.exists(target.resolve("META-INF/native-image/com.example.group/artifact/123/reachability-metadata.properties")));
+    }
+
+    @Test
+    void copyWhenHasOverrideGeneratesMetadataRepositoryProperties() throws IOException {
+        Path directory = temp.resolve("source/com.example.group/artifact/123");
+        Path target = temp.resolve("target");
+        createJsonFiles(directory);
+        DirectoryConfiguration configuration = new DirectoryConfiguration("com.example.group", "artifact", "123", directory, true);
+        DirectoryConfiguration.copy(Arrays.asList(configuration), target);
+        Path propertiesFile = target.resolve("META-INF/native-image/com.example.group/artifact/123/reachability-metadata.properties");
+        Properties properties = new Properties();
+        properties.load(new FileInputStream(propertiesFile.toFile()));
+        assertEquals("true", properties.getProperty("override"));
+    }
+
+    private void createJsonFiles(Path directory) throws IOException {
+        Files.createDirectories(directory);
+        byte[] json = "{}".getBytes();
+        Files.copy(new ByteArrayInputStream(json), directory.resolve("index.json"));
+        Files.copy(new ByteArrayInputStream(json), directory.resolve("reflect-config.json"));
+        Files.copy(new ByteArrayInputStream(json), directory.resolve("other.json"));
+    }
+
+}

--- a/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/internal/index/artifacts/SingleModuleJsonVersionToConfigDirectoryIndexTest.java
+++ b/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/internal/index/artifacts/SingleModuleJsonVersionToConfigDirectoryIndexTest.java
@@ -88,7 +88,7 @@ class SingleModuleJsonVersionToConfigDirectoryIndexTest {
         config = index.findConfiguration("com.foo", "nope", "1.0");
         assertFalse(config.isPresent());
 
-        Optional<DirectoryConfiguration> latest = index.findLatestConfigurationFor("com.foo", "bar");
+        Optional<DirectoryConfiguration> latest = index.findLatestConfigurationFor("com.foo", "bar", "123");
         assertTrue(latest.isPresent());
         assertEquals(repoPath.resolve("2.0"), latest.get().getDirectory());
         assertTrue(latest.get().isOverride());

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -411,6 +411,32 @@ include::../snippets/gradle/groovy/build.gradle[tags=specify-metadata-version-fo
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=specify-metadata-version-for-library]
 ----
 
+=== Including metadata repository files
+
+By default, reachability metadata will be used only when your native image is generated.
+In some situations, you may want a copy of the reachability metadata to use directly.
+
+For example, copying the reachability metadata into your jar can be useful when some other process is responsible for converting your jar into a native image.
+You might be generating a shaded jar and using a https://paketo.io/[Paketo buildpack] to convert it to a native image.
+
+To download a copy of the metadata into the `build/native-reachability-metadata` directory you can the `collectReachabilityMetadata` task.
+Files will be downloaded into `META-INF/native-image/<groupId>/<versionId>` subdirectories.
+
+To include metadata repository inside your jar you can link to the task using the `jar` DSL `from` directive:
+
+.Including metadata repository files
+[source, groovy, role="multi-language-sample"]
+----
+include::../snippets/gradle/groovy/build.gradle[tags=include-metadata]
+----
+
+[source, kotlin, role="multi-language-sample"]
+----
+include::../snippets/gradle/kotlin/build.gradle.kts[tags=include-metadata]
+----
+
+For more advanced configurations you can declare a `org.graalvm.buildtools.gradle.tasks.CollectReachabilityMetadata` task and set the appropriate properties.
+
 [[plugin-configurations]]
 == Configurations defined by the plugin
 

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -660,6 +660,23 @@ This may be interesting if there's no specific metadata available for the partic
 include::../../../../samples/native-config-integration/pom.xml[tag=metadata-force-version]
 ----
 
+=== Adding metadata respoistory files
+
+By default, repository metadata will be used only when your native image is generated.
+In some situations, you may want to include the metadata directly inside your jar.
+
+Adding metadata to your jar can be useful when some other process is responsible for converting your jar into a native image.
+For example, you might be generating a shaded jar and using a https://paketo.io/[Paketo buildpack] to convert it to a native image.
+
+To include metadata repository inside your jar you can use the `add-reachability-metadata` goal.
+Typically the goal will be included in an execution step where by default it will be bound to the `generate-resources` phase:
+
+.Configuring the `add-reachability-metadata` goal to execute with the `generate-resources` phase
+[source,xml,indent=0]
+----
+include::../../../../samples/native-config-integration/pom.xml[tag=add-reachability-metadata-execution]
+----
+
 [[javadocs]]
 == Javadocs
 

--- a/docs/src/docs/snippets/gradle/groovy/build.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/build.gradle
@@ -207,3 +207,9 @@ graalvmNative {
     }
 }
 // end::specify-metadata-version-for-library[]
+
+// tag::include-metadata[]
+tasks.named("jar") {
+    from collectReachabilityMetadata
+}
+// end::include-metadata[]

--- a/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
+++ b/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
@@ -221,3 +221,9 @@ graalvmNative {
     }
 }
 // end::specify-metadata-version-for-library[]
+
+// tag::include-metadata[]
+tasks.named("jar", Jar) {
+	from(collectReachabilityMetadata)
+}
+// end::include-metadata[]

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadata.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadata.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.gradle.tasks;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.graalvm.buildtools.gradle.internal.GraalVMReachabilityMetadataService;
+import org.graalvm.reachability.DirectoryConfiguration;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+public abstract class CollectReachabilityMetadata extends DefaultTask {
+
+    private Configuration classpath;
+
+    /**
+     * The classpath for which the metadata should be copied.
+     * @return the classpath to use
+     */
+    @Classpath
+    @Optional
+    public Configuration getClasspath() {
+        return classpath;
+    }
+
+    public void setClasspath(Configuration classpath) {
+        this.classpath = classpath;
+    }
+
+    @Internal
+    public abstract Property<GraalVMReachabilityMetadataService> getMetadataService();
+
+    /**
+     * A URI pointing to a GraalVM reachability metadata repository. This must
+     * either be a local file or a remote URI. In case of remote
+     * files, only zip or tarballs are supported.
+     * @return the uri property
+     */
+    @Input
+    @Optional
+    public abstract Property<URI> getUri();
+
+    /**
+     * An optional version of the remote repository: if specified,
+     * and that no URI is provided, it will automatically use a
+     * published repository from the official GraalVM reachability
+     * metadata repository.
+     *
+     * @return the version of the repository to use
+     */
+    @Input
+    @Optional
+    public abstract Property<String> getVersion();
+
+    /**
+     * The set of modules for which we don't want to use the
+     * configuration found in the repository. Modules must be
+     * declared with the `groupId:artifactId` syntax.
+     *
+     * @return the set of excluded modules
+     */
+    @Input
+    @Optional
+    public abstract SetProperty<String> getExcludedModules();
+
+    /**
+     * A map from a module (org.group:artifact) to configuration
+     * repository config version.
+     *
+     * @return the map of modules to forced configuration versions
+     */
+    @Input
+    @Optional
+    public abstract MapProperty<String, String> getModuleToConfigVersion();
+
+    @OutputDirectory
+    @Optional
+    public abstract DirectoryProperty getInto();
+
+    @TaskAction
+    void copyReachabilityMetadata() throws IOException {
+        GraalVMReachabilityMetadataService service = getMetadataService().get();
+        Configuration classpath = (this.classpath != null) ? this.classpath
+                : getProject().getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+        Objects.requireNonNull(classpath);
+        Set<String> excludedModules = getExcludedModules().getOrElse(Collections.emptySet());
+        Map<String, String> forcedVersions = getModuleToConfigVersion().getOrElse(Collections.emptyMap());
+        for (ResolvedComponentResult component : classpath.getIncoming().getResolutionResult().getAllComponents()) {
+            ModuleVersionIdentifier moduleVersion = component.getModuleVersion();
+            Set<DirectoryConfiguration> configurations = service.findConfigurationsFor(excludedModules, forcedVersions, moduleVersion);
+            DirectoryConfiguration.copy(configurations, getInto().get().getAsFile().toPath());
+        }
+    }
+
+}

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
@@ -175,4 +175,23 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         outputContains "Failed to download from https://httpstat.us/404: 404 Not Found"
     }
 
+    void "it can include hints in jar"() {
+        given:
+        withSample("native-config-integration")
+
+        when:
+        mvn '-X', '-PaddMetadataHints', '-DskipTests', 'package'
+
+        then:
+        buildSucceeded
+
+        and:
+        file("target/classes/META-INF/native-image/org.graalvm.internal/library-with-reflection/1.5/reflect-config.json").text.trim() == '''[
+  {
+    "name": "org.graalvm.internal.reflect.Message",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  }
+]'''
+    }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.toolchain.ToolchainManager;
+import org.graalvm.buildtools.Utils;
+import org.graalvm.buildtools.maven.config.ExcludeConfigConfiguration;
+import org.graalvm.buildtools.utils.NativeImageUtils;
+import org.graalvm.buildtools.utils.SharedConstants;
+
+/**
+ * @author Sebastien Deleuze
+ */
+public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
+    protected static final String NATIVE_IMAGE_META_INF = "META-INF/native-image";
+    protected static final String NATIVE_IMAGE_PROPERTIES_FILENAME = "native-image.properties";
+    protected static final String NATIVE_IMAGE_DRY_RUN = "nativeDryRun";
+
+    @Parameter(defaultValue = "${plugin}", readonly = true) // Maven 3 only
+    protected PluginDescriptor plugin;
+
+    @Parameter(defaultValue = "${session}", readonly = true)
+    protected MavenSession session;
+
+    @Parameter(defaultValue = "${mojoExecution}")
+    protected MojoExecution mojoExecution;
+
+    @Parameter(property = "plugin.artifacts", required = true, readonly = true)
+    protected List<Artifact> pluginArtifacts;
+
+    @Parameter(defaultValue = "${project.build.directory}", property = "outputDir", required = true)
+    protected File outputDirectory;
+
+    @Parameter(property = "mainClass")
+    protected String mainClass;
+
+    @Parameter(property = "imageName", defaultValue = "${project.artifactId}")
+    protected String imageName;
+
+    @Parameter(property = "classpath")
+    protected List<String> classpath;
+
+    @Parameter(property = "classesDirectory")
+    protected File classesDirectory;
+
+    @Parameter(defaultValue = "${project.build.outputDirectory}", readonly = true, required = true)
+    protected File defaultClassesDirectory;
+
+    protected final List<Path> imageClasspath;
+
+    @Parameter(property = "debug", defaultValue = "false")
+    protected boolean debug;
+
+    @Parameter(property = "fallback", defaultValue = "false")
+    protected boolean fallback;
+
+    @Parameter(property = "verbose", defaultValue = "false")
+    protected boolean verbose;
+
+    @Parameter(property = "sharedLibrary", defaultValue = "false")
+    protected boolean sharedLibrary;
+
+    @Parameter(property = "quickBuild", defaultValue = "false")
+    protected boolean quickBuild;
+
+    @Parameter(property = "useArgFile")
+    protected Boolean useArgFile;
+
+    @Parameter(property = "buildArgs")
+    protected List<String> buildArgs;
+
+    @Parameter(defaultValue = "${project.build.directory}/native/generated", property = "resourcesConfigDirectory", required = true)
+    protected File resourcesConfigDirectory;
+
+    @Parameter(property = "agentResourceDirectory")
+    protected File agentResourceDirectory;
+
+    @Parameter(property = "excludeConfig")
+    protected List<ExcludeConfigConfiguration> excludeConfig;
+
+    @Parameter(property = "environmentVariables")
+    protected Map<String, String> environment;
+
+    @Parameter(property = "systemPropertyVariables")
+    protected Map<String, String> systemProperties;
+
+    @Parameter(property = "configurationFileDirectories")
+    protected List<String> configFiles;
+
+    @Parameter(property = "jvmArgs")
+    protected List<String> jvmArgs;
+
+    @Parameter(property = NATIVE_IMAGE_DRY_RUN, defaultValue = "false")
+    protected boolean dryRun;
+
+    @Component
+    protected ToolchainManager toolchainManager;
+
+    @Inject
+    protected AbstractNativeImageMojo() {
+        imageClasspath = new ArrayList<>();
+        useArgFile = SharedConstants.IS_WINDOWS;
+    }
+
+    protected List<String> getBuildArgs() throws MojoExecutionException {
+        final List<String> cliArgs = new ArrayList<>();
+
+        if (excludeConfig != null) {
+            excludeConfig.forEach(entry -> {
+                cliArgs.add("--exclude-config");
+                cliArgs.add(entry.getJarPath());
+                cliArgs.add(String.format("\"%s\"", entry.getResourcePattern()));
+            });
+        }
+
+        cliArgs.add("-cp");
+        cliArgs.add(getClasspath());
+
+        if (debug) {
+            cliArgs.add("-g");
+        }
+        if (!fallback) {
+            cliArgs.add("--no-fallback");
+        }
+        if (verbose) {
+            cliArgs.add("--verbose");
+        }
+        if (sharedLibrary) {
+            cliArgs.add("--shared");
+        }
+
+        // Let's allow user to specify environment option to toggle quick build.
+        String quickBuildEnv = System.getenv("GRAALVM_QUICK_BUILD");
+        if (quickBuildEnv != null) {
+            logger.warn("Quick build environment variable is set.");
+            quickBuild = quickBuildEnv.isEmpty() || Boolean.parseBoolean(quickBuildEnv);
+        }
+
+        if (quickBuild) {
+            cliArgs.add("-Ob");
+        }
+
+        cliArgs.add("-H:Path=" + outputDirectory.toPath().toAbsolutePath());
+        cliArgs.add("-H:Name=" + imageName);
+
+        if (systemProperties != null) {
+            for (Map.Entry<String, String> entry : systemProperties.entrySet()) {
+                cliArgs.add("-D" + entry.getKey() + "=" + entry.getValue());
+            }
+        }
+
+        if (jvmArgs != null) {
+            jvmArgs.forEach(jvmArg -> cliArgs.add("-J" + jvmArg));
+        }
+
+        maybeAddGeneratedResourcesConfig(buildArgs);
+        maybeAddReachabilityMetadata(configFiles);
+
+        if (configFiles != null && !configFiles.isEmpty()) {
+            cliArgs.add("-H:ConfigurationFileDirectories=" +
+                    configFiles.stream()
+                    .map(Paths::get)
+                    .map(Path::toAbsolutePath)
+                    .map(Path::toString)
+                    .collect(Collectors.joining(","))
+            );
+        }
+
+        if (mainClass != null && !mainClass.equals(".")) {
+            cliArgs.add("-H:Class=" + mainClass);
+        }
+
+        if (buildArgs != null && !buildArgs.isEmpty()) {
+            for (String buildArg : buildArgs) {
+                cliArgs.addAll(Arrays.asList(buildArg.split("\\s+")));
+            }
+        }
+
+        if (useArgFile) {
+            Path tmpDir = Paths.get("target", "tmp");
+            return NativeImageUtils.convertToArgsFile(cliArgs, tmpDir);
+        }
+        return Collections.unmodifiableList(cliArgs);
+    }
+
+    protected Path processSupportedArtifacts(Artifact artifact) throws MojoExecutionException {
+        return processArtifact(artifact, "jar", "test-jar", "war");
+    }
+
+    protected Path processArtifact(Artifact artifact, String... artifactTypes) throws MojoExecutionException {
+        File artifactFile = artifact.getFile();
+
+        if (artifactFile == null) {
+            logger.debug("Missing artifact file for artifact " + artifact + " (type: " + artifact.getType() + ")");
+            return null;
+        }
+
+        if (Arrays.stream(artifactTypes).noneMatch(a -> a.equals(artifact.getType()))) {
+            logger.warn("Ignoring ImageClasspath Entry '" + artifact + "' with unsupported type '" + artifact.getType() + "'");
+            return null;
+        }
+        if (!artifactFile.exists()) {
+            throw new MojoExecutionException("Missing jar-file for " + artifact + ". " +
+                    "Ensure that " + plugin.getArtifactId() + " runs in package phase.");
+        }
+
+        Path jarFilePath = artifactFile.toPath();
+        logger.debug("ImageClasspath Entry: " + artifact + " (" + jarFilePath.toUri() + ")");
+
+        warnIfWrongMetaInfLayout(jarFilePath, artifact);
+        return jarFilePath;
+    }
+
+    protected void addArtifactToClasspath(Artifact artifact) throws MojoExecutionException {
+        Optional.ofNullable(processSupportedArtifacts(artifact)).ifPresent(imageClasspath::add);
+    }
+
+    protected void warnIfWrongMetaInfLayout(Path jarFilePath, Artifact artifact) throws MojoExecutionException {
+        if (jarFilePath.toFile().isDirectory()) {
+            logger.debug("Artifact `" + jarFilePath + "` is a directory.");
+            return;
+        }
+        URI jarFileURI = URI.create("jar:" + jarFilePath.toUri());
+        try (FileSystem jarFS = FileSystems.newFileSystem(jarFileURI, Collections.emptyMap())) {
+            Path nativeImageMetaInfBase = jarFS.getPath("/" + NATIVE_IMAGE_META_INF);
+            if (Files.isDirectory(nativeImageMetaInfBase)) {
+                try (Stream<Path> stream = Files.walk(nativeImageMetaInfBase)) {
+                    List<Path> nativeImageProperties = stream
+                            .filter(p -> p.endsWith(NATIVE_IMAGE_PROPERTIES_FILENAME)).collect(Collectors.toList());
+                    for (Path nativeImageProperty : nativeImageProperties) {
+                        Path relativeSubDir = nativeImageMetaInfBase.relativize(nativeImageProperty).getParent();
+                        boolean valid = relativeSubDir != null && (relativeSubDir.getNameCount() == 2);
+                        valid = valid && relativeSubDir.getName(0).toString().equals(artifact.getGroupId());
+                        valid = valid && relativeSubDir.getName(1).toString().equals(artifact.getArtifactId());
+                        if (!valid) {
+                            String example = NATIVE_IMAGE_META_INF + "/%s/%s/" + NATIVE_IMAGE_PROPERTIES_FILENAME;
+                            example = String.format(example, artifact.getGroupId(), artifact.getArtifactId());
+                            logger.warn("Properties file at '" + nativeImageProperty.toUri() + "' does not match the recommended '" + example + "' layout.");
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new MojoExecutionException("Artifact " + artifact + "cannot be added to image classpath", e);
+        }
+    }
+
+    protected abstract List<String> getDependencyScopes();
+
+    protected void addDependenciesToClasspath() throws MojoExecutionException {
+        configureMetadataRepository();
+        for (Artifact dependency : project.getArtifacts().stream()
+                .filter(artifact -> getDependencyScopes().contains(artifact.getScope()))
+                .collect(Collectors.toSet())) {
+            addArtifactToClasspath(dependency);
+            maybeAddDependencyMetadata(dependency, file -> {
+                buildArgs.add("--exclude-config");
+                buildArgs.add(Pattern.quote(dependency.getFile().getAbsolutePath()));
+                buildArgs.add("^/META-INF/native-image/");
+            });
+        }
+    }
+
+    /**
+     * Returns path to where application classes are stored, or jar artifact if it is produced.
+     * @return Path to application classes
+     * @throws MojoExecutionException failed getting main build path
+     */
+    protected Path getMainBuildPath() throws MojoExecutionException {
+        if (classesDirectory != null) {
+            return classesDirectory.toPath();
+        } else {
+            Path artifactPath = processArtifact(project.getArtifact(), project.getPackaging());
+            if (artifactPath != null) {
+                return artifactPath;
+            } else {
+                return defaultClassesDirectory.toPath();
+            }
+        }
+    }
+
+    protected void populateApplicationClasspath() throws MojoExecutionException {
+        imageClasspath.add(getMainBuildPath());
+    }
+
+    protected void populateClasspath() throws MojoExecutionException {
+        if (classpath != null && !classpath.isEmpty()) {
+            imageClasspath.addAll(classpath.stream()
+                    .map(Paths::get)
+                    .map(Path::toAbsolutePath)
+                    .collect(Collectors.toSet())
+            );
+        } else {
+            populateApplicationClasspath();
+            addDependenciesToClasspath();
+        }
+        imageClasspath.removeIf(entry -> !entry.toFile().exists());
+    }
+
+    protected String getClasspath() throws MojoExecutionException {
+        populateClasspath();
+        if (imageClasspath.isEmpty()) {
+            throw new MojoExecutionException("Image classpath is empty. " +
+                    "Check if your classpath configuration is correct.");
+        }
+        return imageClasspath.stream()
+                .map(Path::toString)
+                .collect(Collectors.joining(File.pathSeparator));
+    }
+
+    protected void buildImage() throws MojoExecutionException {
+        Path nativeImageExecutable = Utils.getNativeImage(logger);
+
+        try {
+            ProcessBuilder processBuilder = new ProcessBuilder(nativeImageExecutable.toString());
+            processBuilder.command().addAll(getBuildArgs());
+
+            if (environment != null) {
+                processBuilder.environment().putAll(environment);
+            }
+
+            if (!outputDirectory.exists() && !outputDirectory.mkdirs()) {
+                throw new MojoExecutionException("Failed creating output directory");
+            }
+            processBuilder.inheritIO();
+
+            String commandString = String.join(" ", processBuilder.command());
+            logger.info("Executing: " + commandString);
+
+            if (dryRun) {
+                logger.warn("Skipped native-image building due to `" + NATIVE_IMAGE_DRY_RUN + "` being specified.");
+                return;
+            }
+
+            Process imageBuildProcess = processBuilder.start();
+            if (imageBuildProcess.waitFor() != 0) {
+                throw new MojoExecutionException("Execution of " + commandString + " returned non-zero result");
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new MojoExecutionException("Building image with " + nativeImageExecutable + " failed", e);
+        }
+    }
+
+    protected void maybeAddGeneratedResourcesConfig(List<String> into) {
+        if (resourcesConfigDirectory.exists() || agentResourceDirectory != null) {
+            File[] dirs = resourcesConfigDirectory.listFiles();
+            Stream<File> configDirs =
+                    Stream.concat(dirs == null ? Stream.empty() : Arrays.stream(dirs),
+                            agentResourceDirectory == null ? Stream.empty() : Stream.of(agentResourceDirectory).filter(File::isDirectory));
+
+            String value = configDirs.map(File::getAbsolutePath).collect(Collectors.joining(","));
+            if (!value.isEmpty()) {
+                into.add("-H:ConfigurationFileDirectories=" + value);
+                if (agentResourceDirectory != null && agentResourceDirectory.isDirectory()) {
+                    // The generated reflect config file contains references to java.*
+                    // and org.apache.maven.surefire that we'd need to remove using
+                    // a proper JSON parser/writer instead
+                    into.add("-H:+AllowIncompleteClasspath");
+                }
+            }
+        }
+    }
+
+
+
+    protected void maybeAddReachabilityMetadata(List<String> configDirs) {
+        if (isMetadataRepositoryEnabled() && !metadataRepositoryConfigurations.isEmpty()) {
+            metadataRepositoryConfigurations.stream()
+                    .map(configuration -> configuration.getDirectory().toAbsolutePath())
+                    .map(Path::toFile)
+                    .map(File::getAbsolutePath)
+                    .forEach(configDirs::add);
+        }
+    }
+}

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AddReachabilityMetadataMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AddReachabilityMetadataMojo.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.graalvm.reachability.DirectoryConfiguration;
+
+@Mojo(name = "add-reachability-metadata", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, requiresDependencyResolution = ResolutionScope.RUNTIME, requiresDependencyCollection = ResolutionScope.RUNTIME)
+public class AddReachabilityMetadataMojo extends AbstractNativeMojo {
+
+    private static final Set<String> SCOPES;
+    static {
+        Set<String> scopes = new HashSet<>();
+        scopes.add(Artifact.SCOPE_COMPILE);
+        scopes.add(Artifact.SCOPE_RUNTIME);
+        scopes.add(Artifact.SCOPE_COMPILE_PLUS_RUNTIME);
+        SCOPES = Collections.unmodifiableSet(scopes);
+    }
+
+    @Parameter(defaultValue = "${project.build.outputDirectory}", required = true)
+    protected File outputDirectory;
+
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        configureMetadataRepository();
+        project.getArtifacts().stream().filter(this::isInScope)
+                .forEach(dependency -> maybeAddDependencyMetadata(dependency, null));
+        if (isMetadataRepositoryEnabled() && !metadataRepositoryConfigurations.isEmpty()) {
+            Path destination = outputDirectory.toPath();
+            try {
+                DirectoryConfiguration.copy(metadataRepositoryConfigurations, destination);
+            } catch (IOException ex) {
+                throw new MojoExecutionException(ex.getMessage(), ex);
+            }
+        }
+    }
+
+    private boolean isInScope(Artifact artifact) {
+        return SCOPES.contains(artifact.getScope());
+    }
+
+}

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeCompileNoForkMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeCompileNoForkMojo.java
@@ -66,7 +66,7 @@ import java.util.function.BiFunction;
 @Mojo(name = "compile-no-fork", defaultPhase = LifecyclePhase.PACKAGE,
         requiresDependencyResolution = ResolutionScope.RUNTIME,
         requiresDependencyCollection = ResolutionScope.RUNTIME)
-public class NativeCompileNoForkMojo extends AbstractNativeMojo {
+public class NativeCompileNoForkMojo extends AbstractNativeImageMojo {
 
     @Parameter(property = "skipNativeBuild", defaultValue = "false")
     private boolean skip;

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -76,7 +76,7 @@ import static org.graalvm.buildtools.Utils.NATIVE_TESTS_EXE;
 @Mojo(name = "test", defaultPhase = LifecyclePhase.TEST, threadSafe = true,
         requiresDependencyResolution = ResolutionScope.TEST,
         requiresDependencyCollection = ResolutionScope.TEST)
-public class NativeTestMojo extends AbstractNativeMojo {
+public class NativeTestMojo extends AbstractNativeImageMojo {
 
     @Parameter(property = "skipTests", defaultValue = "false")
     private boolean skipTests;

--- a/samples/native-config-integration/pom.xml
+++ b/samples/native-config-integration/pom.xml
@@ -359,6 +359,34 @@
             </build>
         </profile>
         <profile>
+            <id>addMetadataHints</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <configuration>
+                            <metadataRepository>
+                                <enabled>true</enabled>
+                                <localPath>${project.basedir}/config-directory</localPath> <!--1-->
+                            </metadataRepository>
+                        </configuration>
+                        <!-- tag::add-reachability-metadata-execution[] -->
+                        <executions>
+                            <execution>
+                                <id>add-reachability-metadata</id>
+                                <goals>
+                                    <goal>add-reachability-metadata</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <!-- end::add-reachability-metadata-execution[] -->
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>excludeConfigTest</id>
             <build>
                 <plugins>


### PR DESCRIPTION
I believe that this request was discussed recently with @bclozel who kindly wrote the following:

## Motivation

Currently, Native Build Tools build plugins fetch reachability metadata from the official repository right before building a native image of the application.
While the library in charge of fetching the metadata repository is available and can be reused in different contexts, there is still a non-trivial amount of code required to do the following:

* get reachability metadata for the libraries in the application classpath
* apply filtering options described in the plugin configuration

Frameworks using NBT can generate their own reachability metadata before packaging the application as a JAR.
It would be useful if vanilla or shaded JARs could be packaged with all the required reachability metadata (Framework + metadata repository) so that such JARs could be used by CI or cloud infrastructure to generate a native image directly.

This would provide the following advantages:

* the application JAR is the single source for running the application in JVM mode, or building it as a native binary
* this enables build reproducibility - without this change, building the JAR as a native binary at different times could yield different results if the shared repo has changed.

## Requested behavior

The current change proposal would require a new build tool task, for the Maven and Gradle plugins. Those tasks would:

1. Fetch the repository, collect the relevant metadata, apply filters and in general the plugin configuration related to this step
2. Write the resulting metadata to a location configurable in the plugin. By default the location should align with the build tool defaults to pack these files with the resulting JAR.
3. Be designed to be run independently of other NBT tasks
4. Be designed to be called by Framework plugins or as a task/goal directly by the developer
