### PR TITLE
Bug fixes and improvements for GraalVM for JDK 21.

### DIFF
--- a/.github/workflows/test-native-gradle-plugin.yml
+++ b/.github/workflows/test-native-gradle-plugin.yml
@@ -48,6 +48,8 @@ jobs:
   functional-testing-gradle-plugin-dev:
     name: "Functional testing (GraalVM Dev Build)"
     runs-on: ${{ matrix.os }}
+    env:
+      IS_GRAALVM_DEV_BUILD: 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-native-gradle-plugin.yml
+++ b/.github/workflows/test-native-gradle-plugin.yml
@@ -45,6 +45,37 @@ jobs:
         with:
           name: unit-tests-results
           path: native-gradle-plugin/build/reports/tests/test/
+  functional-testing-gradle-plugin-dev:
+    name: "Functional testing (GraalVM Dev Build)"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [ 17 ]
+        os: [ ubuntu-20.04 ]
+    steps:
+      - name: "☁️ Checkout repository"
+        uses: actions/checkout@v2
+      - uses: ./.github/actions/prepare-environment
+        with:
+          java-version: ${{ matrix.java-version }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "🔧 Install GraalVM (dev)"
+        uses: graalvm/setup-graalvm@main
+        with:
+          components: 'native-image'
+          github-token: ${{ inputs.github-token }}
+          java-version: 'dev'
+          distribution: 'graalvm'
+          set-java-home: 'false'
+      - name: "❓ Check and test the plugin"
+        run: ./gradlew :native-gradle-plugin:functionalTest
+      - name: "📜 Upload functional tests results"
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: functional-tests-results-graalvm-dev
+          path: native-gradle-plugin/build/reports/tests/functionalTest/
   functional-testing-gradle-plugin:
     name: "Functional testing"
     runs-on: ${{ matrix.os }}

--- a/build-logic/gradle-functional-testing/src/main/groovy/org.graalvm.build.functional-testing.gradle
+++ b/build-logic/gradle-functional-testing/src/main/groovy/org.graalvm.build.functional-testing.gradle
@@ -74,6 +74,7 @@ configurations {
 gradlePlugin.testSourceSets(sourceSets.functionalTest)
 configurations.functionalTestImplementation.extendsFrom(configurations.testImplementation)
 
+def graalVmHomeProvider = providers.environmentVariable("GRAALVM_HOME")
 def graalVm = javaToolchains.launcherFor {
     languageVersion.set(JavaLanguageVersion.of(17))
 //    vendor.set(JvmVendorSpec.matching("Oracle Corporation"))
@@ -99,7 +100,14 @@ def fullFunctionalTest = tasks.register("fullFunctionalTest")
             systemProperty('common.repo.url', configurations.functionalTestCommonRepository.incoming.files.files[0])
             systemProperty('gradle.test.version', effectiveVersion)
             systemProperty('versions.junit', libs.versions.junitJupiter.get())
-            environment('GRAALVM_HOME', graalVm.get().metadata.installationPath.asFile.absolutePath)
+            environment('GRAALVM_HOME', graalVmHomeProvider.
+                    orElse(providers.provider(() -> graalVm.get().metadata.installationPath.asFile.absolutePath))
+                    .map {
+                        println("Test task $taskName will use GRAALVM_HOME = $it")
+                        it
+                    }
+                    .get()
+            )
             testClassesDirs = sourceSets.functionalTest.output.classesDirs
             classpath = sourceSets.functionalTest.runtimeClasspath
             javaLauncher.set(graalVm)

--- a/build-logic/gradle-functional-testing/src/main/groovy/org.graalvm.build.functional-testing.gradle
+++ b/build-logic/gradle-functional-testing/src/main/groovy/org.graalvm.build.functional-testing.gradle
@@ -75,6 +75,7 @@ gradlePlugin.testSourceSets(sourceSets.functionalTest)
 configurations.functionalTestImplementation.extendsFrom(configurations.testImplementation)
 
 def graalVmHomeProvider = providers.environmentVariable("GRAALVM_HOME")
+def isGraalVmDevBuild = providers.environmentVariable("IS_GRAALVM_DEV_BUILD")
 def graalVm = javaToolchains.launcherFor {
     languageVersion.set(JavaLanguageVersion.of(17))
 //    vendor.set(JvmVendorSpec.matching("Oracle Corporation"))
@@ -108,6 +109,9 @@ def fullFunctionalTest = tasks.register("fullFunctionalTest")
                     }
                     .get()
             )
+            if (isGraalVmDevBuild.isPresent()) {
+                environment('IS_GRAALVM_DEV_BUILD', 'true')
+            }
             testClassesDirs = sourceSets.functionalTest.output.classesDirs
             classpath = sourceSets.functionalTest.runtimeClasspath
             javaLauncher.set(graalVm)

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/NativeImageConfigurationImpl.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/NativeImageConfigurationImpl.java
@@ -65,18 +65,6 @@ class NativeImageConfigurationImpl implements NativeImageConfiguration {
         RuntimeReflection.register(fields);
     }
 
-    @Override
-    public void initializeAtBuildTime(String... classNames) {
-        for (String className : classNames) {
-            Class<?> clazz;
-            try {
-                clazz = Class.forName(className);
-                initializeAtBuildTime(clazz);
-            } catch (ClassNotFoundException e) {
-                JUnitPlatformFeature.debug("[Native Image Configuration] Failed to register class for build time initialization: %s Reason: %s", className, e);
-            }
-        }
-    }
 
     @Override
     public void initializeAtBuildTime(Class<?>... classes) {

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/core/PluginConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/core/PluginConfigProvider.java
@@ -47,4 +47,8 @@ public interface PluginConfigProvider {
 
     void onTestClassRegistered(Class<?> testClass, NativeImageConfiguration registry);
 
+    default int getMajorJDKVersion() {
+        return Runtime.version().feature();
+    }
+
 }

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java
@@ -68,7 +68,7 @@ public class JupiterConfigProvider implements PluginConfigProvider {
 
     @Override
     public void onLoad(NativeImageConfiguration config) {
-        String[] buildTimeInitializedClasses = new String[]{
+        config.initializeAtBuildTime(
                 "org.junit.jupiter.engine.config.EnumConfigurationParameterConverter",
                 "org.junit.jupiter.engine.descriptor.ClassTestDescriptor",
                 "org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor",
@@ -84,23 +84,12 @@ public class JupiterConfigProvider implements PluginConfigProvider {
                 // new in Junit 5.10
                 "org.junit.platform.launcher.core.LauncherConfig",
                 "org.junit.jupiter.engine.config.InstantiatingConfigurationParameterConverter"
-        };
-        for (String className : buildTimeInitializedClasses) {
-            config.initializeAtBuildTime(className);
-        }
+        );
 
-        String[] registeredForReflection = {
+        config.registerAllClassMembersForReflection(
                 "org.junit.jupiter.engine.extension.TimeoutExtension$ExecutorResource",
                 "org.junit.jupiter.engine.extension.TimeoutInvocationFactory$SingleThreadExecutorResource"
-        };
-        for (String className : registeredForReflection) {
-            try {
-                Class <?> executor = Class.forName(className);
-                config.registerAllClassMembersForReflection(executor);
-            } catch (ClassNotFoundException e) {
-                debug("Failed to register class for reflection. Reason: %s", e);
-            }
-        }
+        );
     }
 
     @Override

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java
@@ -86,6 +86,27 @@ public class JupiterConfigProvider implements PluginConfigProvider {
                 "org.junit.jupiter.engine.config.InstantiatingConfigurationParameterConverter"
         );
 
+        if (getMajorJDKVersion() >= 21) {
+            /* new with simulated class initialization */
+            config.initializeAtBuildTime(
+                    "org.junit.jupiter.api.DisplayNameGenerator$Standard",
+                    "org.junit.jupiter.api.extension.ConditionEvaluationResult",
+                    "org.junit.jupiter.api.TestInstance$Lifecycle",
+                    "org.junit.jupiter.engine.config.CachingJupiterConfiguration",
+                    "org.junit.jupiter.engine.config.DefaultJupiterConfiguration",
+                    "org.junit.jupiter.engine.descriptor.DynamicDescendantFilter",
+                    "org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor",
+                    "org.junit.jupiter.engine.descriptor.NestedClassTestDescriptor",
+                    "org.junit.jupiter.engine.execution.InterceptingExecutableInvoker",
+                    "org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall",
+                    "org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall$VoidMethodInterceptorCall",
+                    "org.junit.jupiter.engine.execution.InvocationInterceptorChain",
+                    "org.junit.jupiter.engine.JupiterTestEngine",
+                    "org.junit.jupiter.params.provider.EnumSource$Mode$Validator"
+            );
+        }
+
+
         config.registerAllClassMembersForReflection(
                 "org.junit.jupiter.engine.extension.TimeoutExtension$ExecutorResource",
                 "org.junit.jupiter.engine.extension.TimeoutInvocationFactory$SingleThreadExecutorResource"

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/platform/PlatformConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/platform/PlatformConfigProvider.java
@@ -63,6 +63,30 @@ public class PlatformConfigProvider implements PluginConfigProvider {
                 "org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener"
         );
 
+        if (getMajorJDKVersion() >= 21) {
+            /* new with simulated class initialization */
+            config.initializeAtBuildTime(
+                    "org.junit.platform.engine.support.descriptor.ClassSource",
+                    "org.junit.platform.engine.support.descriptor.MethodSource",
+                    "org.junit.platform.engine.support.hierarchical.Node$ExecutionMode",
+                    "org.junit.platform.engine.TestDescriptor$Type",
+                    "org.junit.platform.engine.UniqueId",
+                    "org.junit.platform.engine.UniqueId$Segment",
+                    "org.junit.platform.launcher.core.DefaultLauncher",
+                    "org.junit.platform.launcher.core.DefaultLauncherConfig",
+                    "org.junit.platform.launcher.core.EngineExecutionOrchestrator",
+                    "org.junit.platform.launcher.core.LauncherConfigurationParameters$ParameterProvider$2",
+                    "org.junit.platform.launcher.core.LauncherConfigurationParameters$ParameterProvider$3",
+                    "org.junit.platform.launcher.core.LauncherDiscoveryResult",
+                    "org.junit.platform.launcher.core.LauncherListenerRegistry",
+                    "org.junit.platform.launcher.core.ListenerRegistry",
+                    "org.junit.platform.launcher.core.SessionPerRequestLauncher",
+                    "org.junit.platform.launcher.LauncherSessionListener$1",
+                    "org.junit.platform.launcher.listeners.UniqueIdTrackingListener",
+                    "org.junit.platform.reporting.shadow.org.opentest4j.reporting.events.api.DocumentWriter$1"
+            );
+        }
+
         try {
             /* Verify if the core JUnit Platform test class is available on the classpath */
             Class.forName("org.junit.platform.commons.annotation.Testable");

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/platform/PlatformConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/platform/PlatformConfigProvider.java
@@ -48,7 +48,7 @@ public class PlatformConfigProvider implements PluginConfigProvider {
 
     @Override
     public void onLoad(NativeImageConfiguration config) {
-        String[] buildTimeInitializedClasses = new String[] {
+        config.initializeAtBuildTime(
                 "org.junit.platform.launcher.TestIdentifier",
                 "org.junit.platform.launcher.core.InternalTestPlan",
                 "org.junit.platform.commons.util.StringUtils",
@@ -61,10 +61,7 @@ public class PlatformConfigProvider implements PluginConfigProvider {
                 "org.junit.platform.commons.util.ReflectionUtils",
                 // https://github.com/graalvm/native-build-tools/issues/300
                 "org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener"
-        };
-        for (String className : buildTimeInitializedClasses) {
-            config.initializeAtBuildTime(className);
-        }
+        );
 
         try {
             /* Verify if the core JUnit Platform test class is available on the classpath */

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/util/Utils.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/util/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -39,39 +39,22 @@
  * SOFTWARE.
  */
 
-package org.graalvm.junit.platform.config.core;
+package org.graalvm.junit.platform.config.util;
 
 import org.graalvm.junit.platform.JUnitPlatformFeature;
-import org.graalvm.junit.platform.config.util.Utils;
 
-import java.lang.reflect.Executable;
-import java.lang.reflect.Field;
+import java.util.Arrays;
 
-public interface NativeImageConfiguration {
-
-    void registerForReflection(Class<?>... classes);
-
-    void registerForReflection(Executable... methods);
-
-    void registerForReflection(Field... fields);
-
-    default void registerAllClassMembersForReflection(String... classNames) {
-        registerAllClassMembersForReflection(Utils.toClasses(classNames));
-    };
-
-    default void registerAllClassMembersForReflection(Class<?>... classes) {
-        for (Class<?> clazz : classes) {
-            JUnitPlatformFeature.debug("[Native Image Configuration] Registering for reflection: %s", clazz.getName());
-            registerForReflection(clazz);
-            registerForReflection(clazz.getDeclaredConstructors());
-            registerForReflection(clazz.getDeclaredMethods());
-            registerForReflection(clazz.getDeclaredFields());
-        }
+public class Utils {
+    public static Class<?>[] toClasses(String... classNames) {
+        return Arrays.stream(classNames).map(className -> {
+            Class<?> clazz = null;
+            try {
+                clazz = Class.forName(className);
+            } catch (ClassNotFoundException e) {
+                JUnitPlatformFeature.debug("[Native Image Configuration] Failed to resolve: %s Reason: %s", className, e);
+            }
+            return clazz;
+        }).filter(c -> c != null).toArray(Class[]::new);
     }
-
-    default void initializeAtBuildTime(String... classNames) {
-        initializeAtBuildTime(Utils.toClasses(classNames));
-    };
-
-    void initializeAtBuildTime(Class<?>... classes);
 }

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/vintage/VintageConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/vintage/VintageConfigProvider.java
@@ -48,7 +48,7 @@ public class VintageConfigProvider implements PluginConfigProvider {
 
     @Override
     public void onLoad(NativeImageConfiguration config) {
-        String[] buildTimeInitializedClasses = new String[]{
+        config.initializeAtBuildTime(
                 "org.junit.vintage.engine.descriptor.RunnerTestDescriptor",
                 "org.junit.vintage.engine.support.UniqueIdReader",
                 "org.junit.vintage.engine.support.UniqueIdStringifier",
@@ -57,10 +57,7 @@ public class VintageConfigProvider implements PluginConfigProvider {
                 "org.junit.runners.JUnit4",
                 /* Workaround until we can register serializable classes from a native-image feature */
                 "org.junit.runner.Result"
-        };
-        for (String className : buildTimeInitializedClasses) {
-            config.initializeAtBuildTime(className);
-        }
+        );
     }
 
     @Override

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/vintage/VintageConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/vintage/VintageConfigProvider.java
@@ -58,6 +58,19 @@ public class VintageConfigProvider implements PluginConfigProvider {
                 /* Workaround until we can register serializable classes from a native-image feature */
                 "org.junit.runner.Result"
         );
+
+        if (getMajorJDKVersion() >= 21) {
+            /* new with simulated class initialization */
+            config.initializeAtBuildTime(
+                    "java.lang.annotation.Annotation",
+                    "org.junit.runners.model.FrameworkMethod",
+                    "org.junit.runners.model.TestClass",
+                    "org.junit.runners.ParentRunner$1",
+                    "org.junit.Test",
+                    "org.junit.vintage.engine.descriptor.VintageEngineDescriptor",
+                    "org.junit.vintage.engine.VintageTestEngine"
+            );
+        }
     }
 
     @Override

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
@@ -116,7 +116,10 @@ public class NativeImageUtils {
         if (m.matches()) {
             return arg;
         }
-        return "'" + arg.replace("'", "'\"'\"'") + "'";
+        return "'" + arg
+                .replace("'", "'\"'\"'")
+                .replace("\\", "\\\\") /* for Windows paths */
+                + "'";
     }
 
 

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -19,6 +19,11 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 [[changelog]]
 == Changelog
 
+=== Release 0.9.27
+
+* Update JUnit configuration for native testing on GraalVM for JDK 21 with `--strict-image-heap` mode.
+* Fix path escaping problem for Windows users
+
 === Release 0.9.26
 
 * Relax GraalVM version check for dev versions

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -43,6 +43,7 @@ package org.graalvm.buildtools.gradle
 
 import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Requires
 
@@ -217,6 +218,7 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
 
     }
 
+    @IgnoreIf({ System.getenv("IS_GRAALVM_DEV_BUILD") })
     def "can build a native image with PGO instrumentation"() {
         def pgoDir = file("src/pgo-profiles/main").toPath()
         def nativeApp = file("build/native/nativeCompile/java-application-instrumented")

--- a/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-functional-testing.gradle.kts
+++ b/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-functional-testing.gradle.kts
@@ -64,6 +64,8 @@ configurations {
     }
 }
 
+val graalVmHomeProvider = providers.environmentVariable("GRAALVM_HOME")
+
 // Add a task to run the functional tests
 tasks.register<Test>("functionalTest") {
     // Any change to samples invalidates functional tests
@@ -82,4 +84,10 @@ tasks.named("check") {
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    if (graalVmHomeProvider.isPresent) {
+        val graalvmHome = graalVmHomeProvider.get()
+        inputs.property("GRAALVM_HOME", graalvmHome)
+        environment("GRAALVM_HOME", graalvmHome)
+        println("Task $name will use GRAALVM_HOME = $graalvmHome")
+    }
 }


### PR DESCRIPTION
Note: We need to run with `--strict-image-heap` enabled on GraalVM dev builds / GraalVM for JDK 21 in the future. The current dev build does not have the option, but has `--strict-image-heap` enabled by default.