### PR TITLE
Bump the default metadata repository version to 0.2.1

### DIFF
--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/SharedConstants.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/SharedConstants.java
@@ -76,5 +76,5 @@ public interface SharedConstants {
     String AGENT_OUTPUT_DIRECTORY_MARKER = "{output_dir}";
     String AGENT_OUTPUT_DIRECTORY_OPTION = "config-output-dir=";
     String METADATA_REPO_URL_TEMPLATE = "https://github.com/oracle/graalvm-reachability-metadata/releases/download/%1$s/graalvm-reachability-metadata-%1$s.zip";
-    String METADATA_REPO_DEFAULT_VERSION = "0.2.0";
+    String METADATA_REPO_DEFAULT_VERSION = "0.2.1";
 }


### PR DESCRIPTION
Bump the default metadata repository version to 0.2.1

Signed-off-by: David Nestorovic <david.nestorovic@oracle.com>