### PR TITLE
Quickstart guides for Native Image Build Tools Maven/Gradle plugins.

### DIFF
--- a/docs/src/docs/asciidoc/graalvm-setup.adoc
+++ b/docs/src/docs/asciidoc/graalvm-setup.adoc
@@ -2,7 +2,7 @@
 
 image:https://www.graalvm.org/resources/img/logo-colored.svg[GraalVM]
 
-Working GraalVM distribution with `native-image` installable and `GRAALVM_HOME` and/or `JAVA_HOME` environment variables set, is the prequisite fo a successful *native-image* building.
+Working GraalVM distribution with `native-image` installable and `GRAALVM_HOME` and/or `JAVA_HOME` environment variables set, is the prequisite for a successful *native-image* building.
 
 Following are the steps needed to obtain and setup the GraalVM environment.
 

--- a/docs/src/docs/asciidoc/graalvm-setup.adoc
+++ b/docs/src/docs/asciidoc/graalvm-setup.adoc
@@ -2,11 +2,11 @@
 
 image:https://www.graalvm.org/resources/img/logo-colored.svg[GraalVM]
 
-Working GraalVM distribution with `native-image` installable and `GRAALVM_HOME` and/or `JAVA_HOME` environment variables set, is the prequisite for a successful *native-image* building.
+As a prerequisite for building with GraalVM Native Image, a GraalVM JDK is required and the `GRAALVM_HOME` and/or `JAVA_HOME` environment variables need to be set.
 
-Following are the steps needed to obtain and setup the GraalVM environment.
+Following are the steps needed to obtain and setup a GraalVM environment.
 
-NOTE: This is just a quick overview, and a user can consult the https://www.graalvm.org/docs/getting-started/[GraalVM Getting Started section] before proceeding.
+NOTE: This is just a quick overview, and users can consult the https://www.graalvm.org/docs/getting-started/[GraalVM Getting Started section] before proceeding.
 
 == 1. Obtaining distribution
 

--- a/docs/src/docs/asciidoc/graalvm-setup.adoc
+++ b/docs/src/docs/asciidoc/graalvm-setup.adoc
@@ -1,12 +1,12 @@
-= Setting up GraalVM with native-image support
+= Setting up GraalVM with Native Image Support
 
 image:https://www.graalvm.org/resources/img/logo-colored.svg[GraalVM]
 
-Working GraalVM distribution with `native-image` installable and `GRAALVM_HOME` and/or `JAVA_HOME` environment variables set, is prequisite for successful *native-image* building.
+Working GraalVM distribution with `native-image` installable and `GRAALVM_HOME` and/or `JAVA_HOME` environment variables set, is the prequisite fo a successful *native-image* building.
 
-Following are the steps needed to obtain and setup GraalVM environment.
+Following are the steps needed to obtain and setup the GraalVM environment.
 
-NOTE: This is just a quick overview, and that user should consult https://www.graalvm.org/docs/getting-started/[Getting Started section] in official documentation before proceeding.
+NOTE: This is just a quick overview, and a user can consult the https://www.graalvm.org/docs/getting-started/[GraalVM Getting Started section] before proceeding.
 
 == 1. Obtaining distribution
 

--- a/docs/src/docs/asciidoc/graalvm-setup.adoc
+++ b/docs/src/docs/asciidoc/graalvm-setup.adoc
@@ -36,7 +36,7 @@ setx /M GRAALVM_HOME "C:\path\to\graalvm"
 
 NOTE: Preferably user would also set `JAVA_HOME` variable in the same manner (by replacing `GRAALVM_HOME` with `JAVA_HOME` in previous commands).
 
-== 3. `native-image` tool instalation
+== 3. `native-image` tool installation
 
 .Linux / macOS
 ```bash

--- a/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
@@ -93,9 +93,9 @@ public class Fortune {
     }
 
     public String randomFortune() {
-        //Pick a random number
+        // Pick a random number
         int r = RANDOM.nextInt(fortunes.size());
-        //Use the random number to pick a random fortune
+        // Use the random number to pick a random fortune
         return fortunes.get(r);
     }
 
@@ -457,11 +457,4 @@ The Gradle plugin for GraalVM Native Image adds support for building and testing
 https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html[plugin
 reference documentation].
 
-Note that if your application does not call any classes dynamically at run time, the execution with the agent is needless. Your workflow, in that case, is just:
-
-[source,shell]
-----
-./gradlew nativeRun
-----
-
-Lastly, if you use GraalVM Enterprise as your `JAVA_HOME` environment, the plugin builds a native executable with enterprise features enabled.
+Note that if your application does not call any classes dynamically at run time, the execution with the agent is needless. Your workflow, in that case, is just `./gradlew nativeRun`.

--- a/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
@@ -1,6 +1,8 @@
 = Getting Started with Gradle Plugin for GraalVM Native Image
+The GraalVM team
+:highlighjsdir: {gradle-relative-srcdir}/highlight
 
-This guide shows how to get started with the <<gradle-plugin.adoc,Gradle plugin for GraalVM Native Image>> and build a native executable for a Java application.
+This guide shows how to get started with the <<gradle-plugin.adoc#,Gradle plugin for GraalVM Native Image>> and build a native executable for a Java application.
 
 You will create a sample application, enable the plugin, add support for dynamic features, run JUnit tests, and build a native executable.
 
@@ -9,18 +11,23 @@ Two ways to build a native executable using the plugin are demonstrated:
 - <<#build-a-native-executable-with-resources-autodetection,Build a Native Executable with Resources Autodetection>>
 -  <<#build-a-native-executable-detecting-resources-with-the-agent,Build a Native Executable Detecting Resources with the Agent>>
 
-.Note on a Sample Application
+[NOTE]
+====
+.Sample Application
 
 You start by creating a **Fortune Teller** sample application that simulates the traditional 
 https://en.wikipedia.org/wiki/Fortune_(Unix)[fortune Unix program]. 
 The data for the fortune phrases is provided by https://github.com/your-fortune[YourFortune].
+====
 
 ====
 To use the Native Build Tools, install GraalVM with Native Image. 
 The easiest way to install GraalVM with Native Image is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
-```
+
+[source,bash]
+----
 bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
