### PR TITLE
Update <buildArgs> Maven documentation

### DIFF
--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -134,7 +134,7 @@ Build Configuration]. It is also possible to customize the plugin within a
 [source,xml]
 ----
 <buildArgs>
-    <arg>--argument</arg>
+    --argument
 </buildArgs>
 ----
 `<skipNativeBuild>`::
@@ -279,7 +279,7 @@ The `<buildArgs>` element can be combined between parent and children POMs. Supp
     <imageName>${project.artifactId}</imageName>
     <mainClass>${exec.mainClass}</mainClass>
     <buildArgs>
-      <buildArg>--no-fallback</buildArg>
+      --no-fallback
     </buildArgs>
   </configuration>
 </plugin>
@@ -427,7 +427,7 @@ Depending on the other plugins your build uses (typically the Spring Boot plugin
 		<imageName>${project.artifactId}</imageName>
 		<mainClass>${exec.mainClass}</mainClass>
 		<buildArgs>
-			<buildArg>--no-fallback</buildArg>
+			--no-fallback
 		</buildArgs>
 		<classpath>
 			<param>


### PR DESCRIPTION
Sources:

- https://docs.oracle.com/en/graalvm/enterprise/20/docs/reference-manual/native-image/NativeImageMavenPlugin/
- Local issues with following documentation in the current state, fixed with the above