### PR TITLE
Prepare NBT for release of GraalVM for JDK 21.

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -22,7 +22,7 @@ jobs:
         os: [ ubuntu-20.04 ]
     steps:
       - name: "☁  Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ssh-key: "${{ secrets.SSH_PRIVATE_KEY }}"
       - name: "🔧 Prepare environment"

--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -24,7 +24,7 @@ jobs:
         os: [ ubuntu-22.04 ]
     steps:
       - name: "☁  Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ssh-key: "${{ secrets.SSH_PRIVATE_KEY }}"
       - name: "🔧 Prepare environment"

--- a/.github/workflows/test-graalvm-metadata.yml
+++ b/.github/workflows/test-graalvm-metadata.yml
@@ -28,7 +28,7 @@ jobs:
         os: [ ubuntu-20.04 ]
     steps:
       - name: "☁️ Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "🔧 Prepare environment"
         uses: ./.github/actions/prepare-environment
         with:

--- a/.github/workflows/test-junit-platform-native.yml
+++ b/.github/workflows/test-junit-platform-native.yml
@@ -28,7 +28,7 @@ jobs:
         os: [ ubuntu-20.04 ]
     steps:
       - name: "☁️ Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "🔧 Prepare environment"
         uses: ./.github/actions/prepare-environment
         with:

--- a/.github/workflows/test-native-gradle-plugin.yml
+++ b/.github/workflows/test-native-gradle-plugin.yml
@@ -32,7 +32,7 @@ jobs:
         os: [ ubuntu-20.04 ]
     steps:
       - name: "☁️ Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "🔧 Prepare environment"
         uses: ./.github/actions/prepare-environment
         with:
@@ -59,7 +59,7 @@ jobs:
         os: [ ubuntu-20.04 ]
     steps:
       - name: "☁️ Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: ./.github/actions/prepare-environment
         with:
           java-version: ${{ matrix.java-version }}
@@ -86,7 +86,7 @@ jobs:
         os: [ windows-latest ]
     steps:
       - name: "☁️ Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: ./.github/actions/prepare-environment
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/test-native-maven-plugin.yml
+++ b/.github/workflows/test-native-maven-plugin.yml
@@ -32,7 +32,7 @@ jobs:
         os: [ ubuntu-20.04 ]
     steps:
       - name: "☁️ Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: ./.github/actions/prepare-environment
         with:
           java-version: ${{ matrix.java-version }}
@@ -57,7 +57,7 @@ jobs:
         os: [ windows-latest ]
     steps:
       - name: "☁️ Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: ./.github/actions/prepare-environment
         with:
           java-version: ${{ matrix.java-version }}

--- a/common/graalvm-reachability-metadata/gradle/native-image-testing.gradle
+++ b/common/graalvm-reachability-metadata/gradle/native-image-testing.gradle
@@ -98,8 +98,7 @@ abstract class NativeTestArgumentProvider implements CommandLineArgumentProvider
                 "-cp", classpath.asPath,
                 "--no-fallback",
                 "--features=org.graalvm.junit.platform.JUnitPlatformFeature",
-                "-H:Name=native-image-tests",
-                "-H:Class=org.graalvm.junit.platform.NativeImageJUnitLauncher",
+                "-o", "native-image-tests",
                 "-Djunit.platform.listeners.uid.tracking.output.dir=${testIdsDir.get().asFile.absolutePath}"
         ]
         if (agentOutputDir.isPresent()) {
@@ -110,12 +109,15 @@ abstract class NativeTestArgumentProvider implements CommandLineArgumentProvider
             }
 
             args << "-H:ConfigurationFileDirectories=${outputDir.absolutePath}/agentOutput"
-            args << "-H:+AllowIncompleteClasspath"
         }
 
         if (discovery.get()) {
             args << "-DtestDiscovery"
         }
+
+        // Main class comes last
+        args << "org.graalvm.junit.platform.NativeImageJUnitLauncher"
+
         args.collect { it.toString() }
     }
 }

--- a/common/junit-platform-native/gradle/native-image-testing.gradle
+++ b/common/junit-platform-native/gradle/native-image-testing.gradle
@@ -96,8 +96,7 @@ abstract class NativeTestArgumentProvider implements CommandLineArgumentProvider
                 "-cp", classpath.asPath,
                 "--no-fallback",
                 "--features=org.graalvm.junit.platform.JUnitPlatformFeature",
-                "-H:Name=native-image-tests",
-                "-H:Class=org.graalvm.junit.platform.NativeImageJUnitLauncher",
+                "-o", "native-image-tests",
                 "-Djunit.platform.listeners.uid.tracking.output.dir=${testIdsDir.get().asFile.absolutePath}"
         ]
         if (agentOutputDir.isPresent()) {
@@ -108,12 +107,15 @@ abstract class NativeTestArgumentProvider implements CommandLineArgumentProvider
             }
 
             args << "-H:ConfigurationFileDirectories=${outputDir.absolutePath}/agentOutput"
-            args << "-H:+AllowIncompleteClasspath"
         }
 
         if (discovery.get()) {
             args << "-DtestDiscovery"
         }
+
+        // Main class comes last
+        args << "org.graalvm.junit.platform.NativeImageJUnitLauncher"
+
         args.collect { it.toString() }
     }
 }

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -22,6 +22,7 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 === Release 0.9.26
 
 * Relax GraalVM version check for dev versions
+* Prepare plugins for release of *GraalVM for JDK 21*. They no longer deploy any experimental options.
 
 ==== Gradle plugin
 

--- a/docs/src/docs/snippets/gradle/groovy/build.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/build.gradle
@@ -129,7 +129,7 @@ graalvmNative {
             excludeConfig.put(file("path/to/artifact.jar"), listOf("^/META-INF/native-image/.*", "^/config/.*"))
 
             // Advanced options
-            buildArgs.add('-H:Extra') // Passes '-H:Extra' to the native image builder options. This can be used to pass parameters which are not directly supported by this extension
+            buildArgs.add('--link-at-build-time') // Passes '--link-at-build-time' to the native image builder options. This can be used to pass parameters which are not directly supported by this extension
             jvmArgs.add('flag') // Passes 'flag' directly to the JVM running the native image builder
 
             // Runtime options

--- a/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
+++ b/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
@@ -130,7 +130,7 @@ graalvmNative {
             excludeConfig.put(file("path/to/artifact.jar"), listOf("^/META-INF/native-image/.*", "^/config/.*"))
 
             // Advanced options
-            buildArgs.add("-H:Extra") // Passes '-H:Extra' to the native image builder options. This can be used to pass parameters which are not directly supported by this extension
+            buildArgs.add("--link-at-build-time") // Passes '--link-at-build-time' to the native image builder options. This can be used to pass parameters which are not directly supported by this extension
             jvmArgs.add("flag") // Passes 'flag' directly to the JVM running the native image builder
 
             // Runtime options

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaLibraryFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaLibraryFunctionalTest.groovy
@@ -70,7 +70,7 @@ class JavaLibraryFunctionalTest extends AbstractFunctionalTest {
             doesNotContain ':build'
         }
 
-        outputContains "-H:+SharedLibrary"
+        outputContains "--shared"
 
         and:
         library.exists()


### PR DESCRIPTION
This PR changes NBT so that it only uses public / stable Native Image API, which otherwise would require uses to unlock experimental options (see https://github.com/oracle/graal/issues/7105 for context) in the next release of GraalVM.