### PR TITLE
Fix compile task out of date when runtime args change

### DIFF
--- a/.github/workflows/test-native-gradle-plugin.yml
+++ b/.github/workflows/test-native-gradle-plugin.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradle-version: ["current", "6.7.1"]
+        gradle-version: ["current", "7.1"]
         # Following versions are disabled temporarily in order to speed up PR testing
         # "7.3.3", "7.2", "7.1", "6.8.3"
         graalvm-version: [ latest ] # dev

--- a/build-logic/gradle-functional-testing/src/main/groovy/org.graalvm.build.functional-testing.gradle
+++ b/build-logic/gradle-functional-testing/src/main/groovy/org.graalvm.build.functional-testing.gradle
@@ -82,7 +82,7 @@ def graalVm = javaToolchains.launcherFor {
 def fullFunctionalTest = tasks.register("fullFunctionalTest")
 
 ['functionalTest', 'configCacheFunctionalTest'].each { baseName ->
-    ["current", "7.3.3", "7.2", "7.1", "6.8.3", "6.7.1"].each { gradleVersion ->
+    ["current", "7.3.3", "7.2", "7.1"].each { gradleVersion ->
         String taskName = gradleVersion == 'current' ? baseName : "gradle${gradleVersion}${baseName.capitalize()}"
         // Add a task to run the functional tests
         def testTask = tasks.register(taskName, Test) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageCompileOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageCompileOptions.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.dsl;
+
+import org.graalvm.buildtools.gradle.dsl.agent.DeprecatedAgentOptions;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+import org.gradle.jvm.toolchain.JavaLauncher;
+
+import java.util.List;
+
+/**
+ * Configuration options for compiling a native binary.
+ */
+public interface NativeImageCompileOptions {
+    /**
+     * Returns the fully qualified name of the Main class to be executed.
+     * <p>
+     * This does not need to be set if using an <a href="https://docs.oracle.com/javase/tutorial/deployment/jar/appman.html">Executable Jar</a> with a {@code Main-Class} attribute.
+     * </p>
+     *
+     * @return mainClass The main class.
+     */
+    @Input
+    @Optional
+    Property<String> getMainClass();
+
+    /**
+     * Returns the arguments for the native-image invocation.
+     *
+     * @return Arguments for the native-image invocation.
+     */
+    @Input
+    ListProperty<String> getBuildArgs();
+
+    /**
+     * Returns the system properties which will be used by the native-image builder process.
+     *
+     * @return The system properties. Returns an empty map when there are no system properties.
+     */
+    @Input
+    MapProperty<String, Object> getSystemProperties();
+
+    /**
+     * Returns the environment variables which will be used by the native-image builder process.
+     * @return the environment variables. Returns an empty map when there are no environment variables.
+     *
+     * @since 0.9.14
+     */
+    @Input
+    MapProperty<String, Object> getEnvironmentVariables();
+
+    /**
+     * Returns the classpath for the native-image building.
+     *
+     * @return classpath The classpath for the native-image building.
+     */
+    @InputFiles
+    @Classpath
+    ConfigurableFileCollection getClasspath();
+
+    /**
+     * Returns the extra arguments to use when launching the JVM for the native-image building process.
+     * Does not include system properties and the minimum/maximum heap size.
+     *
+     * @return The arguments. Returns an empty list if there are no arguments.
+     */
+    @Input
+    ListProperty<String> getJvmArgs();
+
+    /**
+     * Gets the value which toggles native-image debug symbol output.
+     *
+     * @return Is debug enabled
+     */
+    @Input
+    Property<Boolean> getDebug();
+
+    /**
+     * @return Whether to enable fallbacks (defaults to false).
+     */
+    @Input
+    Property<Boolean> getFallback();
+
+    /**
+     * Gets the value which toggles native-image verbose output.
+     *
+     * @return Is verbose output
+     */
+    @Input
+    Property<Boolean> getVerbose();
+
+    /**
+     * Gets the value which determines if shared library is being built.
+     *
+     * @return The value which determines if shared library is being built.
+     */
+    @Input
+    Property<Boolean> getSharedLibrary();
+
+    /**
+     * Gets the value which determines if image is being built in quick build mode.
+     *
+     * @return The value which determines if image is being built in quick build mode.
+     */
+    @Input
+    Property<Boolean> getQuickBuild();
+
+    /**
+     * Gets the value which determines if image is being built with rich output.
+     *
+     * @return The value which determines if image is being built with rich output.
+     */
+    @Input
+    Property<Boolean> getRichOutput();
+
+    /**
+     * Returns the MapProperty that contains information about configuration that should be excluded
+     * during image building. It consists of a dependency coordinates and a list of
+     * regular expressions that match resources that should be excluded as a value.
+     *
+     * @return a map of filters for configuration exclusion
+     */
+    @Input
+    MapProperty<Object, List<String>> getExcludeConfig();
+
+    @Nested
+    NativeResourcesOptions getResources();
+
+    /**
+     * Returns the list of configuration file directories (e.g. resource-config.json, ...) which need
+     * to be passed to native-image.
+     *
+     * @return a collection of directories
+     */
+    @InputFiles
+    ConfigurableFileCollection getConfigurationFileDirectories();
+
+    @Input
+    ListProperty<String> getExcludeConfigArgs();
+
+    /**
+     * Gets the name of the native executable to be generated.
+     *
+     * @return The image name property.
+     */
+    @Input
+    Property<String> getImageName();
+
+    /**
+     * Returns the toolchain used to invoke native-image. Currently pointing
+     * to a Java launcher due to Gradle limitations.
+     *
+     * @return the detected java launcher
+     */
+    @Nested
+    @Optional
+    Property<JavaLauncher> getJavaLauncher();
+
+    /**
+     * If set to true, this will build a fat jar of the image classpath
+     * instead of passing each jar individually to the classpath. This
+     * option can be used in case the classpath is too long and that
+     * invoking native image fails, which can happen on Windows.
+     *
+     * @return true if a fatjar should be used. Defaults to true for Windows, and false otherwise.
+     */
+    @Input
+    Property<Boolean> getUseFatJar();
+
+    @Nested
+    DeprecatedAgentOptions getAgent();
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageOptions.java
@@ -42,183 +42,33 @@
 package org.graalvm.buildtools.gradle.dsl;
 
 import org.graalvm.buildtools.gradle.dsl.agent.DeprecatedAgentOptions;
+import org.graalvm.buildtools.gradle.internal.DelegatingCompileOptions;
 import org.gradle.api.Action;
 import org.gradle.api.Named;
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
-import org.gradle.jvm.toolchain.JavaLauncher;
 
-import java.util.List;
 import java.util.Map;
 
 
 /**
  * Class that declares native image options.
+ * This object is a domain object which can be configured via
+ * the Gradle DSL. Multiple instances of this object can be created,
+ * in which case it means we have multiple native binaries.
+ * 
+ * The DSL combines the compiler options (building a native binary)
+ * and the runtime options (executing a native binary).
  *
  * @author gkrocher
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public interface NativeImageOptions extends Named {
+public interface NativeImageOptions extends Named, NativeImageCompileOptions, NativeImageRuntimeOptions {
     @Override
     @Internal
     String getName();
-
-    /**
-     * Gets the name of the native executable to be generated.
-     *
-     * @return The image name property.
-     */
-    @Input
-    Property<String> getImageName();
-
-    /**
-     * Returns the fully qualified name of the Main class to be executed.
-     * <p>
-     * This does not need to be set if using an <a href="https://docs.oracle.com/javase/tutorial/deployment/jar/appman.html">Executable Jar</a> with a {@code Main-Class} attribute.
-     * </p>
-     *
-     * @return mainClass The main class.
-     */
-    @Input
-    @Optional
-    Property<String> getMainClass();
-
-    /**
-     * Returns the arguments for the native-image invocation.
-     *
-     * @return Arguments for the native-image invocation.
-     */
-    @Input
-    ListProperty<String> getBuildArgs();
-
-    /**
-     * Returns the system properties which will be used by the native-image builder process.
-     *
-     * @return The system properties. Returns an empty map when there are no system properties.
-     */
-    @Input
-    MapProperty<String, Object> getSystemProperties();
-
-    /**
-     * Returns the environment variables which will be used by the native-image builder process.
-     * @return the environment variables. Returns an empty map when there are no environment variables.
-     *
-     * @since 0.9.14
-     */
-    @Input
-    MapProperty<String, Object> getEnvironmentVariables();
-
-    /**
-     * Returns the classpath for the native-image building.
-     *
-     * @return classpath The classpath for the native-image building.
-     */
-    @InputFiles
-    @Classpath
-    ConfigurableFileCollection getClasspath();
-
-    /**
-     * Returns the extra arguments to use when launching the JVM for the native-image building process.
-     * Does not include system properties and the minimum/maximum heap size.
-     *
-     * @return The arguments. Returns an empty list if there are no arguments.
-     */
-    @Input
-    ListProperty<String> getJvmArgs();
-
-    /**
-     * Returns the arguments to use when launching the built image.
-     *
-     * @return The arguments. Returns an empty list if there are no arguments.
-     */
-    @Input
-    ListProperty<String> getRuntimeArgs();
-
-    /**
-     * Gets the value which toggles native-image debug symbol output.
-     *
-     * @return Is debug enabled
-     */
-    @Input
-    Property<Boolean> getDebug();
-
-    /**
-     * @return Whether to enable fallbacks (defaults to false).
-     */
-    @Input
-    Property<Boolean> getFallback();
-
-    /**
-     * Gets the value which toggles native-image verbose output.
-     *
-     * @return Is verbose output
-     */
-    @Input
-    Property<Boolean> getVerbose();
-
-    /**
-     * Gets the value which determines if shared library is being built.
-     *
-     * @return The value which determines if shared library is being built.
-     */
-    @Input
-    Property<Boolean> getSharedLibrary();
-
-    /**
-     * Gets the value which determines if image is being built in quick build mode.
-     *
-     * @return The value which determines if image is being built in quick build mode.
-     */
-    @Input
-    Property<Boolean> getQuickBuild();
-
-    /**
-     * Gets the value which determines if image is being built with rich output.
-     *
-     * @return The value which determines if image is being built with rich output.
-     */
-    @Input
-    Property<Boolean> getRichOutput();
-
-    /**
-     * Returns the toolchain used to invoke native-image. Currently pointing
-     * to a Java launcher due to Gradle limitations.
-     *
-     * @return the detected java launcher
-     */
-    @Nested
-    @Optional
-    Property<JavaLauncher> getJavaLauncher();
-
-    /**
-     * Returns the list of configuration file directories (e.g. resource-config.json, ...) which need
-     * to be passed to native-image.
-     *
-     * @return a collection of directories
-     */
-    @InputFiles
-    ConfigurableFileCollection getConfigurationFileDirectories();
-
-    /**
-     * Returns the MapProperty that contains information about configuration that should be excluded
-     * during image building. It consists of a dependency coordinates and a list of
-     * regular expressions that match resources that should be excluded as a value.
-     *
-     * @return a map of filters for configuration exclusion
-     */
-    @Input
-    MapProperty<Object, List<String>> getExcludeConfig();
-
-    @Nested
-    NativeResourcesOptions getResources();
 
     void resources(Action<? super NativeResourcesOptions> spec);
 
@@ -296,24 +146,7 @@ public interface NativeImageOptions extends Named {
      */
     NativeImageOptions runtimeArgs(Iterable<?> arguments);
 
-    /**
-     * If set to true, this will build a fat jar of the image classpath
-     * instead of passing each jar individually to the classpath. This
-     * option can be used in case the classpath is too long and that
-     * invoking native image fails, which can happen on Windows.
-     *
-     * @return true if a fatjar should be used. Defaults to true for Windows, and false otherwise.
-     */
-    @Input
-    Property<Boolean> getUseFatJar();
-
-    @Nested
-    DeprecatedAgentOptions getAgent();
-
     void agent(Action<? super DeprecatedAgentOptions> spec);
-
-    @Input
-    ListProperty<String> getExcludeConfigArgs();
 
     /**
      * Specify the minimal GraalVM version, can be {@code MAJOR}, {@code MAJOR.MINOR} or {@code MAJOR.MINOR.PATCH}.
@@ -323,4 +156,17 @@ public interface NativeImageOptions extends Named {
     @Input
     @Optional
     Property<String> getRequiredVersion();
+
+    /**
+     * Restricts this object to the list of options which are
+     * required for compilation. This is required so that Gradle
+     * only considers the inputs from that type instead of the
+     * full set of properties when building a native binary.
+     *
+     * @return the compilation options.
+     */
+    default NativeImageCompileOptions asCompileOptions() {
+        return new DelegatingCompileOptions(this);
+    }
+
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageRuntimeOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageRuntimeOptions.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.dsl;
+
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.Input;
+
+/**
+ * Options required when running a native image.
+ */
+public interface NativeImageRuntimeOptions {
+    /**
+     * Returns the arguments to use when launching the built image.
+     *
+     * @return The arguments. Returns an empty list if there are no arguments.
+     */
+    @Input
+    ListProperty<String> getRuntimeArgs();
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DelegatingCompileOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DelegatingCompileOptions.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.internal;
+
+import org.graalvm.buildtools.gradle.dsl.NativeImageCompileOptions;
+import org.graalvm.buildtools.gradle.dsl.NativeResourcesOptions;
+import org.graalvm.buildtools.gradle.dsl.agent.DeprecatedAgentOptions;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.jvm.toolchain.JavaLauncher;
+
+import java.util.List;
+
+/**
+ * Configuration options for compiling a native binary.
+ */
+public class DelegatingCompileOptions implements NativeImageCompileOptions {
+    private final NativeImageCompileOptions options;
+
+    public DelegatingCompileOptions(NativeImageCompileOptions options) {
+        this.options = options;
+    }
+
+    @Override
+    public Property<String> getImageName() {
+        return options.getImageName();
+    }
+
+    @Override
+    public Property<JavaLauncher> getJavaLauncher() {
+        return options.getJavaLauncher();
+    }
+
+    @Override
+    public Property<String> getMainClass() {
+        return options.getMainClass();
+    }
+
+    @Override
+    public ListProperty<String> getBuildArgs() {
+        return options.getBuildArgs();
+    }
+
+    @Override
+    public MapProperty<String, Object> getSystemProperties() {
+        return options.getSystemProperties();
+    }
+
+    @Override
+    public MapProperty<String, Object> getEnvironmentVariables() {
+        return options.getEnvironmentVariables();
+    }
+
+    @Override
+    public ConfigurableFileCollection getClasspath() {
+        return options.getClasspath();
+    }
+
+    @Override
+    public ListProperty<String> getJvmArgs() {
+        return options.getJvmArgs();
+    }
+
+    @Override
+    public Property<Boolean> getDebug() {
+        return options.getDebug();
+    }
+
+    @Override
+    public Property<Boolean> getFallback() {
+        return options.getFallback();
+    }
+
+    @Override
+    public Property<Boolean> getVerbose() {
+        return options.getVerbose();
+    }
+
+    @Override
+    public Property<Boolean> getSharedLibrary() {
+        return options.getSharedLibrary();
+    }
+
+    @Override
+    public Property<Boolean> getQuickBuild() {
+        return options.getQuickBuild();
+    }
+
+    @Override
+    public Property<Boolean> getRichOutput() {
+        return options.getRichOutput();
+    }
+
+    @Override
+    public MapProperty<Object, List<String>> getExcludeConfig() {
+        return options.getExcludeConfig();
+    }
+
+    @Override
+    public NativeResourcesOptions getResources() {
+        return options.getResources();
+    }
+
+    @Override
+    public ConfigurableFileCollection getConfigurationFileDirectories() {
+        return options.getConfigurationFileDirectories();
+    }
+
+    @Override
+    public ListProperty<String> getExcludeConfigArgs() {
+        return options.getExcludeConfigArgs();
+    }
+
+    @Override
+    public Property<Boolean> getUseFatJar() {
+        return options.getUseFatJar();
+    }
+
+    @Override
+    public DeprecatedAgentOptions getAgent() {
+        return options.getAgent();
+    }
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
@@ -96,8 +96,9 @@ public class NativeImageExecutableLocator {
                 logger.log("Native Image executable wasn't found. We will now try to download it. ");
                 File graalVmHomeGuess = executablePath.getParentFile();
 
-                if (!graalVmHomeGuess.toPath().resolve(GU_EXE).toFile().exists()) {
-                    throw new GradleException("'" + GU_EXE + "' tool wasn't found. This probably means that JDK at isn't a GraalVM distribution.");
+                File guPath = graalVmHomeGuess.toPath().resolve(GU_EXE).toFile();
+                if (!guPath.exists()) {
+                    throw new GradleException("'" + GU_EXE + "' at '" + guPath + "' tool wasn't found. This probably means that JDK at isn't a GraalVM distribution.");
                 }
                 ExecResult res = execOperations.exec(spec -> {
                     spec.args("install", "native-image");
@@ -150,6 +151,7 @@ public class NativeImageExecutableLocator {
         public void withExecutablePath(File path) {
             executablePath = path;
         }
+
         public List<String> getDiagnostics() {
             List<String> diags = new ArrayList<>();
             diags.add("GraalVM Toolchain detection is " + (toolchainDetectionDisabled ? "disabled" : "enabled"));

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -41,14 +41,8 @@
 
 package org.graalvm.buildtools.gradle.tasks;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-
-import javax.inject.Inject;
-
 import org.graalvm.buildtools.gradle.NativeImagePlugin;
+import org.graalvm.buildtools.gradle.dsl.NativeImageCompileOptions;
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.internal.GraalVMLogger;
 import org.graalvm.buildtools.gradle.internal.NativeImageCommandLineProvider;
@@ -77,6 +71,12 @@ import org.gradle.api.tasks.options.Option;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
 
+import javax.inject.Inject;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
 import static org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator.graalvmHomeProvider;
 import static org.graalvm.buildtools.utils.SharedConstants.EXECUTABLE_EXTENSION;
 
@@ -88,8 +88,14 @@ public abstract class BuildNativeImageTask extends DefaultTask {
     private final Provider<String> graalvmHomeProvider;
     private final NativeImageExecutableLocator.Diagnostics diagnostics;
 
-    @Nested
+    @Internal
     public abstract Property<NativeImageOptions> getOptions();
+
+    @Nested
+    protected NativeImageCompileOptions getCompileOptions() {
+        getOptions().finalizeValue();
+        return getOptions().get().asCompileOptions();
+    }
 
     @Option(option = "quick-build-native", description = "Enables quick build mode")
     public void overrideQuickBuild() {


### PR DESCRIPTION
The `NativeImageOptions` domain object is used in the DSL to configure both compile and runtime arguments for native images: the compile options are used to invoke `native-image` and build a binary, while the runtime args are used to pass extra arguments when executing the native image.

The full `NativeImageOptions` domain object was passed to the native image compilation task as a `@Nested` input, which meant in practice that if the _runtime_ arguments changed, then we would rebuild the image although it isn't necessary.

This commit fixes the problem in a binary compatible way, by introducing a couple of interfaces: one for the compile options, the other for the runtime options. It makes the "options" internal on the compile task, and uses a delegated view of compile options for input snapshotting.

Fixes #371