### PR TITLE
Add a new write-args-file goal

### DIFF
--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/FileUtilsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/FileUtilsTest.java
@@ -80,21 +80,21 @@ class FileUtilsTest {
     @Test
     @DisplayName("It doesn't blow up with a URL that isn't a file download")
     void testDownloadNoFile(@TempDir Path tempDir) throws IOException {
-        URL url = new URL("https://httpstat.us/200");
+        URL url = new URL("https://httpbin.org/html");
         List<String> errorLogs = new ArrayList<>();
 
         Optional<Path> download = FileUtils.download(url, tempDir, errorLogs::add);
         System.out.println("errorLogs = " + errorLogs);
 
         assertTrue(download.isPresent());
-        assertEquals("200", download.get().getFileName().toString());
+        assertEquals("html", download.get().getFileName().toString());
         assertEquals(0, errorLogs.size());
     }
 
     @Test
     @DisplayName("It doesn't blow up with a URL that does not exist")
     void testDownloadNotFound(@TempDir Path tempDir) throws IOException {
-        URL url = new URL("https://httpstat.us/404");
+        URL url = new URL("https://google.com/notfound");
         List<String> errorLogs = new ArrayList<>();
 
         Optional<Path> download = FileUtils.download(url, tempDir, errorLogs::add);
@@ -107,7 +107,7 @@ class FileUtilsTest {
     @Test
     @DisplayName("It doesn't blow up with connection timeouts")
     void testDownloadTimeout(@TempDir Path tempDir) throws IOException {
-        URL url = new URL("https://httpstat.us/200?sleep=" + (FileUtils.READ_TIMEOUT + 1000));
+        URL url = new URL("https://httpbin.org/delay/10");
         List<String> errorLogs = new ArrayList<>();
 
         Optional<Path> download = FileUtils.download(url, tempDir, errorLogs::add);

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -21,10 +21,6 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 
 === Release 0.9.21
 
-==== Gradle plugin
-
-- TBD
-
 ==== Maven plugin
 
 - Add a new `native:write-args-file` goal that can be used to write the arguments passed to `native-image` to a file

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -19,6 +19,16 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 [[changelog]]
 == Changelog
 
+=== Release 0.9.21
+
+==== Gradle plugin
+
+- TBD
+
+==== Maven plugin
+
+- Add a new `native:write-args-file` goal that can be used to write the arguments passed to `native-image` to a file
+
 === Release 0.9.20
 
 ==== Gradle plugin

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -399,6 +399,9 @@ Under Windows, https://github.com/graalvm/native-build-tools/issues/85[it is pos
 
 To avoid this, since release 0.9.10, the plugin will use an argument file to pass the arguments to the `native-image` tool, instead of passing them directly.
 
+There is also a `native:write-args-file` goal that can be used to generate this argument file. This can be useful in situations where the Native Build Tools plugin is not available, for example, when running native-image in a Docker container. The path to the args file is stored in the project properties
+under the key `graalvm.native-image.args-file`, so that other Maven plugins further in the lifecycle can use it.
+
 In case you are using a GraalVM version older than 21.3, you will however have to use a workaround, since the argument file wasn't supported.
 
 One option is to use a https://maven.apache.org/plugins/maven-shade-plugin[shaded jar] and use it instead of individual jars on classpath.

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
@@ -108,4 +108,15 @@ class JavaApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
         outputContains "Hello, native!"
     }
 
+    def "can write the args file"() {
+        withSample("java-application")
+
+        when:
+        mvn '-Pnative', 'native:write-args-file'
+
+        then:
+        buildSucceeded
+        outputContains "Args file written to: target/native-image"
+    }
+
 }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
@@ -167,12 +167,12 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         withLocalServer()
 
         when:
-        mvn '-Pnative,metadataUrl', "-Dmetadata.url=https://httpstat.us/404", '-DskipTests', 'package', 'exec:exec@native'
+        mvn '-Pnative,metadataUrl', "-Dmetadata.url=https://google.com/notfound", '-DskipTests', 'package', 'exec:exec@native'
 
         then:
         buildSucceeded
         outputContains "Reflection failed"
-        outputContains "Failed to download from https://httpstat.us/404: 404 Not Found"
+        outputContains "Failed to download from https://google.com/notfound: 404 Not Found"
     }
 
     void "it can include hints in jar"() {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/WriteArgsFileMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/WriteArgsFileMojo.java
@@ -1,3 +1,44 @@
+/*
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.graalvm.buildtools.maven;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -14,7 +55,7 @@ import java.util.List;
  *
  * The path to the args file is stored in the project properties under the key {@code graalvm.native-image.args-file}.
  *
- * @author Álvaro Sánchez-Mariscal
+ * @author Alvaro Sanchez-Mariscal
  * @since 0.9.21
  */
 @Mojo(name = WriteArgsFileMojo.NAME, requiresDependencyResolution = ResolutionScope.RUNTIME, requiresDependencyCollection = ResolutionScope.RUNTIME)

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/WriteArgsFileMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/WriteArgsFileMojo.java
@@ -1,0 +1,39 @@
+package org.graalvm.buildtools.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.graalvm.buildtools.utils.NativeImageUtils;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Persists the arguments file to be used by the native-image command. This can be useful in situations where
+ * Native Build Tools plugin is not available, for example, when running native-image in a Docker container.
+ *
+ * The path to the args file is stored in the project properties under the key {@code graalvm.native-image.args-file}.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 0.9.21
+ */
+@Mojo(name = WriteArgsFileMojo.NAME, requiresDependencyResolution = ResolutionScope.RUNTIME, requiresDependencyCollection = ResolutionScope.RUNTIME)
+public class WriteArgsFileMojo extends NativeCompileNoForkMojo {
+
+    public static final String NAME = "write-args-file";
+    public static final String PROPERTY_NAME = "graalvm.native-image.args-file";
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        List<String> args = getBuildArgs();
+        List<String> conversionResult = NativeImageUtils.convertToArgsFile(args, outputDirectory.toPath());
+        if (conversionResult.size() == 1) {
+            String argsFileName = conversionResult.get(0).replace("@", "");
+            getLog().info("Args file written to: " + argsFileName);
+            File argsFile = new File(argsFileName);
+            project.getProperties().setProperty(PROPERTY_NAME, argsFile.getAbsolutePath());
+        } else {
+            throw new MojoExecutionException("Error writing args file");
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a goal that only writes the args file, so that other plugins further in the lifecycle can use it. In particular, the Micronaut Maven Plugin needs this goal.

The path to the args file is stored in the `MavenProject` properties, an approach that is used by other plugins such as the JaCoCo Maven Plugin.