### PR TITLE
fix issue #359 parse version with windows newlines

### DIFF
--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
@@ -117,6 +117,7 @@ public class NativeImageUtils {
      * @throws IllegalStateException when the version is not correct
      */
     public static void checkVersion(String requiredVersion, String versionToCheck) {
+        versionToCheck = versionToCheck.trim();
         Matcher requiredMatcher = requiredVersionPattern.matcher(requiredVersion);
         if (!requiredMatcher.matches()) {
             throw new IllegalArgumentException("Invalid version " + requiredVersion + ", should be for example \"22\", \"22.3\" or \"22.3.0\".");

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageUtilsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageUtilsTest.java
@@ -66,6 +66,7 @@ class NativeImageUtilsTest {
         NativeImageUtils.checkVersion("22", "GraalVM 22.3.0 Java 17 CE (Java Version 17.0.5+8-jvmci-22.3-b08)");
         NativeImageUtils.checkVersion("22.3", "GraalVM 22.3.0 Java 17 CE (Java Version 17.0.5+8-jvmci-22.3-b08)");
         NativeImageUtils.checkVersion("22.3.0", "GraalVM 22.3.0 Java 17 CE (Java Version 17.0.5+8-jvmci-22.3-b08)");
+        NativeImageUtils.checkVersion("22.3.0", "GraalVM 22.3.0 Java 17 CE (Java Version 17.0.5+8-jvmci-22.3-b08)\n");
     }
 
     @Test

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -237,7 +237,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
             spec.setExecutable(executablePath.getAbsolutePath());
         });
         execResult.assertNormalExitValue();
-        String versionToCheck = new String(outputStream.toByteArray(), StandardCharsets.UTF_8).replace("\n", "");
+        String versionToCheck = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
         NativeImageUtils.checkVersion(options.getRequiredVersion().get(), versionToCheck);
     }
 


### PR DESCRIPTION
facing this issue myself, 

there is a windows newline at the end of the version string on windows, and by default "." in the regex does not match newlines

thanks!.