-```
+----
 ====
 
 == Prepare a Demo Application
@@ -29,9 +36,9 @@ bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
 +
 [source,shell]
 ----
-gradle init --project-name fortune --type java-application --package demo --test-framework junit-jupiter --dsl groovy
+gradle init --project-name fortune-parent --type java-application --package demo --test-framework junit-jupiter --dsl groovy
 ----
-. Rename the default `app` directory to `fortune`, then rename the default filename `App.java` to `Fortune.java`, and replace its contents with the following:
+. Rename the default `app` directory to `fortune`, edit the `settings.gradle` file to replace `app` with `fortune`, then rename the default filename `App.java` to `Fortune.java`, and replace its contents with the following:
 +
 [source,java]
 ----
@@ -113,7 +120,7 @@ public class Fortune {
 ----
 . Delete the `fortune/src/test/java` directory, you will add tests in a later stage.
 . Copy and paste the following file,
-https://github.com/graalvm/graalvm-demos/blob/master/fortune-demo/fortune/src/main/resources/fortunes.json[fortunes.json] under `fortune/src/main/resources/`. Your project tree should be:
+https://raw.githubusercontent.com/graalvm/graalvm-demos/master/fortune-demo/fortune/src/main/resources/fortunes.json[fortunes.json] under `fortune/src/main/resources/`. Your project tree should be:
 +
 [source,shell]
 ----
@@ -160,21 +167,32 @@ The next steps demonstrate what you should do to enable the
 https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html[Gradle Plugin for GraalVM Native Image].
 . Register the plugin. Add the following to
 `plugins` section of your project’s _build.gradle_ file:
-+
-[source,xml]
+
+[source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 plugins {
-// ...
+  // ...
 
-id 'org.graalvm.buildtools.native' version '0.9.19'
+  // Apply GraalVM Native Image plugin
+  id 'org.graalvm.buildtools.native' version '{gradle-plugin-version}'
 }
 ----
-+
+
+[source,kotlin,subs="verbatim,attributes",role="multi-language-sample"]
+----
+plugins {
+  // ...
+
+  // Apply GraalVM Native Image plugin
+  id("org.graalvm.buildtools.native") version "{gradle-plugin-version}"
+}
+----
+
 The plugin discovers which JAR files it needs to pass to the
 `native-image` builder and what the executable main class should be.
 . The plugin is not yet available on the Gradle Plugin Portal, so declare an additional plugin repository. Open the _settings.gradle_ file and replace the default content with this:
-+
-[source,xml]
+
+[source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 pluginManagement {
     repositories {
@@ -186,9 +204,23 @@ pluginManagement {
 rootProject.name = 'fortune-parent'
 include('fortune')
 ----
-+
+
+[source,kotlin,subs="verbatim,attributes", role="multi-language-sample"]
+----
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "fortune-parent"
+include("fortune")
+----
+
 Note that the `pluginManagement {}` block must appear before any other statements in the file.
 
+[[build-a-native-executable-with-resources-autodetection]]
 == Build a Native Executable with Resources Autodetection
 
 You can already build a native executable by running
@@ -196,8 +228,8 @@ You can already build a native executable by running
 `./gradlew nativeRun`. However, at this stage, running the native executable will fail because this application requires additional metadata: you need to provide it with a list of resources to load.
 
 . Instruct the plugin to automatically detect resources to be included in the native executable. Add this to your `build.gradle` file:
-+
-[source,xml]
+
+[source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 graalvmNative {
     binaries.all {
@@ -206,46 +238,74 @@ graalvmNative {
     toolchainDetection = false
 }
 ----
-+
+
+[source,kotlin,subs="verbatim,attributes", role="multi-language-sample"]
+----
+graalvmNative {
+    binaries.all {
+        resources.autodetect()
+    }
+    toolchainDetection.set(false)
+}
+----
+
 Another thing to note here: the plugin may not be able to properly detect the GraalVM installation, because of limitations in Gradle. By default, the plugin selects a Java 11 GraalVM Community Edition. If you want to use GraalVM Enterprise, or a particular version of GraalVM and Java, you need to explicitly tell this in plugin's configuration. For example:
-+
-[source,xml]
+
+[source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 graalvmNative {
     binaries {
         main {
             javaLauncher = javaToolchains.launcherFor {
-                languageVersion = JavaLanguageVersion.of(8)
+                languageVersion = JavaLanguageVersion.of(11)
                 vendor = JvmVendorSpec.matching("GraalVM Community")
             }
         }
     }
 }
 ----
-+
+
+[source,kotlin,subs="verbatim,attributes", role="multi-language-sample"]
+----
+graalvmNative {
+    binaries {
+        main {
+            javaLauncher = javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(11)
+                vendor = JvmVendorSpec.matching("GraalVM Community")
+            }
+        }
+    }
+}
+----
+
 The workaround to this is to disable toolchain detection with this command `toolchainDetection = false`.
+
+[start=2]
 . Compile the project and build a native executable at one step:
-+
+
 [source,shell]
 ----
 ./gradlew nativeRun
 ----
-+
+
 The native executable, named _fortune_, is created in the
 _/fortune/build/native/nativeCompile_ directory.
+[start=3]
 . Run the native executable:
-+
+
 [source,shell]
 ----
 ./fortune/build/native/nativeCompile/fortune
 ----
-+
+
 The application starts and prints a random quote.
 
 Configuring the `graalvmNative` plugin to automatically detect resources (`resources.autodetect()`) to be included in a binary is one way to make this example work. Using `resources.autodetect()` works because the application uses resources (_fortunes.json_) which are directly available in the `src/main/resources` location.
 
 In the next section, the guide shows that you can use the tracing agent to do the same.
 
+[[build-a-native-executable-detecting-resources-with-the-agent]]
 == Build a Native Executable by Detecting Resources with the Agent
 
 The Native Image Gradle plugin simplifies generation of the required metadata by injecting the
@@ -293,13 +353,25 @@ To see the benefits of running your application as a native executable, `time` h
 
 You can customize the plugin. For example, change the name of the native executable and pass additional parameters to the plugin in the _build.gradle_ file, as follows:
 
-[source,xml]
+[source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 graalvmNative {
     binaries {
         main {
             imageName.set('fortuneteller') 
             buildArgs.add('--verbose') 
+        }
+    }
+}
+----
+
+[source,kotlin,subs="verbatim,attributes", role="multi-language-sample"]
+----
+graalvmNative {
+    binaries {
+        main {
+            imageName.set("fortuneteller")
+            buildArgs.add("--verbose")
         }
     }
 }
@@ -313,8 +385,9 @@ The Gradle plugin for GraalVM Native Image can run
 https://junit.org/junit5/docs/current/user-guide/[JUnit Platform] tests on your native executable. This means that the tests will be compiled and run as native code.
 
 . Create the following test in the
-`fortunate/src/test/java/demo/FortuneTest.java` file:
+`fortune/src/test/java/demo/FortuneTest.java` file:
 +
+.fortune/src/test/java/demo/FortuneTest.java
 [source,java]
 ----
 package demo;
@@ -334,19 +407,26 @@ class FortuneTest {
     }
 }
 ----
+
 . Run JUnit tests:
-+
 [source,shell]
 ----
 ./gradlew nativeTest
 ----
-+
+
 The plugin runs tests on the JVM prior to running tests from the native executable. To disable testing support (which comes by default), add the following configuration to the _build.gradle_ file:
-+
-[source,xml]
+
+[source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 graalvmNative {
     testSupport = false
+}
+----
+
+[source,kotlin,subs="verbatim,attributes", role="multi-language-sample"]
+----
+graalvmNative {
+    testSupport.set(false)
 }
 ----
 
@@ -356,17 +436,16 @@ If you need to test collecting metadata with the agent, add the
 `-Pagent` option to the `test` and `nativeTest` task invocations:
 
 . Run the tests on the JVM with the agent:
-+
 [source,shell]
 ----
 ./gradlew -Pagent test
 ----
-+
+
 It runs your application on the JVM with the agent, collects the metadata and uses it for testing on `native-image`. The generated configuration files (containing the metadata) can be found in the
 _$\{buildDir}/native/agent-output/$\{taskName}_ directory. 
 In this case, the plugin also substitutes `{output_dir}` in the agent options to point to this directory.
 . Build a native executable using the metadata collected by the agent:
-+
+
 [source,shell]
 ----
 ./gradlew -Pagent nativeTest

--- a/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
@@ -167,7 +167,7 @@ The next steps demonstrate what you should do to enable the
 https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html[Gradle Plugin for GraalVM Native Image].
 . Register the plugin. Add the following to
 `plugins` section of your project’s _build.gradle_ file:
-
++
 [source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 plugins {
@@ -177,7 +177,7 @@ plugins {
   id 'org.graalvm.buildtools.native' version '{gradle-plugin-version}'
 }
 ----
-
++
 [source,kotlin,subs="verbatim,attributes",role="multi-language-sample"]
 ----
 plugins {
@@ -187,11 +187,12 @@ plugins {
   id("org.graalvm.buildtools.native") version "{gradle-plugin-version}"
 }
 ----
-
++
+The `{gradle-plugin-version}` block pulls the latest plugin version. Replace it with a specific version if you prefer.
 The plugin discovers which JAR files it needs to pass to the
 `native-image` builder and what the executable main class should be.
 . The plugin is not yet available on the Gradle Plugin Portal, so declare an additional plugin repository. Open the _settings.gradle_ file and replace the default content with this:
-
++
 [source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 pluginManagement {
@@ -204,7 +205,7 @@ pluginManagement {
 rootProject.name = 'fortune-parent'
 include('fortune')
 ----
-
++
 [source,kotlin,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 pluginManagement {
@@ -217,7 +218,7 @@ pluginManagement {
 rootProject.name = "fortune-parent"
 include("fortune")
 ----
-
++
 Note that the `pluginManagement {}` block must appear before any other statements in the file.
 
 [[build-a-native-executable-with-resources-autodetection]]
@@ -228,7 +229,7 @@ You can already build a native executable by running
 `./gradlew nativeRun`. However, at this stage, running the native executable will fail because this application requires additional metadata: you need to provide it with a list of resources to load.
 
 . Instruct the plugin to automatically detect resources to be included in the native executable. Add this to your `build.gradle` file:
-
++
 [source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 graalvmNative {
@@ -238,7 +239,7 @@ graalvmNative {
     toolchainDetection = false
 }
 ----
-
++
 [source,kotlin,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 graalvmNative {
@@ -248,9 +249,9 @@ graalvmNative {
     toolchainDetection.set(false)
 }
 ----
-
++
 Another thing to note here: the plugin may not be able to properly detect the GraalVM installation, because of limitations in Gradle. By default, the plugin selects a Java 11 GraalVM Community Edition. If you want to use GraalVM Enterprise, or a particular version of GraalVM and Java, you need to explicitly tell this in plugin's configuration. For example:
-
++
 [source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 graalvmNative {
@@ -264,7 +265,7 @@ graalvmNative {
     }
 }
 ----
-
++
 [source,kotlin,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 graalvmNative {
@@ -278,22 +279,22 @@ graalvmNative {
     }
 }
 ----
-
++
 The workaround to this is to disable toolchain detection with this command `toolchainDetection = false`.
 
 [start=2]
 . Compile the project and build a native executable at one step:
-
++
 [source,shell]
 ----
 ./gradlew nativeRun
 ----
-
++
 The native executable, named _fortune_, is created in the
 _/fortune/build/native/nativeCompile_ directory.
 [start=3]
 . Run the native executable:
-
++
 [source,shell]
 ----
 ./fortune/build/native/nativeCompile/fortune
@@ -312,17 +313,24 @@ The Native Image Gradle plugin simplifies generation of the required metadata by
 https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html#agent-support[
 tracing agent] automatically for you at compile time. To enable the agent, just pass the `-Pagent` option to any Gradle tasks that extends `JavaForkOptions` (for example, `test` or `run`).
 
-The configuration block you added takes care of detecting resources, but it potentially adds more than what you need, and may not deal with more advanced use cases such as dynamic proxies. To demonstrate this approach, remove the `resources.autodetect()` configuration block.
-
 The following steps illustrate how to collect metadata using the agent, and then build a native executable using that metadata.
 
+. To demonstrate this approach, remove the `resources.autodetect()` block from your `build.gradle` file:
++
+[source,shell]
+----
+binaries.all {
+    resources.autodetect()
+}
+----
 . Run your application with the agent enabled:
 +
 [source,shell]
 ----
 ./gradlew -Pagent run
 ----
-. Once the metadata is collected, copy it into the project's
+It runs your application on the JVM with the agent, collects the metadata, and generates configuration files in the _$\{buildDir}/native/agent-output/$\{taskName}_ directory.
+. Copy the configuration files into the project's
 `/META-INF/native-image` directory using the `metadataCopy` task:
 +
 [source,shell]
@@ -436,16 +444,17 @@ If you need to test collecting metadata with the agent, add the
 `-Pagent` option to the `test` and `nativeTest` task invocations:
 
 . Run the tests on the JVM with the agent:
++
 [source,shell]
 ----
 ./gradlew -Pagent test
 ----
-
++
 It runs your application on the JVM with the agent, collects the metadata and uses it for testing on `native-image`. The generated configuration files (containing the metadata) can be found in the
 _$\{buildDir}/native/agent-output/$\{taskName}_ directory. 
 In this case, the plugin also substitutes `{output_dir}` in the agent options to point to this directory.
 . Build a native executable using the metadata collected by the agent:
-
++
 [source,shell]
 ----
 ./gradlew -Pagent nativeTest

--- a/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
@@ -26,7 +26,7 @@ The easiest way to install GraalVM with Native Image is to use the https://githu
 
 [source,bash]
 ----
-bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
+bash <(curl -sL https://get.graalvm.org/jdk)
 ----
 ====
 

--- a/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
@@ -1,0 +1,389 @@
+= Getting Started with Gradle Plugin for GraalVM Native Image
+
+This guide demonstrates how to quickly get started with the Gradle plugin for GraalVM Native Image to build a native executable from a Java application.
+
+You will create a sample application, enable the Gradle plugin for GraalVM Native Image, add support for dynamic features, run JUnit tests, and build a native executable.
+
+Two ways to build a native executable using the plugin are demonstrated:
+
+- <<#build-a-native-executable-with-resources-autodetection,Build a Native Executable with Resources Autodetection>>
+-  <<#build-a-native-executable-detecting-resources-with-the-agent,Build a Native Executable Detecting Resources with the Agent>>
+
+== Sample Application
+
+You start by creating a **Fortune Teller** sample application that simulates the traditional 
+https://en.wikipedia.org/wiki/Fortune_(Unix)[fortune Unix program]. 
+The data for the fortune phrases is provided by https://github.com/your-fortune[YourFortune].
+
+====
+To use the Native Build Tools, first install GraalVM. 
+The easiest way to install GraalVM is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
+```
+bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
+```
+
+====
+
+== Prepare a Demo Application
+
+. Create a new Java project with *Gradle* using the following command (alternatively, you can use your IDE to generate a project):
++
+[source,shell]
+----
+gradle init --project-name fortune --type java-application --package demo --test-framework junit-jupiter --dsl groovy
+----
+. Rename the default `app` directory to `fortune`, then rename the default filename `App.java` to `Fortune.java`, and replace its contents with the following:
++
+[source,java]
+----
+package demo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class Fortune {
+
+    private static final Random RANDOM = new Random();
+    private final ArrayList<String> fortunes = new ArrayList<>();
+
+    public Fortune() throws JsonProcessingException {
+        // Scan the file into the array of fortunes
+        String json = readInputStream(ClassLoader.getSystemResourceAsStream("fortunes.json"));
+        ObjectMapper omap = new ObjectMapper();
+        JsonNode root = omap.readTree(json);
+        JsonNode data = root.get("data");
+        Iterator<JsonNode> elements = data.elements();
+        while (elements.hasNext()) {
+            JsonNode quote = elements.next().get("quote");
+            fortunes.add(quote.asText());
+        }
+    }
+
+    private String readInputStream(InputStream is) {
+        StringBuilder out = new StringBuilder();
+        try (InputStreamReader streamReader = new InputStreamReader(is, StandardCharsets.UTF_8);
+             BufferedReader reader = new BufferedReader(streamReader)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                out.append(line);
+            }
+
+        } catch (IOException e) {
+            Logger.getLogger(Fortune.class.getName()).log(Level.SEVERE, null, e);
+        }
+        return out.toString();
+    }
+
+    public String randomFortune() {
+        //Pick a random number
+        int r = RANDOM.nextInt(fortunes.size());
+        //Use the random number to pick a random fortune
+        return fortunes.get(r);
+    }
+
+    private void printRandomFortune() throws InterruptedException {
+        String f = randomFortune();
+        // Print out the fortune s.l.o.w.l.y
+        for (char c : f.toCharArray()) {
+            System.out.print(c);
+            Thread.sleep(100);
+        }
+        System.out.println();
+    }
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(String[] args) throws InterruptedException, JsonProcessingException {
+        Fortune fortune = new Fortune();
+        fortune.printRandomFortune();
+    }
+}
+----
+. Delete the `fortune/src/test/java` directory, you will add tests in a later stage.
+. Copy and paste the following file,
+https://github.com/graalvm/graalvm-demos/blob/master/fortune-demo/fortune/src/main/resources/fortunes.json[fortunes.json] under `fortune/src/main/resources/`. Your project tree should be:
++
+[source,shell]
+----
+.
+├── fortune
+│   ├── build.gradle
+│   └── src
+│       ├── main
+│       │   ├── java
+│       │   │   └── demo
+│       │   │       └── Fortune.java
+│       │   └── resources
+│       │       └── fortunes.json
+│       └── test
+│           └── resources
+├── gradle
+│   └── wrapper
+│       ├── gradle-wrapper.jar
+│       └── gradle-wrapper.properties
+├── gradlew
+├── gradlew.bat
+└── settings.gradle
+----
+. Open the Gradle configuration file _build.gradle_, and update the main class in the `application` section:
++
+[source,xml]
+----
+application {
+    mainClass = 'demo.Fortune'
+}
+----
+. Add explicit FasterXML Jackson dependencies that provide functionality to read and write JSON, data bindings (used in the demo application). Insert the following three lines in the `dependencies` section of _build.gradle_:
++
+[source,xml]
+----
+implementation 'com.fasterxml.jackson.core:jackson-core:2.13.2'
+implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
+----
++
+Also, remove the dependency on `guava` that will not be used.
++
+The next steps demonstrate what you should do to enable the
+https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html[Gradle Plugin for GraalVM Native Image].
+. Register the plugin. Add the following to
+`plugins` section of your project’s _build.gradle_ file:
++
+[source,xml]
+----
+plugins {
+// ...
+
+id 'org.graalvm.buildtools.native' version '0.9.19'
+}
+----
++
+The plugin discovers which JAR files it needs to pass to the
+`native-image` builder and what the executable main class should be.
+. The plugin is not yet available on the Gradle Plugin Portal, so declare an additional plugin repository. Open the _settings.gradle_ file and replace the default content with this:
++
+[source,xml]
+----
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = 'fortune-parent'
+include('fortune')
+----
++
+Note that the `pluginManagement {}` block must appear before any other statements in the file.
+
+== Build a Native Executable with Resources Autodetection
+
+You can already build a native executable by running
+`./gradlew nativeCompile` or run it directly by invoking
+`./gradlew nativeRun`. However, at this stage, running the native executable will fail because this application requires additional metadata: you need to provide it with a list of resources to load.
+
+. Instruct the plugin to automatically detect resources to be included in the native executable. Add this to your `build.gradle` file:
++
+[source,xml]
+----
+graalvmNative {
+    binaries.all {
+        resources.autodetect()
+    }
+    toolchainDetection = false
+}
+----
++
+Another thing to note here: the plugin may not be able to properly detect the GraalVM installation, because of limitations in Gradle. By default, the plugin selects a Java 11 GraalVM Community Edition. If you want to use GraalVM Enterprise, or a particular version of GraalVM and Java, you need to explicitly tell this in plugin's configuration. For example:
++
+[source,xml]
+----
+graalvmNative {
+    binaries {
+        main {
+            javaLauncher = javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(8)
+                vendor = JvmVendorSpec.matching("GraalVM Community")
+            }
+        }
+    }
+}
+----
++
+The workaround to this is to disable toolchain detection with this command `toolchainDetection = false`.
+. Compile the project and build a native executable at one step:
++
+[source,shell]
+----
+./gradlew nativeRun
+----
++
+The native executable, named _fortune_, is created in the
+_/fortune/build/native/nativeCompile_ directory.
+. Run the native executable:
++
+[source,shell]
+----
+./fortune/build/native/nativeCompile/fortune
+----
++
+The application starts and prints a random quote.
+
+Configuring the `graalvmNative` plugin to automatically detect resources (`resources.autodetect()`) to be included in a binary is one way to make this example work. Using `resources.autodetect()` works because the application uses resources (_fortunes.json_) which are directly available in the `src/main/resources` location.
+
+In the next section, the guide shows that you can use the tracing agent to do the same.
+
+== Build a Native Executable by Detecting Resources with the Agent
+
+The Native Image Gradle plugin simplifies generation of the required metadata by injecting the
+https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html#agent-support[
+tracing agent] automatically for you at compile time. To enable the agent, just pass the `-Pagent` option to any Gradle tasks that extends `JavaForkOptions` (for example, `test` or `run`).
+
+The configuration block you added takes care of detecting resources, but it potentially adds more than what you need, and may not deal with more advanced use cases such as dynamic proxies. To demonstrate this approach, remove the `resources.autodetect()` configuration block.
+
+The following steps illustrate how to collect metadata using the agent, and then build a native executable using that metadata.
+
+. Run your application with the agent enabled:
++
+[source,shell]
+----
+./gradlew -Pagent run
+----
+. Once the metadata is collected, copy it into the project's
+`/META-INF/native-image` directory using the `metadataCopy` task:
++
+[source,shell]
+----
+./gradlew metadataCopy --task run --dir src/main/resources/META-INF/native-image
+----
+. Build a native executable using metadata acquired by the agent:
++
+[source,shell]
+----
+./gradlew nativeCompile
+----
++
+The native executable, named _fortune_, is created in the
+_build/native/nativeCompile_ directory.
+. Run the native executable:
++
+[source,shell]
+----
+./fortune/build/native/nativeCompile/fortune
+----
++
+The application starts and prints a random quote.
+
+To see the benefits of running your application as a native executable, `time` how long it takes and compare the results with running as a Java application.
+
+=== Plugin Customization
+
+You can customize the plugin. For example, change the name of the native executable and pass additional parameters to the plugin in the _build.gradle_ file, as follows:
+
+[source,xml]
+----
+graalvmNative {
+    binaries {
+        main {
+            imageName.set('fortuneteller') 
+            buildArgs.add('--verbose') 
+        }
+    }
+}
+----
+
+The native executable then will be called `fortuneteller`. Notice how you can pass additional arguments to the `native-image` tool using the `buildArgs.add` syntax.
+
+== Add JUnit Testing
+
+The Gradle plugin for GraalVM Native Image can run
+https://junit.org/junit5/docs/current/user-guide/[JUnit Platform] tests on your native executable. This means that the tests will be compiled and run as native code.
+
+. Create the following test in the
+`fortunate/src/test/java/demo/FortuneTest.java` file:
++
+[source,java]
+----
+package demo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FortuneTest {
+    @Test
+    @DisplayName("Returns a fortune")
+    void testItWorks() throws JsonProcessingException {
+        Fortune fortune = new Fortune();
+        assertTrue(fortune.randomFortune().length()>0);
+    }
+}
+----
+. Run JUnit tests:
++
+[source,shell]
+----
+./gradlew nativeTest
+----
++
+The plugin runs tests on the JVM prior to running tests from the native executable. To disable testing support (which comes by default), add the following configuration to the _build.gradle_ file:
++
+[source,xml]
+----
+graalvmNative {
+    testSupport = false
+}
+----
+
+== Run Tests with the Agent
+
+If you need to test collecting metadata with the agent, add the
+`-Pagent` option to the `test` and `nativeTest` task invocations:
+
+. Run the tests on the JVM with the agent:
++
+[source,shell]
+----
+./gradlew -Pagent test
+----
++
+It runs your application on the JVM with the agent, collects the metadata and uses it for testing on `native-image`. The generated configuration files (containing the metadata) can be found in the
+_$\{buildDir}/native/agent-output/$\{taskName}_ directory. 
+In this case, the plugin also substitutes `{output_dir}` in the agent options to point to this directory.
+. Build a native executable using the metadata collected by the agent:
++
+[source,shell]
+----
+./gradlew -Pagent nativeTest
+----
+
+=== Summary
+
+The Gradle plugin for GraalVM Native Image adds support for building and testing native executables using the https://gradle.org[Gradle]. The plugin has many more features, described in the 
+https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html[plugin
+reference documentation].
+
+Note that if your application does not call any classes dynamically at run time, the execution with the agent is needless. Your workflow in that case is just:
+
+[source,shell]
+----
+./gradlew nativeRun
+----
+
+Lastly, if you use GraalVM Enterprise as your `JAVA_HOME` environment, the plugin builds a native executable with enterprise features enabled.

--- a/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
@@ -16,7 +16,7 @@ https://en.wikipedia.org/wiki/Fortune_(Unix)[fortune Unix program].
 The data for the fortune phrases is provided by https://github.com/your-fortune[YourFortune].
 
 ====
-To use the Native Build Tools, first install GraalVM. 
+To use the Native Build Tools, install GraalVM with Native Image. 
 The easiest way to install GraalVM with Native Image is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
 ```
 bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'

