### PR TITLE
Fix deadlock when collecting metadata

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -19,6 +19,12 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 [[changelog]]
 == Changelog
 
+=== Release 0.9.20
+
+==== Gradle plugin
+
+- Fix `collectReachabilityMetadata` not being thread-safe
+
 === Release 0.9.19
 
 ==== Gradle plugin

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -387,6 +387,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                 .getSharedServices()
                 .registerIfAbsent("nativeConfigurationService", GraalVMReachabilityMetadataService.class, spec -> {
                     LogLevel logLevel = determineLogLevel();
+                    spec.getMaxParallelUsages().set(1);
                     spec.getParameters().getLogLevel().set(logLevel);
                     spec.getParameters().getUri().set(repositoryExtension.getUri().map(configuredUri -> computeMetadataRepositoryUri(project, repositoryExtension, configuredUri, GraalVMLogger.of(project.getLogger()))));
                     spec.getParameters().getCacheDir().set(


### PR DESCRIPTION
The reachability metadata service is not thread-safe, but it is possible for it to be called from multiple tasks in a multi-project. It this happens, then a deadlock may happen, or weird errors with a property not set can be thrown at the user.

This fixes the problem by making sure only a single task can access the service concurrently. Ideally, the service should be reworked to allow concurrent access, but it's quite some work since it involves locking access to the repository (typically to download and unzip metadata).

Fixes #387