### PR TITLE
Fix "collect reachability metadata" with config cache

### DIFF
--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -287,6 +287,7 @@ public class NativeImagePlugin implements Plugin<Project> {
         project.getTasks().register("collectReachabilityMetadata", CollectReachabilityMetadata.class, task -> {
             task.setGroup(LifecycleBasePlugin.BUILD_GROUP);
             task.setDescription("Obtains native reachability metdata for the runtime classpath configuration");
+            task.setClasspath(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
         });
 
         GraalVMReachabilityMetadataRepositoryExtension metadataRepositoryExtension = reachabilityExtensionOn(graalExtension);


### PR DESCRIPTION
This commit fixes the compatbilility of the "collect reachability metadata" task with Gradle's configuration cache. It does so by moving from a configuration as input to a resolved component result.