--- a/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
@@ -1,15 +1,15 @@
 = Getting Started with Gradle Plugin for GraalVM Native Image
 
-This guide demonstrates how to quickly get started with the Gradle plugin for GraalVM Native Image to build a native executable from a Java application.
+This guide shows how to get started with the <<gradle-plugin.adoc,Gradle plugin for GraalVM Native Image>> and build a native executable for a Java application.
 
-You will create a sample application, enable the Gradle plugin for GraalVM Native Image, add support for dynamic features, run JUnit tests, and build a native executable.
+You will create a sample application, enable the plugin, add support for dynamic features, run JUnit tests, and build a native executable.
 
 Two ways to build a native executable using the plugin are demonstrated:
 
 - <<#build-a-native-executable-with-resources-autodetection,Build a Native Executable with Resources Autodetection>>
 -  <<#build-a-native-executable-detecting-resources-with-the-agent,Build a Native Executable Detecting Resources with the Agent>>
 
-== Sample Application
+.Note on a Sample Application
 
 You start by creating a **Fortune Teller** sample application that simulates the traditional 
 https://en.wikipedia.org/wiki/Fortune_(Unix)[fortune Unix program]. 
@@ -17,11 +17,10 @@ The data for the fortune phrases is provided by https://github.com/your-fortune[
 
 ====
 To use the Native Build Tools, first install GraalVM. 
