### PR TITLE
Fixes the problem that `org.junit.jupiter.api.condition.EnabledOnOs` cannot be used in NativeTest

### DIFF
--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java
@@ -69,6 +69,7 @@ public class JupiterConfigProvider implements PluginConfigProvider {
     @Override
     public void onLoad(NativeImageConfiguration config) {
         config.initializeAtBuildTime(
+                "org.junit.jupiter.api.condition.OS",
                 "org.junit.jupiter.engine.config.EnumConfigurationParameterConverter",
                 "org.junit.jupiter.engine.descriptor.ClassTestDescriptor",
                 "org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor",

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/OSTest.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/OSTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.junit.jupiter;
+
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.util.Locale;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class OSTest {
+    @Test
+    @EnabledOnOs({OS.LINUX})
+    public void timeoutTest() {
+        assertThat(System.getProperties().getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("linux"), is(true));
+    }
+}


### PR DESCRIPTION
- Fixes https://github.com/oracle/graalvm-reachability-metadata/issues/24 .
- For https://github.com/oracle/graalvm-reachability-metadata/issues/206 .
- Fixes the problem that `org.junit.jupiter.api.condition.EnabledOnOs` cannot be used in NativeTest.
- This will avoid duplication of configuration as follows.
```groovy
binaries {
         test {
             buildArgs.add("--initialize-at-build-time=org.junit.jupiter.api.condition.OS")
         }
}
```