### PR TITLE
Ship the GraalVM metadata repository as an artifact alongside NBT

### DIFF
--- a/build-logic/reachability-plugins/build.gradle.kts
+++ b/build-logic/reachability-plugins/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -39,14 +39,16 @@
  * SOFTWARE.
  */
 
-pluginManagement {
-    includeBuild("../../build-logic/settings-plugins")
-    includeBuild("../../build-logic/common-plugins")
-    includeBuild("../../build-logic/reachability-plugins")
-}
-
 plugins {
-    id("org.graalvm.build.common")
+    java
+    `kotlin-dsl`
 }
 
-rootProject.name = "graalvm-reachability-metadata"
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation(":common-plugins")
+}

--- a/build-logic/reachability-plugins/settings.gradle.kts
+++ b/build-logic/reachability-plugins/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -39,14 +39,14 @@
  * SOFTWARE.
  */
 
+rootProject.name = "reachability-plugins"
+
 pluginManagement {
-    includeBuild("../../build-logic/settings-plugins")
-    includeBuild("../../build-logic/common-plugins")
-    includeBuild("../../build-logic/reachability-plugins")
+    includeBuild("../settings-plugins")
 }
+
+includeBuild("../common-plugins")
 
 plugins {
     id("org.graalvm.build.common")
 }
-
-rootProject.name = "graalvm-reachability-metadata"