-The easiest way to install GraalVM is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
+The easiest way to install GraalVM with Native Image is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
 ```
 bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
 ```
-
 ====
 
 == Prepare a Demo Application
@@ -375,11 +374,11 @@ In this case, the plugin also substitutes `{output_dir}` in the agent options to
 
 === Summary
 
-The Gradle plugin for GraalVM Native Image adds support for building and testing native executables using the https://gradle.org[Gradle]. The plugin has many more features, described in the 
+The Gradle plugin for GraalVM Native Image adds support for building and testing native executables using the https://gradle.org[Gradle]. The plugin has many features, described in the 
 https://graalvm.github.io/native-build-tools/latest/gradle-plugin.html[plugin
 reference documentation].
 
-Note that if your application does not call any classes dynamically at run time, the execution with the agent is needless. Your workflow in that case is just:
+Note that if your application does not call any classes dynamically at run time, the execution with the agent is needless. Your workflow, in that case, is just:
 
 [source,shell]
 ----

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -12,10 +12,15 @@ For upgrading please take a look at the <<index.adoc#changelog,Changelog>>.
 
 == Quickstart
 
-[NOTE]
+====
+<<gradle-plugin-quickstart.adoc,Getting Started with Gradle Plugin for GraalVM Native Image>>
+====
+
 ====
 You can find full samples in https://github.com/graalvm/native-build-tools/tree/master/samples[the source repository].
 ====
