### PR TITLE
Enable metadata copy when agent is enabled from cmd

### DIFF
--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
@@ -81,10 +81,10 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
     def "test agent with metadata copy task"() {
         given:
         withSample("java-application-with-reflection")
-        mvn'-Pnative', '-DskipNativeBuild=true', 'package', 'exec:exec@java-agent'
+        mvn'-Pnative', '-DskipNativeBuild=true', 'package', '-Dagent=true', 'exec:exec@java-agent'
 
         when:
-        mvn'-Pnative', '-DskipNativeTests', 'native:metadata-copy'
+        mvn'-Pnative', '-DskipNativeTests', '-Dagent=true', 'native:metadata-copy'
 
         then:
         buildSucceeded

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
@@ -54,7 +54,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
         when:
         // Run Maven in debug mode (-X) in order to capture the command line arguments
         // used to launch Surefire with the agent.
-        mvnDebug '-Pnative', 'test', '-DskipNativeTests'
+        mvnDebug '-Pnative', 'test', '-Dagent=true', '-DskipNativeTests'
 
         then:
         // Agent is used with Surefire

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
@@ -81,7 +81,7 @@ public class MetadataCopyMojo extends AbstractMergeAgentFilesMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
-        if (agentConfiguration != null && (agentConfiguration.isEnabled() || session.getSystemProperties().getProperty("agent").equalsIgnoreCase("true"))) {
+        if (agentConfiguration != null && (agentConfiguration.isEnabled() || agentIsEnabledFromCmd())) {
             // in direct mode user is fully responsible for agent configuration, and we will not execute anything besides line that user provided
             if (agentConfiguration.getDefaultMode().equalsIgnoreCase("direct")) {
                 logger.info("You are running agent in direct mode. Skipping both merge and metadata copy tasks.");
@@ -217,6 +217,18 @@ public class MetadataCopyMojo extends AbstractMergeAgentFilesMojo {
         List<String> diff = new ArrayList<>(list1);
         diff.removeAll(list2);
         return diff;
+    }
+
+    private boolean agentIsEnabledFromCmd() {
+        if (session == null) {
+            return false;
+        }
+
+        if (session.getSystemProperties().getProperty("agent") == null) {
+            return false;
+        }
+
+        return session.getSystemProperties().getProperty("agent").equalsIgnoreCase("true");
     }
 
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
@@ -40,6 +40,7 @@
  */
 package org.graalvm.buildtools.maven;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -75,9 +76,12 @@ public class MetadataCopyMojo extends AbstractMergeAgentFilesMojo {
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
+    @Parameter(defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
     @Override
     public void execute() throws MojoExecutionException {
-        if (agentConfiguration != null && agentConfiguration.isEnabled()) {
+        if (agentConfiguration != null && (agentConfiguration.isEnabled() || session.getSystemProperties().getProperty("agent").equalsIgnoreCase("true"))) {
             // in direct mode user is fully responsible for agent configuration, and we will not execute anything besides line that user provided
             if (agentConfiguration.getDefaultMode().equalsIgnoreCase("direct")) {
                 logger.info("You are running agent in direct mode. Skipping both merge and metadata copy tasks.");

--- a/samples/java-application-with-reflection/pom.xml
+++ b/samples/java-application-with-reflection/pom.xml
@@ -141,7 +141,6 @@
                         <configuration>
                             <!-- end::native-plugin-agent-options[] -->
                             <agent>
-                                <enabled>true</enabled>
                                 <defaultMode>Standard</defaultMode>
                                 <options>
                                     <builtinCallerFilter>true</builtinCallerFilter>


### PR DESCRIPTION
This PR should fix [this](https://github.com/graalvm/native-build-tools/issues/403) issue. Previously metadata-copy mojo didn't check if agent is enabled via command line