### PR TITLE
Remove deprecated use of `getConvention`

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -24,6 +24,10 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 * Update JUnit configuration for native testing on GraalVM for JDK 21 with `--strict-image-heap` mode.
 * Fix path escaping problem for Windows users
 
+==== Gradle plugin
+
+- Remove use of deprecated `getConvention` APIs
+
 === Release 0.9.26
 
 * Relax GraalVM version check for dev versions

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -95,7 +95,7 @@ import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.JavaApplication;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -259,7 +259,7 @@ public class NativeImagePlugin implements Plugin<Project> {
 
         // Register Native Image tasks
         TaskContainer tasks = project.getTasks();
-        JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
+        JavaPluginExtension javaConvention = project.getExtensions().getByType(JavaPluginExtension.class);
         configureAutomaticTaskCreation(project, graalExtension, tasks, javaConvention.getSourceSets());
 
         TaskProvider<BuildNativeImageTask> imageBuilder = tasks.named(NATIVE_COMPILE_TASK_NAME, BuildNativeImageTask.class);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -624,8 +624,7 @@ public class NativeImagePlugin implements Plugin<Project> {
 
         // Testing part begins here. -------------------------------------------
 
-        // In future Gradle releases this becomes a proper DirectoryProperty
-        File testResultsDir = GradleUtils.getJavaPluginConvention(project).getTestResultsDir();
+        DirectoryProperty testResultsDir = GradleUtils.getJavaPluginConvention(project).getTestResultsDir();
         DirectoryProperty testListDirectory = project.getObjects().directoryProperty();
 
         // Add DSL extension for testing
@@ -633,7 +632,7 @@ public class NativeImagePlugin implements Plugin<Project> {
 
         TaskProvider<Test> testTask = config.validate().getTestTask();
         testTask.configure(test -> {
-            File testList = new File(testResultsDir, test.getName() + "/testlist");
+            var testList = testResultsDir.dir(test.getName() + "/testlist");
             testListDirectory.set(testList);
             test.getOutputs().dir(testList);
             // Set system property read by the UniqueIdTrackingListener.

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/GradleUtils.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/GradleUtils.java
@@ -47,7 +47,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.util.GradleVersion;
@@ -64,8 +64,8 @@ public class GradleUtils {
         return sourceSetContainer.findByName(sourceSetName);
     }
 
-    public static JavaPluginConvention getJavaPluginConvention(Project project) {
-        return project.getConvention().getPlugin(JavaPluginConvention.class);
+    public static JavaPluginExtension getJavaPluginConvention(Project project) {
+        return project.getExtensions().getByType(JavaPluginExtension.class);
     }
 
 


### PR DESCRIPTION
This removes warnings about Gradle 9 potential breakage: https://scans.gradle.com/s/yctgj7inufw5o/deprecations?expanded=WyI3NCJd#78