### PR TITLE
Remove redundant settings.gradle configuration

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
@@ -187,36 +187,6 @@ plugins {
 The `{gradle-plugin-version}` block pulls the latest plugin version.
 Replace it with a specific version if you prefer.
 The plugin discovers which JAR files it needs to pass to the `native-image` builder and what the executable main class should be.
-. The plugin is not yet available on the Gradle Plugin Portal, so declare an additional plugin repository.
-Open the _settings.gradle_ file and replace the default content with this:
-+
-[source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
-----
-pluginManagement {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
-}
-
-rootProject.name = 'fortune-parent'
-include('fortune')
-----
-+
-[source,kotlin,subs="verbatim,attributes", role="multi-language-sample"]
-----
-pluginManagement {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
-}
-
-rootProject.name = "fortune-parent"
-include("fortune")
-----
-+
-Note that the `pluginManagement {}` block must appear before any other statements in the file.
 
 [[build-a-native-executable-with-resources-autodetection]]
 == Build a Native Executable with Resources Autodetection

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -58,24 +58,8 @@ plugins {
 
 NOTE: This plugin supplements and heavily relies on regular Java plugins (e.g. `application`, `java-library`, `java` etc). Not having them included in your project will most probably cause errors.
 
-The plugin isn't available on the https://plugins.gradle.org[Gradle Plugin Portal] yet, so you will need to declare a plugin repository in addition:
-
-Add the following to your `settings.gradle` / `settings.gradle.kts`:
-
-.Declaring the plugin repository
-[source,groovy,role="multi-language-sample"]
-----
-include::../snippets/gradle/groovy/settings.gradle[tags=plugin-management]
-----
-
-[source,kotlin,role="multi-language-sample"]
-----
-include::../snippets/gradle/kotlin/settings.gradle.kts[tags=plugin-management]
-----
-
-
 [TIP]
-.Testing pre-releases (BROKEN AT THE MOMENT!)
+.Testing pre-releases
 ====
 You can use development versions of the plugin by adding our snapshot repository instead. Pre-releases are provided for convenience, without any guarantee.
 [source, groovy, role="multi-language-sample"]

--- a/docs/src/docs/snippets/gradle/groovy/settings.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/settings.gradle
@@ -38,15 +38,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-// tag::plugin-management[]
-pluginManagement {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
-}
-// end::plugin-management[]
-
 if (false) {
 // tag::pre-release[]
 pluginManagement {

--- a/docs/src/docs/snippets/gradle/kotlin/settings.gradle.kts
+++ b/docs/src/docs/snippets/gradle/kotlin/settings.gradle.kts
@@ -39,15 +39,6 @@
  * SOFTWARE.
  */
 
-// tag::plugin-management[]
-pluginManagement {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
-}
-// end::plugin-management[]
-
 if (false) {
 // tag::pre-release[]
     pluginManagement {

--- a/samples/java-application-with-custom-tests/settings.gradle
+++ b/samples/java-application-with-custom-tests/settings.gradle
@@ -43,10 +43,6 @@ pluginManagement {
     plugins {
         id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
     }
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
 }
 
 rootProject.name = 'java-application'

--- a/samples/java-application-with-extra-sourceset/settings.gradle
+++ b/samples/java-application-with-extra-sourceset/settings.gradle
@@ -43,10 +43,6 @@ pluginManagement {
     plugins {
         id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
     }
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
 }
 
 rootProject.name = 'java-application'

--- a/samples/java-application-with-reflection/settings.gradle
+++ b/samples/java-application-with-reflection/settings.gradle
@@ -43,10 +43,6 @@ pluginManagement {
     plugins {
         id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
     }
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
 }
 
 rootProject.name = 'java-application'

--- a/samples/java-application-with-resources/settings.gradle
+++ b/samples/java-application-with-resources/settings.gradle
@@ -43,10 +43,6 @@ pluginManagement {
     plugins {
         id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
     }
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
 }
 
 rootProject.name = 'java-application'

--- a/samples/java-application-with-tests/settings.gradle
+++ b/samples/java-application-with-tests/settings.gradle
@@ -43,10 +43,6 @@ pluginManagement {
     plugins {
         id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
     }
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
 }
 
 rootProject.name = 'java-application'

--- a/samples/java-application/settings.gradle
+++ b/samples/java-application/settings.gradle
@@ -43,10 +43,6 @@ pluginManagement {
     plugins {
         id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
     }
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
 }
 
 rootProject.name = 'java-application'

--- a/samples/java-library/settings.gradle
+++ b/samples/java-library/settings.gradle
@@ -43,10 +43,6 @@ pluginManagement {
     plugins {
         id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
     }
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
 }
 
 rootProject.name = 'java-library'

--- a/samples/kotlin-application-with-tests/settings.gradle
+++ b/samples/kotlin-application-with-tests/settings.gradle
@@ -43,10 +43,6 @@
     plugins {
         id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
     }
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
 }
 
 rootProject.name = "kotlin-application"

--- a/samples/metadata-repo-integration/settings.gradle
+++ b/samples/metadata-repo-integration/settings.gradle
@@ -2,10 +2,6 @@ pluginManagement {
     plugins {
         id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
     }
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
 }
 
 rootProject.name = 'metadata-repo-demo'

--- a/samples/multi-project-with-tests/settings.gradle
+++ b/samples/multi-project-with-tests/settings.gradle
@@ -43,10 +43,6 @@ pluginManagement {
     plugins {
         id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
     }
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
 }
 
 rootProject.name = 'java-application'

--- a/samples/native-config-integration/settings.gradle
+++ b/samples/native-config-integration/settings.gradle
@@ -43,10 +43,6 @@ pluginManagement {
     plugins {
         id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
     }
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
 }
 
 rootProject.name = 'native-config-integration'


### PR DESCRIPTION
This is no longer required in recent Gradle versions.

Fixes #529