### PR TITLE
Test and fix `--exclude-config` regression

### DIFF
--- a/samples/metadata-repo-integration/build.gradle
+++ b/samples/metadata-repo-integration/build.gradle
@@ -49,16 +49,21 @@ repositories {
 }
 
 application {
-    mainClass.set('org.graalvm.example.H2Example')
+    mainClass.set('org.graalvm.example.Example')
 }
 
 String h2_version = getProperty("h2.version")
 String netty_version = getProperty("netty.version")
-
+String logback_version = getProperty("logback.version")
+String log4j_version = getProperty("log4j.version")
+String slf4j_version = getProperty("slf4j.version")
 
 dependencies {
     implementation("com.h2database:h2:$h2_version")
     implementation("io.netty:netty-codec-http:$netty_version")
+    implementation("ch.qos.logback:logback-classic:$logback_version")
+    implementation("org.apache.logging.log4j:log4j-to-slf4j:$log4j_version")
+    implementation("org.slf4j:jul-to-slf4j:$slf4j_version")
 }
 
 graalvmNative {

--- a/samples/metadata-repo-integration/gradle.properties
+++ b/samples/metadata-repo-integration/gradle.properties
@@ -1,3 +1,6 @@
 native.gradle.plugin.version = 0.9.16-SNAPSHOT
 h2.version = 2.1.210
 netty.version = 4.1.80.Final
+logback.version = 1.4.4
+log4j.version = 2.19.0
+slf4j.version = 2.0.3

--- a/samples/metadata-repo-integration/pom.xml
+++ b/samples/metadata-repo-integration/pom.xml
@@ -54,8 +54,13 @@
         <native.maven.plugin.version>0.9.16-SNAPSHOT</native.maven.plugin.version>
         <junit.platform.native.version>0.9.16-SNAPSHOT</junit.platform.native.version>
         <h2.version>2.1.210</h2.version>
-        <imageName>h2-demo</imageName>
-        <mainClass>org.graalvm.example.H2Example</mainClass>
+        <netty.version>4.1.80.Final</netty.version>
+        <logback.version>1.4.4</logback.version>
+        <log4j.version>2.19.0</log4j.version>
+        <slf4j.version>2.0.3</slf4j.version>
+
+        <imageName>metadata-repo-demo</imageName>
+        <mainClass>org.graalvm.example.Example</mainClass>
     </properties>
 
     <dependencies>
@@ -63,6 +68,26 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
     </dependencies>
 
@@ -118,7 +143,7 @@
                             <!-- tag::metadata-versioned[] -->
                             <metadataRepository>
                                 <enabled>true</enabled>
-                                <version>0.1.0</version>
+                                <version>0.2.3</version>
                             </metadataRepository>
                             <!-- end::metadata-versioned[] -->
                         </configuration>

--- a/samples/metadata-repo-integration/settings.gradle
+++ b/samples/metadata-repo-integration/settings.gradle
@@ -8,4 +8,4 @@ pluginManagement {
     }
 }
 
-rootProject.name = 'h2-demo'
+rootProject.name = 'metadata-repo-demo'

--- a/samples/metadata-repo-integration/src/main/java/org/graalvm/example/Example.java
+++ b/samples/metadata-repo-integration/src/main/java/org/graalvm/example/Example.java
@@ -1,0 +1,9 @@
+package org.graalvm.example;
+
+public class Example {
+
+	public static void main(String[] args) throws Exception {
+		H2Example.test();
+		NettyExample.test();
+	}
+}

--- a/samples/metadata-repo-integration/src/main/java/org/graalvm/example/H2Example.java
+++ b/samples/metadata-repo-integration/src/main/java/org/graalvm/example/H2Example.java
@@ -16,7 +16,7 @@ public class H2Example {
 
     public static final String JDBC_CONNECTION_URL = "jdbc:h2:./data/test";
 
-    public static void main(String[] args) throws Exception {
+    public static void test() throws Exception {
         // Cleanup
         withConnection(JDBC_CONNECTION_URL, connection -> {
             connection.prepareStatement("DROP TABLE IF EXISTS customers").execute();

--- a/samples/metadata-repo-integration/src/main/java/org/graalvm/example/NettyExample.java
+++ b/samples/metadata-repo-integration/src/main/java/org/graalvm/example/NettyExample.java
@@ -1,0 +1,11 @@
+package org.graalvm.example;
+
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
+
+public class NettyExample {
+
+	public static void test() {
+		ServerCookieDecoder.STRICT.decode("");
+	}
+
+}


### PR DESCRIPTION
Can now be checked by running `OfficialMetadataRepoFunctionalTest` for Gradle
and `OfficialMetadataRepositoryFunctionalTest` for Maven.

See gh-340