### PR TITLE
Rich output should also enable progress printing.

### DIFF
--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -117,6 +117,7 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         appendBooleanOption(cliArgs, options.getVerbose(), "--verbose");
         appendBooleanOption(cliArgs, options.getSharedLibrary(), "--shared");
         appendBooleanOption(cliArgs, options.getQuickBuild(), "-Ob");
+        appendBooleanOption(cliArgs, options.getRichOutput(), "-H:+BuildOutputProgress");
         appendBooleanOption(cliArgs, options.getRichOutput(), "-H:+BuildOutputColorful");
 
         if (getOutputDirectory().isPresent()) {


### PR DESCRIPTION
I think the rich output option should also enable progress printing. That's also enabled by default within Native Image and works in Maven. It's weird if it's not behaving the same way in Gradle.