+
+== Reference Documentation
 
 === Adding the plugin
 

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -10,6 +10,7 @@ The {doctitle} adds support for building and testing native images using the htt
 
 For upgrading please take a look at the <<index.adoc#changelog,Changelog>>.
 
+[[quickstart]]
 == Quickstart
 
 ====
@@ -20,7 +21,15 @@ For upgrading please take a look at the <<index.adoc#changelog,Changelog>>.
 You can find full samples in https://github.com/graalvm/native-build-tools/tree/master/samples[the source repository].
 ====
 
-== Reference Documentation
+====
+The plugin requires that you <<graalvm-setup.adoc#,setup GraalVM and Native Image>>.
+The easiest way to install GraalVM is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
+```
+bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
+```
+====
+
+== Reference documentation
 
 === Adding the plugin
 

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -23,7 +23,7 @@ You can find full samples in https://github.com/graalvm/native-build-tools/tree/
 
 ====
 The plugin requires that you <<graalvm-setup.adoc#,setup GraalVM and Native Image>>.
-The easiest way to install GraalVM is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
+The easiest way to install GraalVM with Native Image is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
 ```
 bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
 ```

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -25,7 +25,7 @@ You can find full samples in https://github.com/graalvm/native-build-tools/tree/
 The plugin requires that you <<graalvm-setup.adoc#,setup GraalVM and Native Image>>.
 The easiest way to install GraalVM with Native Image is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
 ```
-bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
+bash <(curl -sL https://get.graalvm.org/jdk)
 ```
 ====
 

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -14,7 +14,7 @@ For upgrading please take a look at the <<index.adoc#changelog,Changelog>>.
 == Quickstart
 
 ====
-<<gradle-plugin-quickstart.adoc,Getting Started with Gradle Plugin for GraalVM Native Image>>
+<<gradle-plugin-quickstart.adoc#,Getting Started with Gradle Plugin for GraalVM Native Image>>
 ====
 
 ====

