### PR TITLE
Bump the metadata repository version

### DIFF
--- a/build-logic/utils-plugins/src/main/kotlin/org.graalvm.build.utils-module.gradle.kts
+++ b/build-logic/utils-plugins/src/main/kotlin/org.graalvm.build.utils-module.gradle.kts
@@ -58,6 +58,7 @@ extensions.findByType<VersionCatalogsExtension>()?.also { catalogs ->
     val libs = catalogs.named("libs")
     val generateVersionInfo = tasks.register("generateVersionInfo", org.graalvm.build.GenerateVersionClass::class.java) {
         versions.put("junitPlatformNative", libs.findVersion("nativeBuildTools").get().requiredVersion)
+        versions.put("metadataRepo", libs.findVersion("metadataRepository").get().requiredVersion)
         outputDirectory.set(layout.buildDirectory.dir("generated/sources/versions"))
     }
 

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/SharedConstants.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/SharedConstants.java
@@ -41,6 +41,8 @@
 
 package org.graalvm.buildtools.utils;
 
+import org.graalvm.buildtools.VersionInfo;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -76,5 +78,11 @@ public interface SharedConstants {
     String AGENT_OUTPUT_DIRECTORY_MARKER = "{output_dir}";
     String AGENT_OUTPUT_DIRECTORY_OPTION = "config-output-dir=";
     String METADATA_REPO_URL_TEMPLATE = "https://github.com/oracle/graalvm-reachability-metadata/releases/download/%1$s/graalvm-reachability-metadata-%1$s.zip";
-    String METADATA_REPO_DEFAULT_VERSION = "0.2.1";
+    /**
+     * The default metadata repository version. Maintained for backwards
+     * compatibility.
+     * @deprecated Please use {@link VersionInfo#METADATA_REPO_VERSION} instead
+     */
+    @Deprecated
+    String METADATA_REPO_DEFAULT_VERSION = VersionInfo.METADATA_REPO_VERSION;
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 # Project versions
 nativeBuildTools = "0.9.15-SNAPSHOT"
+metadataRepository = "0.2.2"
 
 # External dependencies
 spock = "2.1-groovy-3.0"

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -474,7 +474,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     private void configureNativeConfigurationRepo(ExtensionAware graalvmNative) {
         GraalVMReachabilityMetadataRepositoryExtension configurationRepository = graalvmNative.getExtensions().create("metadataRepository", GraalVMReachabilityMetadataRepositoryExtension.class);
         configurationRepository.getEnabled().convention(false);
-        configurationRepository.getVersion().convention(SharedConstants.METADATA_REPO_DEFAULT_VERSION);
+        configurationRepository.getVersion().convention(VersionInfo.METADATA_REPO_VERSION);
         configurationRepository.getUri().convention(configurationRepository.getVersion().map(v -> {
             try {
                 return new URI(String.format(METADATA_REPO_URL_TEMPLATE, v));

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -53,6 +53,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.logging.Logger;
 import org.graalvm.buildtools.Utils;
+import org.graalvm.buildtools.VersionInfo;
 import org.graalvm.buildtools.maven.config.ExcludeConfigConfiguration;
 import org.graalvm.buildtools.maven.config.MetadataRepositoryConfiguration;
 import org.graalvm.buildtools.utils.FileUtils;
@@ -479,7 +480,7 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
                 if (targetUrl == null) {
                     String version = metadataRepositoryConfiguration.getVersion();
                     if (version == null) {
-                        version = SharedConstants.METADATA_REPO_DEFAULT_VERSION;
+                        version = VersionInfo.METADATA_REPO_VERSION;
                     }
                     String metadataUrl = String.format(METADATA_REPO_URL_TEMPLATE, version);
                     try {


### PR DESCRIPTION
This also moves the constant to the `libs.versions.toml` file so that it is both easier to upgrade *and* available in build scripts without having to parse source files. This is going to be useful for repackaging the repository.

This supercedes #329 

@dnestoro would you mind taking a look?