### PR TITLE
Substitute <arg> with <buildArg> in Maven plugin doc.

### DIFF
--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -133,7 +133,7 @@ Build Configuration]. It is also possible to customize the plugin within a
 [source,xml]
 ----
 <buildArgs>
-    <arg>--argument</arg>
+    <buildArg>--argument</buildArg>
 </buildArgs>
 ----
 `<skipNativeBuild>`::


### PR DESCRIPTION
Followup of https://corparch-core-srv.slack.com/archives/C77KND1RN/p1702494052179109