### PR TITLE
Fix the name of the sub-XML tag of the XML tag of the classpath in the document

### DIFF
--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -228,8 +228,8 @@ Build Configuration]. It is also possible to customize the plugin within a
 [source,xml]
 ----
 <classpath>
-    <entry>path/to/file.jar</entry>
-    <entry>path/to/classes</entry>
+    <param>path/to/file.jar</param>
+    <param>path/to/classes</param>
 </classpath>
 ----
 `<classesDirectory>`::


### PR DESCRIPTION
- Fixes https://github.com/graalvm/native-build-tools/issues/316 .
- Fix the name of the sub-XML tag of the XML tag of the classpath in the document.