--- a/build-logic/reachability-plugins/src/main/java/org/graalvm/build/FetchRepositoryMetadata.java
+++ b/build-logic/reachability-plugins/src/main/java/org/graalvm/build/FetchRepositoryMetadata.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.graalvm.build;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.net.URI;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+
+@CacheableTask
+public abstract class FetchRepositoryMetadata extends DefaultTask {
+    @Input
+    public abstract Property<String> getVersion();
+
+    @Input
+    public abstract Property<String> getRepositoryUrlTemplate();
+
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDirectory();
+
+    @Inject
+    protected abstract FileSystemOperations getFileSystemOperations();
+
+    @Internal
+    public Provider<RegularFile> getOutputFile() {
+        return getOutputDirectory().file("repository.zip");
+    }
+
+    public FetchRepositoryMetadata() {
+        getOutputs().doNotCacheIf("Snapshot version", task -> getVersion().get().endsWith("-SNAPSHOT"));
+        getRepositoryUrlTemplate().convention("https://github.com/oracle/graalvm-reachability-metadata/releases/download/%1$s/graalvm-reachability-metadata-%1$s.zip");
+    }
+
+    @TaskAction
+    public void fetchMetadataRepository() {
+        String url = String.format(getRepositoryUrlTemplate().get(), getVersion().get());
+        File tmpFile = new File(getTemporaryDir(), "repository.zip");
+        try (ReadableByteChannel channel = Channels.newChannel(new URI(url).toURL().openStream())) {
+            try (FileChannel outChannel = new FileOutputStream(tmpFile).getChannel()) {
+                outChannel.transferFrom(channel, 0, Long.MAX_VALUE);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Could not download repository metadata from " + url, e);
+        }
+        getFileSystemOperations().copy(spec -> {
+            spec.from(tmpFile);
+            spec.into(getOutputDirectory());
+        });
+        tmpFile.delete();
+    }
+}

--- a/build-logic/utils-plugins/src/main/kotlin/org.graalvm.build.utils-module.gradle.kts
+++ b/build-logic/utils-plugins/src/main/kotlin/org.graalvm.build.utils-module.gradle.kts
@@ -58,6 +58,7 @@ extensions.findByType<VersionCatalogsExtension>()?.also { catalogs ->
     val libs = catalogs.named("libs")
     val generateVersionInfo = tasks.register("generateVersionInfo", org.graalvm.build.GenerateVersionClass::class.java) {
         versions.put("junitPlatformNative", libs.findVersion("nativeBuildTools").get().requiredVersion)
+        versions.put("metadataRepo", libs.findVersion("metadataRepository").get().requiredVersion)
         outputDirectory.set(layout.buildDirectory.dir("generated/sources/versions"))
     }
 

--- a/build-logic/utils-plugins/src/main/kotlin/org.graalvm.build.utils-module.gradle.kts
+++ b/build-logic/utils-plugins/src/main/kotlin/org.graalvm.build.utils-module.gradle.kts
@@ -59,6 +59,7 @@ extensions.findByType<VersionCatalogsExtension>()?.also { catalogs ->
     val generateVersionInfo = tasks.register("generateVersionInfo", org.graalvm.build.GenerateVersionClass::class.java) {
         versions.put("junitPlatformNative", libs.findVersion("nativeBuildTools").get().requiredVersion)
         versions.put("metadataRepo", libs.findVersion("metadataRepository").get().requiredVersion)
+        versions.put("nbt", libs.findVersion("nativeBuildTools").get().requiredVersion)
         outputDirectory.set(layout.buildDirectory.dir("generated/sources/versions"))
     }
 

--- a/common/graalvm-reachability-metadata/build.gradle.kts
+++ b/common/graalvm-reachability-metadata/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.graalvm.build.FetchRepositoryMetadata
+
 /*
  * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -40,9 +42,7 @@
  */
 
 plugins {
-    checkstyle
-    id("org.graalvm.build.java")
-    id("org.graalvm.build.publishing")
+    id("org.graalvm.build.reachability-module")
 }
 
 maven {
@@ -56,18 +56,6 @@ dependencies {
     testImplementation(libs.test.junit.jupiter.core)
 }
 
-tasks.withType<Test>().configureEach {
-    useJUnitPlatform()
-}
-
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
-        }
-    }
-}
-
-tasks.withType<Checkstyle>().configureEach {
-    setConfigFile(layout.projectDirectory.dir("../../config/checkstyle.xml").asFile)
+tasks.withType<FetchRepositoryMetadata>().configureEach {
+    version.set(libs.versions.metadataRepository)
 }

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/FileUtils.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/FileUtils.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -67,6 +68,13 @@ public final class FileUtils {
     }
 
     public static Optional<Path> download(URL url, Path destination, Consumer<String> errorLogger) {
+        if ("file".equals(url.getProtocol())) {
+            try {
+                return Optional.of(new java.io.File(url.toURI()).toPath());
+            } catch (URISyntaxException e) {
+                return Optional.empty();
+            }
+        }
         try {
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/SharedConstants.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/SharedConstants.java
@@ -41,6 +41,8 @@
 
 package org.graalvm.buildtools.utils;
 
+import org.graalvm.buildtools.VersionInfo;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -76,5 +78,11 @@ public interface SharedConstants {
     String AGENT_OUTPUT_DIRECTORY_MARKER = "{output_dir}";
     String AGENT_OUTPUT_DIRECTORY_OPTION = "config-output-dir=";
     String METADATA_REPO_URL_TEMPLATE = "https://github.com/oracle/graalvm-reachability-metadata/releases/download/%1$s/graalvm-reachability-metadata-%1$s.zip";
-    String METADATA_REPO_DEFAULT_VERSION = "0.2.1";
+    /**
+     * The default metadata repository version. Maintained for backwards
+     * compatibility.
+     * @deprecated Please use {@link VersionInfo#METADATA_REPO_VERSION} instead
+     */
+    @Deprecated
+    String METADATA_REPO_DEFAULT_VERSION = VersionInfo.METADATA_REPO_VERSION;
 }

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -70,7 +70,8 @@ asciidoctorj {
             "highlightjsdir" to "highlight",
             "gradle-plugin-version" to libs.versions.nativeBuildTools.get(),
             "gradle-plugin-version" to libs.versions.nativeBuildTools.get(),
-            "maven-plugin-version" to libs.versions.nativeBuildTools.get()
+            "maven-plugin-version" to libs.versions.nativeBuildTools.get(),
+            "metadata-repository-version" to libs.versions.metadataRepository.get(),
     ))
 }
 

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -338,7 +338,7 @@ See <<configuration-options>> for the full list of available options.
 Since release 0.9.11, the plugin adds experimental support for the https://github.com/oracle/graalvm-reachability-metadata/[GraalVM reachability metadata repository].
 This repository provides https://www.graalvm.org/22.2/reference-manual/native-image/ReachabilityMetadata/[reachability metadata] for libraries that do not support GraalVM Native Image.
 
-NOTE: This version of the plugin defaults to the using the metadata repository in version {metadata-repository-version}. There is nothing for you to configure if you are fine with this version. The repository is also published on Maven Central at the following coordinates: `org.graalvm.buildtools:graalvm-reachability-metadata:graalvm-reachability-metadata` with the `repository` classifier and `zip` extension, e.g. `graalvm-reachability-metadata-{metadata-repository-version}-repository.zip`.
+NOTE: This version of the plugin defaults to the using the metadata repository in version {metadata-repository-version}. There is nothing for you to configure if you are fine with this version. The repository is also published on Maven Central at the following coordinates: `org.graalvm.buildtools:graalvm-reachability-metadata:graalvm-reachability-metadata` with the `repository` classifier and `zip` extension, e.g. `graalvm-reachability-metadata-{gradle-plugin-version}-repository.zip`.
 
 === Enabling the metadata repository
 

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -338,6 +338,8 @@ See <<configuration-options>> for the full list of available options.
 Since release 0.9.11, the plugin adds experimental support for the https://github.com/oracle/graalvm-reachability-metadata/[GraalVM reachability metadata repository].
 This repository provides https://www.graalvm.org/22.2/reference-manual/native-image/ReachabilityMetadata/[reachability metadata] for libraries that do not support GraalVM Native Image.
 
+NOTE: This version of the plugin defaults to the using the metadata repository in version {metadata-repository-version}. There is nothing for you to configure if you are fine with this version. The repository is also published on Maven Central at the following coordinates: `org.graalvm.buildtools:graalvm-reachability-metadata:graalvm-reachability-metadata` with the `repository` classifier and `zip` extension, e.g. `graalvm-reachability-metadata-{metadata-repository-version}-repository.zip`.
+
 === Enabling the metadata repository
 
 Support needs to be enabled explicitly:
@@ -356,7 +358,7 @@ include::../snippets/gradle/kotlin/build.gradle.kts[tags=enable-metadata-reposit
 A metadata repository consists of configuration files for GraalVM.
 The plugin will automatically download the configuration metadata from the official repository if you supply the version of the repository you want to use:
 
-.Enabling the metadata repository
+.Overriding the repository version
 [source, groovy, role="multi-language-sample"]
 ----
 include::../snippets/gradle/groovy/build.gradle[tags=specify-metadata-repository-version]

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -19,6 +19,11 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 [[changelog]]
 == Changelog
 
+=== Release 0.9.15
+
+* Upgrade to GraalVM metadata repository {metadata-repository-version}
+* Ship the metadata repository as an artifact alongside the plugin
+
 === Release 0.9.14
 
 ==== Gradle plugin

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -23,6 +23,7 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 
 * Upgrade to GraalVM metadata repository {metadata-repository-version}
 * Ship the metadata repository as an artifact alongside the plugin
+* Add ability to collect GraalVM metadata of dependencies to a custom location
 
 === Release 0.9.14
 

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -10,6 +10,8 @@ Please refer to the following pages for build tool specific documentation:
 - The <<gradle-plugin.adoc#,Gradle plugin documentation>>
 - The <<maven-plugin.adoc#,Maven plugin documentation>>
 
+This release of Native Build Tools ships with the GraalVM reachability metadata repository release {metadata-repository-version}.
+
 If you are interested in contributing, please refer to our https://github.com/graalvm/native-build-tools[Git repository].
 
 If you are using alternative build systems, see <<alternative-build-systems.adoc#,Useful Hints for Alternative Build Systems>>

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -603,6 +603,21 @@ mvn -Pnative -Dagent=true -DskipTests package exec:exec@native
 Since release 0.9.12, the plugin adds support for the https://github.com/oracle/graalvm-reachability-metadata/[GraalVM reachability metadata repository].
 This repository provides https://www.graalvm.org/22.2/reference-manual/native-image/ReachabilityMetadata/[reachability metadata] for libraries that do not support GraalVM Native Image.
 
+[NOTE]
+====
+This version of the plugin defaults to the using the metadata repository in version {metadata-repository-version}. There is nothing for you to configure if you are fine with this version. The repository is also published on Maven Central at the following coordinates:
+```xml
+<dependency>
+   <groupId>org.graalvm.buildtools</groupId>
+    <artifactId>graalvm-reachability-metadata</artifactId>
+    <version>{maven-plugin-version}</version>
+    <classifier>repository</classifier>
+    <type>zip</type>
+</dependency>
+```
+e.g. `graalvm-reachability-metadata-{maven-plugin-version}-repository.zip`.
+====
+
 === Enabling the metadata repository
 
 Support needs to be enabled explicitly by including the following into the `<configuration>` element:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 # Project versions
 nativeBuildTools = "0.9.15-SNAPSHOT"
+metadataRepository = "0.2.2"
 
 # External dependencies
 spock = "2.1-groovy-3.0"

--- a/native-gradle-plugin/build.gradle
+++ b/native-gradle-plugin/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     testFixturesImplementation libs.test.spock
     testFixturesImplementation gradleTestKit()
     functionalTestCommonRepository(libs.junitPlatformNative)
+    functionalTestCommonRepository(libs.jvmReachabilityMetadata)
     functionalTestCommonRepository("org.graalvm.internal:library-with-reflection")
 }
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/OfficialMetadataRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/OfficialMetadataRepoFunctionalTest.groovy
@@ -43,7 +43,6 @@ package org.graalvm.buildtools.gradle
 
 import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 import org.gradle.api.logging.LogLevel
-import spock.lang.Unroll
 
 class OfficialMetadataRepoFunctionalTest extends AbstractFunctionalTest {
 
@@ -61,6 +60,7 @@ class OfficialMetadataRepoFunctionalTest extends AbstractFunctionalTest {
 
         and: "finds metadata in the remote repository"
         outputContains "[graalvm reachability metadata repository for com.h2database:h2:2.1.210]: Configuration directory is com.h2database/h2/2.1.210"
+        outputDoesNotContain "Falling back to the default repository at"
     }
 
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -474,7 +474,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     private void configureNativeConfigurationRepo(ExtensionAware graalvmNative) {
         GraalVMReachabilityMetadataRepositoryExtension configurationRepository = graalvmNative.getExtensions().create("metadataRepository", GraalVMReachabilityMetadataRepositoryExtension.class);
         configurationRepository.getEnabled().convention(false);
-        configurationRepository.getVersion().convention(SharedConstants.METADATA_REPO_DEFAULT_VERSION);
+        configurationRepository.getVersion().convention(VersionInfo.METADATA_REPO_VERSION);
         configurationRepository.getUri().convention(configurationRepository.getVersion().map(v -> {
             try {
                 return new URI(String.format(METADATA_REPO_URL_TEMPLATE, v));

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/OfficialMetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/OfficialMetadataRepositoryFunctionalTest.groovy
@@ -57,6 +57,7 @@ class OfficialMetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunct
 
         and: "finds metadata in the remote repository"
         outputContains "[graalvm reachability metadata repository for com.h2database:h2:2.1.210]: Configuration directory is com.h2database/h2/2.1.210"
+        outputDoesNotContain "Falling back to the default repository."
     }
 
     void "the application runs when using the versioned official metadata repository"() {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -53,6 +53,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.logging.Logger;
 import org.graalvm.buildtools.Utils;
+import org.graalvm.buildtools.VersionInfo;
 import org.graalvm.buildtools.maven.config.ExcludeConfigConfiguration;
 import org.graalvm.buildtools.maven.config.MetadataRepositoryConfiguration;
 import org.graalvm.buildtools.utils.FileUtils;
@@ -479,7 +480,7 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
                 if (targetUrl == null) {
                     String version = metadataRepositoryConfiguration.getVersion();
                     if (version == null) {
-                        version = SharedConstants.METADATA_REPO_DEFAULT_VERSION;
+                        version = VersionInfo.METADATA_REPO_VERSION;
                     }
                     String metadataUrl = String.format(METADATA_REPO_URL_TEMPLATE, version);
                     try {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -52,6 +52,17 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.logging.Logger;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.filter.DependencyFilterUtils;
 import org.graalvm.buildtools.Utils;
 import org.graalvm.buildtools.VersionInfo;
 import org.graalvm.buildtools.maven.config.ExcludeConfigConfiguration;
@@ -98,6 +109,9 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
     protected static final String NATIVE_IMAGE_META_INF = "META-INF/native-image";
     protected static final String NATIVE_IMAGE_PROPERTIES_FILENAME = "native-image.properties";
     protected static final String NATIVE_IMAGE_DRY_RUN = "nativeDryRun";
+    private static final String GROUP_ID = "org.graalvm.buildtools";
+    private static final String GRAALVM_REACHABILITY_METADATA_ARTIFACT_ID = "graalvm-reachability-metadata";
+    private static final String REPOSITORY_FORMAT = "zip";
 
     @Parameter(defaultValue = "${plugin}", readonly = true) // Maven 3 only
     protected PluginDescriptor plugin;
@@ -191,6 +205,12 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
 
     @Component
     protected ToolchainManager toolchainManager;
+
+    @Component
+    protected MavenSession mavenSession;
+
+    @Component
+    protected RepositorySystem repositorySystem;
 
     @Inject
     protected AbstractNativeMojo() {
@@ -480,14 +500,23 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
                 if (targetUrl == null) {
                     String version = metadataRepositoryConfiguration.getVersion();
                     if (version == null) {
-                        version = VersionInfo.METADATA_REPO_VERSION;
+                        // Both the URL and version are unset, so we want to use
+                        // the version from Maven Central
+                        targetUrl = resolveDefaultMetadataRepositoryUrl();
+                        if (targetUrl == null) {
+                            logger.warn("Unable to find the GraalVM reachability metadata repository in Maven repository. " +
+                                        "Falling back to the default repository.");
+                            version = VersionInfo.METADATA_REPO_VERSION;
+                        }
                     }
-                    String metadataUrl = String.format(METADATA_REPO_URL_TEMPLATE, version);
-                    try {
-                        targetUrl = new URI(metadataUrl).toURL();
-                        metadataRepositoryConfiguration.setUrl(targetUrl);
-                    } catch (URISyntaxException | MalformedURLException e) {
-                        throw new RuntimeException(e);
+                    if (version != null) {
+                        String metadataUrl = String.format(METADATA_REPO_URL_TEMPLATE, version);
+                        try {
+                            targetUrl = new URI(metadataUrl).toURL();
+                            metadataRepositoryConfiguration.setUrl(targetUrl);
+                        } catch (URISyntaxException | MalformedURLException e) {
+                            throw new RuntimeException(e);
+                        }
                     }
                 }
                 Path destination;
@@ -518,6 +547,48 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
                 });
             }
         }
+    }
+
+    /**
+     * Downloads the metadata repository from Maven Central and returns the path to the downloaded file.
+     * @return the path to the downloaded repository file, or null if not found
+     */
+    private URL resolveDefaultMetadataRepositoryUrl() {
+        RepositorySystemSession repositorySession = mavenSession.getRepositorySession();
+        DependencyFilter classpathFilter = DependencyFilterUtils.classpathFilter(JavaScopes.RUNTIME);
+        CollectRequest collectRequest = new CollectRequest();
+        collectRequest.setRepositories(project.getRemoteProjectRepositories());
+        Dependency repository = new Dependency(new DefaultArtifact(
+                GROUP_ID,
+                GRAALVM_REACHABILITY_METADATA_ARTIFACT_ID,
+                "repository",
+                REPOSITORY_FORMAT,
+                VersionInfo.NBT_VERSION
+        ), "runtime");
+        collectRequest.addDependency(
+                repository
+        );
+        DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, classpathFilter);
+
+        DependencyResult dependencyResult = null;
+        try {
+            dependencyResult = repositorySystem.resolveDependencies(repositorySession, dependencyRequest);
+        } catch (DependencyResolutionException e) {
+            return null;
+        }
+        return dependencyResult.getArtifactResults()
+                .stream()
+                .filter(result -> result.getArtifact().getGroupId().equals(GROUP_ID) &&
+                        result.getArtifact().getArtifactId().equals(GRAALVM_REACHABILITY_METADATA_ARTIFACT_ID)
+                ).findFirst()
+                .map(r -> {
+                    try {
+                        return r.getArtifact().getFile().toURI().toURL();
+                    } catch (MalformedURLException e) {
+                        return null;
+                    }
+                })
+                .orElse(null);
     }
 
     public boolean isArtifactExcludedFromMetadataRepository(Artifact dependency) {


### PR DESCRIPTION
This PR builds on top of #330 and fixes #328. At build time, we will now download the current version of the GraalVM metadata repository, and make it available as an artifact on the `org.graalvm.buildtools:graalvm-reachability-metadata` coordinates (as a zip file with classifier `repository`). Please take a look at #328 for context.

This basically allows having _some_ releases of the metadata repository on Maven Central, the ones which are "shipped" with native build tools. It does _not_ remove the ability to pick a different version, in which case we would still download it from the GraalVM reachability repository, or even a custom URL (or a local file).