--- a/docs/src/docs/asciidoc/maven-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin-quickstart.adoc
@@ -1,14 +1,19 @@
 = Getting Started with Maven Plugin for GraalVM Native Image
+The GraalVM team
+:highlighjsdir: {gradle-relative-srcdir}/highlight
 
-This guide shows how to get started with the <<maven-plugin.adoc,Maven plugin for GraalVM Native Image>> and build a native executable for a Java application.
+This guide shows how to get started with the <<maven-plugin.adoc#,Maven plugin for GraalVM Native Image>> and build a native executable for a Java application.
 
 You will create a sample application, enable the plugin, add support for dynamic features, run JUnit tests, and build a native executable.
 
-.Note on a Sample Application
+[NOTE]
+====
+.Sample Application
 
-You start by creating a **Fortune Teller** sample application that simulates the traditional 
-https://en.wikipedia.org/wiki/Fortune_(Unix)[fortune Unix program]. 
+You start by creating a **Fortune Teller** sample application that simulates the traditional
+https://en.wikipedia.org/wiki/Fortune_(Unix)[fortune Unix program].
 The data for the fortune phrases is provided by https://github.com/your-fortune[YourFortune].
+====
 
 ====
 The plugin requires that you <<graalvm-setup.adoc#,setup GraalVM and Native Image>>.
@@ -21,7 +26,9 @@ It will then make use of Maven profiles to enable building and testing of native
 
 == Prepare a Demo Application
 
-. Create a new Java project with *Maven* in your favorite IDE, called "Fortune", in the `demo` package. The application should contain a sole Java file with the following content:
+. Create a new Java project with *Maven* in your favorite IDE, called "Fortune", in the `demo` package.
+Make sure to choose JUnit Jupiter as the test engine.
+The application should contain a sole Java file with the following content:
 +
 [source,java]
 ----
@@ -99,7 +106,7 @@ public class Fortune {
 }
 ----
 . Copy and paste the following file,
-https://github.com/graalvm/graalvm-demos/blob/master/fortune-demo/fortune/src/main/resources/fortunes.json[fortunes.json] under `resources/`. Your project tree should be:
+https://raw.githubusercontent.com/graalvm/graalvm-demos/master/fortune-demo/fortune/src/main/resources/fortunes.json[fortunes.json] under `resources/`. Your project tree should be:
 +
 [source,shell]
 ----
@@ -339,7 +346,7 @@ The agent generates the configuration files in a subdirectory of `target/native/
 +
 [source,shell]
 ----
-mvn -Pnative -Dagent package
+mvn -DskipTests=true -Pnative -Dagent package
 ----
 +
 When the command completes a native executable, _fortune_, is created in the _/target_ directory of the project and ready for use.
@@ -402,6 +409,30 @@ the following example:
     </dependency>
 </dependencies>
 ----
+. Create the following test in the
+`src/test/java/demo/FortuneTest.java` file:
++
+.src/test/java/demo/FortuneTest.java
+[source,java]
+----
+package demo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FortuneTest {
+    @Test
+    @DisplayName("Returns a fortune")
+    void testItWorks() throws JsonProcessingException {
+        Fortune fortune = new Fortune();
+        assertTrue(fortune.randomFortune().length()>0);
+    }
+}
+----
++
 . Run native tests:
 +
 [source,shell]
@@ -413,7 +444,7 @@ Run `-Pnative` profile will then build and run native tests.
 
 === Summary
 
-The Maven plugin for GraalVM Native Image adds support for building and testing native executables using https://maven.apache.org/[Apache Maven™]. The plugin has many features, described in the <<maven-plugin.adoc,plugin reference documentation>>.
+The Maven plugin for GraalVM Native Image adds support for building and testing native executables using https://maven.apache.org/[Apache Maven™]. The plugin has many features, described in the <<maven-plugin.adoc#,plugin reference documentation>>.
 
 Note that if your application does not call any classes dynamically at run time, the execution with the agent is needless. Your workflow, in that case, is just:
 

--- a/docs/src/docs/asciidoc/maven-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin-quickstart.adoc
@@ -19,7 +19,7 @@ The data for the fortune phrases is provided by https://github.com/your-fortune[
 The plugin requires that you <<graalvm-setup.adoc#,setup GraalVM and Native Image>>.
 The easiest way to install GraalVM with Native Image is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
 ```
-bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
+bash <(curl -sL https://get.graalvm.org/jdk)
 ```
 It will then make use of Maven profiles to enable building and testing of native executables. 
 ====
@@ -263,6 +263,7 @@ https://graalvm.github.io/native-build-tools/latest/maven-plugin.html[Maven plug
 </profiles>
 ----
 +
+It pulls the latest plugin version. Replace `${native.maven.plugin.version}` with a specific version if you prefer.
 The plugin discovers which JAR files it needs to pass to the
 `native-image` builder and what the executable main class should be. With this plugin you can already build a native executable directly with Maven by running `mvn -Pnative package` (if your application does not call any methods reflectively at run time).
 +
@@ -328,7 +329,7 @@ application the plugin.
 
 == Build a Native Executable
 
-. Compile the project on the Java VM to create a runnable JAR with all dependencies. Open a terminal window and, from the root application directory, run:
+. Compile the project on the JVM to create a runnable JAR with all dependencies. Open a terminal window and, from the root application directory, run:
 +
 [source,shell]
 ----
@@ -341,7 +342,7 @@ mvn clean package
 mvn -Pnative -Dagent exec:exec@java-agent
 ----
 +
-The agent generates the configuration files in a subdirectory of `target/native/agent-output`. Those files will be automatically used by the `native-image` tool if you pass the appropriate options.
+The agent collects the metadata and generates the configuration files in a subdirectory of `target/native/agent-output`. Those files will be automatically used by the `native-image` tool if you pass the appropriate options.
 . Now build a native executable with the Maven profile:
 +
 [source,shell]

--- a/docs/src/docs/asciidoc/maven-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin-quickstart.adoc
@@ -446,14 +446,4 @@ Run `-Pnative` profile will then build and run native tests.
 
 The Maven plugin for GraalVM Native Image adds support for building and testing native executables using https://maven.apache.org/[Apache Maven™]. The plugin has many features, described in the <<maven-plugin.adoc#,plugin reference documentation>>.
 
-Note that if your application does not call any classes dynamically at run time, the execution with the agent is needless. Your workflow, in that case, is just:
-
-[source,shell]
-----
-mvn clean compile
-mvn -Pnative package
-----
-
-Another advantage of the plugin is that if you use GraalVM Enterprise as
-your `JAVA_HOME` environment, the plugin builds a native executable with
-enterprise features enabled.
+Note that if your application does not call any classes dynamically at run time, the execution with the agent is needless. Your workflow, in that case, is just `mvn clean -Pnative package`.

--- a/docs/src/docs/asciidoc/maven-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin-quickstart.adoc
@@ -1,0 +1,428 @@
+= Getting Started with Maven Plugin for GraalVM Native Image
+
+This guide shows how to get started with the <<maven-plugin.adoc,Maven plugin for GraalVM Native Image>> and build a native executable for a Java application.
+
+You will create a sample application, enable the plugin, add support for dynamic features, run JUnit tests, and build a native executable.
+
+.Note on a Sample Application
+
+You start by creating a **Fortune Teller** sample application that simulates the traditional 
+https://en.wikipedia.org/wiki/Fortune_(Unix)[fortune Unix program]. 
+The data for the fortune phrases is provided by https://github.com/your-fortune[YourFortune].
+
+====
+The plugin requires that you <<graalvm-setup.adoc#,setup GraalVM and Native Image>>.
+The easiest way to install GraalVM with Native Image is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
+```
+bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
+```
+It will then make use of Maven profiles to enable building and testing of native executables. 
+====
+
+== Prepare a Demo Application
+
+. Create a new Java project with *Maven* in your favorite IDE, called "Fortune", in the `demo` package. The application should contain a sole Java file with the following content:
++
+[source,java]
+----
+package demo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class Fortune {
+
+    private static final Random RANDOM = new Random();
+    private final ArrayList<String> fortunes = new ArrayList<>();
+
+    public Fortune() throws JsonProcessingException {
+        // Scan the file into the array of fortunes
+        String json = readInputStream(ClassLoader.getSystemResourceAsStream("fortunes.json"));
+        ObjectMapper omap = new ObjectMapper();
+        JsonNode root = omap.readTree(json);
+        JsonNode data = root.get("data");
+        Iterator<JsonNode> elements = data.elements();
+        while (elements.hasNext()) {
+            JsonNode quote = elements.next().get("quote");
+            fortunes.add(quote.asText());
+        }      
+    }
+    
+    private String readInputStream(InputStream is) {
+        StringBuilder out = new StringBuilder();
+        try (InputStreamReader streamReader = new InputStreamReader(is, StandardCharsets.UTF_8);
+            BufferedReader reader = new BufferedReader(streamReader)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                out.append(line);
+            }
+
+        } catch (IOException e) {
+            Logger.getLogger(Fortune.class.getName()).log(Level.SEVERE, null, e);
+        }
+        return out.toString();
+    }
+    
+    private void printRandomFortune() throws InterruptedException {
+        //Pick a random number
+        int r = RANDOM.nextInt(fortunes.size());
+        //Use the random number to pick a random fortune
+        String f = fortunes.get(r);
+        // Print out the fortune s.l.o.w.l.y
+        for (char c: f.toCharArray()) {
+            System.out.print(c);
+            Thread.sleep(100);   
+        }
+        System.out.println();
+    }
+
+    /**
+    * @param args the command line arguments
+    * @throws java.lang.InterruptedException
+    * @throws com.fasterxml.jackson.core.JsonProcessingException
+    */
+    public static void main(String[] args) throws InterruptedException, JsonProcessingException {
+        Fortune fortune = new Fortune();
+        fortune.printRandomFortune();
+    }
+}
+----
+. Copy and paste the following file,
+https://github.com/graalvm/graalvm-demos/blob/master/fortune-demo/fortune/src/main/resources/fortunes.json[fortunes.json] under `resources/`. Your project tree should be:
++
+[source,shell]
+----
+.
+├── pom.xml
+└── src
+    └── main
+        ├── java
+        │   └── demo
+        │       └── Fortune.java
+        └── resources
+            └── fortunes.json
+----
+. Add explicit FasterXML Jackson dependencies that provide functionality to read and write JSON, data bindings (used in the demo application). Open the _pom.xml_ file (a Maven configuration file), and insert the following in the `<dependencies>` section:
++
+[source,xml]
+----
+<dependencies>
+    <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.12.6.1</version>
+    </dependency>
+</dependencies>
+----
+. Add regular Maven plugins for building and assembling a Maven project into an executable JAR. Insert the following into the `build` section in the _pom.xml_ file:
++
+[source,xml]
+----
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+                <execution>
+                    <id>java</id>
+                    <goals>
+                        <goal>java</goal>
+                    </goals>
+                    <configuration>
+                        <mainClass>${mainClass}</mainClass>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.1</version>
+            <configuration>
+                <source>${maven.compiler.source}</source>
+                <target>${maven.compiler.source}</target>
+            </configuration>
+        </plugin>
+
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>3.2.2</version>
+            <configuration>
+                <archive>
+                    <manifest>
+                        <addClasspath>true</addClasspath>
+                        <mainClass>${mainClass}</mainClass>
+                    </manifest>
+                </archive>
+            </configuration>
+        </plugin>
+
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+                <execution>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>single</goal>
+                    </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <archive>
+                    <manifest>
+                        <addClasspath>true</addClasspath>
+                        <mainClass>${mainClass}</mainClass>
+                    </manifest>
+                </archive>
+                <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+            </configuration>
+        </plugin>
+
+    </plugins>
+</build>
+----
+. Replace the default `<properties>` section in the _pom.xml_ file with this content:
++
+[source,xml]
+----
+<properties>
+    <native.maven.plugin.version>0.9.18</native.maven.plugin.version>
+    <junit.jupiter.version>5.8.1</junit.jupiter.version>
+    <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+    <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+    <imageName>fortune</imageName>
+    <mainClass>demo.Fortune</mainClass>
+</properties>
+----
++
+The statements "hardcoded" plugin versions and the entry point class to your application. The next steps demonstrate what you should do to enable the
+https://graalvm.github.io/native-build-tools/latest/maven-plugin.html[Maven plugin for GraalVM Native Image].
+. Register the Maven plugin for GraalVM Native Image,
+`native-maven-plugin`, in the profile called `native` by adding the following to the _pom.xml_ file:
++
+[source,xml]
+----
+<profiles>
+    <profile>
+        <id>native</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.graalvm.buildtools</groupId>
+                    <artifactId>native-maven-plugin</artifactId>
+                    <version>${native.maven.plugin.version}</version>
+                    <extensions>true</extensions>
+                    <executions>
+                        <execution>
+                            <id>build-native</id>
+                            <goals>
+                                <goal>build</goal>
+                            </goals>
+                            <phase>package</phase>
+                        </execution>
+                        <execution>
+                            <id>test-native</id>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                            <phase>test</phase>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <fallback>false</fallback>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+</profiles>
+----
++
+The plugin discovers which JAR files it needs to pass to the
+`native-image` builder and what the executable main class should be. With this plugin you can already build a native executable directly with Maven by running `mvn -Pnative package` (if your application does not call any methods reflectively at run time).
++
+This demo application is a little more complicated than `HelloWorld`, and requires metadata before building a native executable. You do not have to configure anything manually: the plugin can generate the required metadata for you by
+injecting the https://graalvm.github.io/native-build-tools/latest/maven-plugin.html#agent-support[tracing
+agent] at package time. The agent is disabled by default, and can be enabled in project's _pom.xml_ file or via the command line.
+
+- To enable the agent via the _pom.xml_ file, specify
+`<enabled>true</enabled>` in the `native-maven-plugin` plugin
+configuration:
++
+[source,xml]
+----
+<configuration>
+<agent>
+    <enabled>true</enabled>
+</agent>
+</configuration>
+----
+- To enable the agent via the command line, pass the `-Dagent=true` option when running Maven. 
++ 
+So your next step is to run with the agent.
+. Before running with the agent, register a separate Mojo execution in the `native` profile which allows forking the Java process. It is required to run your application with the agent.
++
+[source,xml]
+----
+<plugin>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>exec-maven-plugin</artifactId>
+    <version>3.0.0</version>
+    <executions>
+        <execution>
+            <id>java-agent</id>
+            <goals>
+                <goal>exec</goal>
+            </goals>
+            <configuration>
+                <executable>java</executable>
+                <workingDirectory>${project.build.directory}</workingDirectory>
+                <arguments>
+                    <argument>-classpath</argument>
+                    <classpath/>
+                    <argument>${mainClass}</argument>
+                </arguments>
+            </configuration>
+        </execution>
+        <execution>
+            <id>native</id>
+            <goals>
+                <goal>exec</goal>
+            </goals>
+            <configuration>
+                <executable>${project.build.directory}/${imageName}</executable>
+                <workingDirectory>${project.build.directory}</workingDirectory>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+----
++
+Now you are all set to to build a native executable from a Java
+application the plugin.
+
+== Build a Native Executable
+
+. Compile the project on the Java VM to create a runnable JAR with all dependencies. Open a terminal window and, from the root application directory, run:
++
+[source,shell]
+----
+mvn clean package
+----
+. Run your application with the agent enabled:
++
+[source,shell]
+----
+mvn -Pnative -Dagent exec:exec@java-agent
+----
++
+The agent generates the configuration files in a subdirectory of `target/native/agent-output`. Those files will be automatically used by the `native-image` tool if you pass the appropriate options.
+. Now build a native executable with the Maven profile:
++
+[source,shell]
+----
+mvn -Pnative -Dagent package
+----
++
+When the command completes a native executable, _fortune_, is created in the _/target_ directory of the project and ready for use.
++
+The executable's name is derived from the artifact ID, but you can specify any custom name in `native-maven-plugin` within a
+`<configuration>` node:
++
+[source,xml]
+----
+<configuration>
+    <imageName>fortuneteller</imageName>
+</configuration>
+----
+. Run the demo directly or with the Maven profile:
++
+[source,shell]
+----
+./target/fortune
+----
++
+[source,shell]
+----
+mvn -Pnative exec:exec@native
+----
+
+To see the benefits of running your application as a native executable,
+`time` how long it takes and compare the results with running on the
+JVM.
+
+== Add JUnit Testing
+
+The Maven plugin for GraalVM Native Image can run
+https://junit.org/junit5/docs/current/user-guide/[JUnit Platform] tests on a native executable. This means that tests will be compiled and executed as native code.
+
+This plugin requires JUnit Platform 1.8 or higher and Maven Surefire 2.22.0 or higher to run tests on a native executable.
+
+. Enable extensions in the plugin's configuration,
+`<extensions>true</extensions>`:
++
+[source,xml]
+----
+<plugin>
+    <groupId>org.graalvm.buildtools</groupId>
+    <artifactId>native-maven-plugin</artifactId>
+    <version>${native.maven.plugin.version}</version>
+    <extensions>true</extensions>
+----
+. Add an explicit dependency on the `junit-platform-launcher` artifact
+to the dependencies section of your native profile configuration as in
+the following example:
++
+[source,xml]
+----
+<dependencies>
+    <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-launcher</artifactId>
+        <version>1.8.2</version>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+----
+. Run native tests:
++
+[source,shell]
+----
+mvn -Pnative test
+----
++
+Run `-Pnative` profile will then build and run native tests.
+
+=== Summary
+
+The Maven plugin for GraalVM Native Image adds support for building and testing native executables using https://maven.apache.org/[Apache Maven™]. The plugin has many features, described in the <<maven-plugin.adoc,plugin reference documentation>>.
+
+Note that if your application does not call any classes dynamically at run time, the execution with the agent is needless. Your workflow, in that case, is just:
+
+[source,shell]
+----
+mvn clean compile
+mvn -Pnative package
+----
+
+Another advantage of the plugin is that if you use GraalVM Enterprise as
+your `JAVA_HOME` environment, the plugin builds a native executable with
+enterprise features enabled.

--- a/docs/src/docs/asciidoc/maven-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin-quickstart.adoc
@@ -208,10 +208,10 @@ https://raw.githubusercontent.com/graalvm/graalvm-demos/master/fortune-demo/fort
 ----
 . Replace the default `<properties>` section in the _pom.xml_ file with this content:
 +
-[source,xml]
+[source,xml,subs="verbatim,attributes"]
 ----
 <properties>
-    <native.maven.plugin.version>0.9.18</native.maven.plugin.version>
+    <native.maven.plugin.version>{maven-plugin-version}</native.maven.plugin.version>
     <junit.jupiter.version>5.8.1</junit.jupiter.version>
     <maven.compiler.source>${java.specification.version}</maven.compiler.source>
     <maven.compiler.target>${java.specification.version}</maven.compiler.target>

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -14,17 +14,25 @@ For upgrading please take a look at the <<index.adoc#changelog,Changelog>>.
 [[quickstart]]
 == Quickstart
 
+====
+<<maven-plugin-quickstart.adoc,Getting Started with Maven Plugin for GraalVM Native Image>>
+====
 
-[NOTE]
 ====
 You can find full samples in https://github.com/graalvm/native-build-tools/tree/master/samples[the source repository].
 ====
 
-This plugin first requires that you <<graalvm-setup.adoc#,setup GraalVM and `native-image` properly>>.
-It will then make use of Maven profiles to enable building and testing of native images.
+====
+The plugin requires that you <<graalvm-setup.adoc#,setup GraalVM and Native Image>>.
+The easiest way to install GraalVM is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
+```
+bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
+```
+It will then make use of Maven profiles to enable building and testing of native executables.
+====
 
 [[configuration]]
-== Configuration
+== Reference documentation
 
 [[configuration-registering-plugin]]
 === Registering the plugin

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -24,7 +24,7 @@ You can find full samples in https://github.com/graalvm/native-build-tools/tree/
 
 ====
 The plugin requires that you <<graalvm-setup.adoc#,setup GraalVM and Native Image>>.
-The easiest way to install GraalVM is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
+The easiest way to install GraalVM with Native Image is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
 ```
 bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
 ```

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -15,7 +15,7 @@ For upgrading please take a look at the <<index.adoc#changelog,Changelog>>.
 == Quickstart
 
 ====
-<<maven-plugin-quickstart.adoc,Getting Started with Maven Plugin for GraalVM Native Image>>
+<<maven-plugin-quickstart.adoc#,Getting Started with Maven Plugin for GraalVM Native Image>>
 ====
 
 ====

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -26,7 +26,7 @@ You can find full samples in https://github.com/graalvm/native-build-tools/tree/
 The plugin requires that you <<graalvm-setup.adoc#,setup GraalVM and Native Image>>.
 The easiest way to install GraalVM with Native Image is to use the https://github.com/graalvm/graalvm-jdk-downloader[GraalVM JDK Downloader]:
 ```
-bash <(curl -sL https://get.graalvm.org/jdk) -c 'native-image'
+bash <(curl -sL https://get.graalvm.org/jdk)
 ```
 It will then make use of Maven profiles to enable building and testing of native executables.
 ====

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -14,6 +14,7 @@ For upgrading please take a look at the <<index.adoc#changelog,Changelog>>.
 [[quickstart]]
 == Quickstart
 
+
 [NOTE]
 ====
 You can find full samples in https://github.com/graalvm/native-build-tools/tree/master/samples[the source repository].


### PR DESCRIPTION
Add quickstart guides for beginners, using a “clean” Java project. The guide shows how to create a demo app, enable Maven/Gradle plugin, provide the required configuration, build a native executable, and add and run jUnit tests. 