### PR TITLE
Bump metadata version to 0.3.4 and update docs

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -19,7 +19,13 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 [[changelog]]
 == Changelog
 
+=== Release 0.9.25
+
+* Upgrade metadata to 0.3.4
+
 === Release 0.9.24
+
+* Upgrade metadata to 0.3.3
 
 ==== Gradle plugin
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Project versions
 nativeBuildTools = "0.9.25-SNAPSHOT"
-metadataRepository = "0.3.3"
+metadataRepository = "0.3.4"
 
 # External dependencies
 spock = "2.1-groovy-3.0"


### PR DESCRIPTION
- Bumps metadata repository version to 0.3.4
- Updates documentation for this and previous release