### PR TITLE
Add support for `default-for` attribute

### DIFF
--- a/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/internal/index/artifacts/Artifact.java
+++ b/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/internal/index/artifacts/Artifact.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Set;
+import java.util.regex.Pattern;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Artifact {
@@ -53,18 +54,21 @@ public class Artifact {
     private final String directory;
     private final boolean latest;
     private final boolean override;
+    private final Pattern defaultForPattern;
 
     @JsonCreator
     public Artifact(@JsonProperty("module") String module,
                     @JsonProperty("tested-versions") Set<String> versions,
                     @JsonProperty("metadata-version") String directory,
                     @JsonProperty(value = "latest", defaultValue = "false") boolean latest,
-                    @JsonProperty(value = "override", defaultValue = "false") boolean override) {
+                    @JsonProperty(value = "override", defaultValue = "false") boolean override,
+                    @JsonProperty(value = "default-for") String defaultFor) {
         this.module = module;
         this.versions = versions;
         this.directory = directory;
         this.latest = latest;
         this.override = override;
+        this.defaultForPattern = (defaultFor == null ? null : Pattern.compile(defaultFor));
     }
 
     public String getModule() {
@@ -85,5 +89,9 @@ public class Artifact {
 
     public boolean isOverride() {
         return override;
+    }
+
+    public boolean isDefaultFor(String version) {
+        return defaultForPattern != null && defaultForPattern.matcher(version).matches();
     }
 }

--- a/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/internal/index/artifacts/SingleModuleJsonVersionToConfigDirectoryIndex.java
+++ b/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/internal/index/artifacts/SingleModuleJsonVersionToConfigDirectoryIndex.java
@@ -91,7 +91,8 @@ public class SingleModuleJsonVersionToConfigDirectoryIndex implements VersionToC
      */
     @Override
     public Optional<DirectoryConfiguration> findConfiguration(String groupId, String artifactId, String version) {
-        return findConfigurationFor(groupId, artifactId, version, artifact -> artifact.getVersions().contains(version));
+        return findConfigurationFor(groupId, artifactId, version,
+                artifact -> artifact.getVersions().contains(version) || artifact.isDefaultFor(version));
     }
 
     @Override
@@ -101,15 +102,16 @@ public class SingleModuleJsonVersionToConfigDirectoryIndex implements VersionToC
     }
 
     /**
-     * Returns the latest configuration directory for the requested artifact.
+     * Returns the matching configuration directory for the requested artifact.
      *
      * @param groupId the group ID of the artifact
      * @param artifactId the artifact ID of the artifact
+     * @param version the version of the artifact
      * @return a configuration directory, or empty if no configuration directory is available
      */
     @Override
     public Optional<DirectoryConfiguration> findLatestConfigurationFor(String groupId, String artifactId, String version) {
-        return findConfigurationFor(groupId, artifactId, version, Artifact::isLatest);
+        return findConfigurationFor(groupId, artifactId, version, artifact -> artifact.isDefaultFor(version) || artifact.isLatest());
     }
 
     private Optional<DirectoryConfiguration> findConfigurationFor(String groupId, String artifactId, String version,

--- a/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/internal/index/artifacts/SingleModuleJsonVersionToConfigDirectoryIndex.java
+++ b/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/internal/index/artifacts/SingleModuleJsonVersionToConfigDirectoryIndex.java
@@ -91,8 +91,9 @@ public class SingleModuleJsonVersionToConfigDirectoryIndex implements VersionToC
      */
     @Override
     public Optional<DirectoryConfiguration> findConfiguration(String groupId, String artifactId, String version) {
-        return findConfigurationFor(groupId, artifactId, version,
-                artifact -> artifact.getVersions().contains(version) || artifact.isDefaultFor(version));
+        Optional<DirectoryConfiguration> exactMatch = findConfigurationFor(groupId, artifactId, version, artifact -> artifact.getVersions().contains(version));
+        return exactMatch.isPresent() ? exactMatch :
+                findConfigurationFor(groupId, artifactId, version, artifact -> artifact.isDefaultFor(version));
     }
 
     @Override
@@ -111,7 +112,9 @@ public class SingleModuleJsonVersionToConfigDirectoryIndex implements VersionToC
      */
     @Override
     public Optional<DirectoryConfiguration> findLatestConfigurationFor(String groupId, String artifactId, String version) {
-        return findConfigurationFor(groupId, artifactId, version, artifact -> artifact.isDefaultFor(version) || artifact.isLatest());
+        Optional<DirectoryConfiguration> defaultMatch = findConfigurationFor(groupId, artifactId, version, artifact -> artifact.isDefaultFor(version));
+        return defaultMatch.isPresent() ? defaultMatch :
+                findConfigurationFor(groupId, artifactId, version, Artifact::isLatest);
     }
 
     private Optional<DirectoryConfiguration> findConfigurationFor(String groupId, String artifactId, String version,

--- a/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/internal/index/artifacts/SingleModuleJsonVersionToConfigDirectoryIndexTest.java
+++ b/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/internal/index/artifacts/SingleModuleJsonVersionToConfigDirectoryIndexTest.java
@@ -115,14 +115,25 @@ class SingleModuleJsonVersionToConfigDirectoryIndexTest {
         assertTrue(config.isPresent());
         assertEquals(repoPath.resolve("2.0"), config.get().getDirectory());
 
-        Optional<DirectoryConfiguration> latest = index.findLatestConfigurationFor("com.foo", "bar", "123");
-        assertTrue(latest.isPresent());
-        assertEquals(repoPath.resolve("2.0"), latest.get().getDirectory());
-
         config = index.findConfiguration("com.foo", "baz", "1.1");
         assertTrue(config.isPresent());
         assertEquals(repoPath.resolve("1.0"), config.get().getDirectory());
 
+        Optional<DirectoryConfiguration> latest = index.findLatestConfigurationFor("com.foo", "bar", "123");
+        assertTrue(latest.isPresent());
+        assertEquals(repoPath.resolve("2.0"), latest.get().getDirectory());
+
+        latest = index.findLatestConfigurationFor("com.foo", "bar", "123");
+        assertTrue(latest.isPresent());
+        assertEquals(repoPath.resolve("2.0"), latest.get().getDirectory());
+
+        latest = index.findLatestConfigurationFor("com.foo", "bar", "1.0");
+        assertTrue(latest.isPresent());
+        assertEquals(repoPath.resolve("1.0"), latest.get().getDirectory());
+
+        latest = index.findLatestConfigurationFor("com.foo", "bar", "2.0");
+        assertTrue(latest.isPresent());
+        assertEquals(repoPath.resolve("2.0"), latest.get().getDirectory());
     }
 
     private void withIndex(String json) throws URISyntaxException {

--- a/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/internal/index/artifacts/SingleModuleJsonVersionToConfigDirectoryIndexTest.java
+++ b/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/internal/index/artifacts/SingleModuleJsonVersionToConfigDirectoryIndexTest.java
@@ -95,6 +95,36 @@ class SingleModuleJsonVersionToConfigDirectoryIndexTest {
 
     }
 
+    @Test
+    void checkIndexWithDefaultFor() throws URISyntaxException {
+        withIndex("artifact-2");
+
+        Optional<DirectoryConfiguration> config = index.findConfiguration("com.foo", "bar", "1.0");
+        assertTrue(config.isPresent());
+        assertEquals(repoPath.resolve("1.0"), config.get().getDirectory());
+
+        config = index.findConfiguration("com.foo", "bar", "1.1");
+        assertTrue(config.isPresent());
+        assertEquals(repoPath.resolve("1.0"), config.get().getDirectory());
+
+        config = index.findConfiguration("com.foo", "bar", "2.0");
+        assertTrue(config.isPresent());
+        assertEquals(repoPath.resolve("2.0"), config.get().getDirectory());
+
+        config = index.findConfiguration("com.foo", "bar", "2.1");
+        assertTrue(config.isPresent());
+        assertEquals(repoPath.resolve("2.0"), config.get().getDirectory());
+
+        Optional<DirectoryConfiguration> latest = index.findLatestConfigurationFor("com.foo", "bar", "123");
+        assertTrue(latest.isPresent());
+        assertEquals(repoPath.resolve("2.0"), latest.get().getDirectory());
+
+        config = index.findConfiguration("com.foo", "baz", "1.1");
+        assertTrue(config.isPresent());
+        assertEquals(repoPath.resolve("1.0"), config.get().getDirectory());
+
+    }
+
     private void withIndex(String json) throws URISyntaxException {
         repoPath = new File(SingleModuleJsonVersionToConfigDirectoryIndexTest.class.getResource("/json/" + json).toURI()).toPath();
         index = new SingleModuleJsonVersionToConfigDirectoryIndex(repoPath);

--- a/common/graalvm-reachability-metadata/src/test/resources/json/artifact-2/index.json
+++ b/common/graalvm-reachability-metadata/src/test/resources/json/artifact-2/index.json
@@ -1,0 +1,5 @@
+[
+  { "module": "com.foo:bar", "tested-versions": ["1.0"], "metadata-version": "1.0", "default-for": "1\\..*" },
+  { "module": "com.foo:bar", "tested-versions": ["2.0", "2.1"], "metadata-version": "2.0", "latest": true },
+  { "module": "com.foo:baz", "tested-versions": ["1.0"], "metadata-version": "1.0", "default-for": "1.*" }
+]


### PR DESCRIPTION
This new `index.json` attribute is design to allow more flexible version matching to avoid breakage due to switch on latest version for untested ones.

It should have a `default-for` key and a regexp as a string value, for example "1\\.0\\..*" which should match versions like "1.0.0", "1.0.1", "1.0.2", etc.

Please do not merge before @aclement has given his +1.

See oracle/graalvm-reachability-metadata#62
See oracle/graalvm-reachability-metadata#275