### PR TITLE
Make Plugins Use Metadata Repository by Default

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -361,14 +361,14 @@ This repository provides https://www.graalvm.org/22.2/reference-manual/native-im
 
 NOTE: This version of the plugin defaults to the using the metadata repository in version {metadata-repository-version}. There is nothing for you to configure if you are fine with this version. The repository is also published on Maven Central at the following coordinates: `org.graalvm.buildtools:graalvm-reachability-metadata:graalvm-reachability-metadata` with the `repository` classifier and `zip` extension, e.g. `graalvm-reachability-metadata-{gradle-plugin-version}-repository.zip`.
 
-=== Enabling the metadata repository
+=== Configuring the metadata repository
 
-Support needs to be enabled explicitly:
+Metadata repository is enabled by default. Support can be disabled explicitly:
 
-.Enabling the metadata repository
+.Disabling the metadata repository
 [source, groovy, role="multi-language-sample"]
 ----
-include::../snippets/gradle/groovy/build.gradle[tags=enable-metadata-repository]
+include::../snippets/gradle/groovy/build.gradle[tags=disable-metadata-repository]
 ----
 
 [source, kotlin, role="multi-language-sample"]
@@ -403,9 +403,7 @@ include::../snippets/gradle/groovy/build.gradle[tags=specify-metadata-repository
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=specify-metadata-repository-file]
 ----
 
-=== Configuring the metadata repository
-
-Once activated, for each library included in the native image, the plugin will automatically search for GraalVM reachability metadata in the repository.
+For each library included in the native image, the plugin will automatically search for GraalVM reachability metadata in the repository.
 In some cases, you may need to exclude a particular module from the search.
 This can be done by adding it to the exclude list:
 

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -363,7 +363,7 @@ NOTE: This version of the plugin defaults to the using the metadata repository i
 
 === Configuring the metadata repository
 
-Metadata repository is enabled by default. Support can be disabled explicitly:
+Metadata repository support is enabled by default. Support can be disabled explicitly:
 
 .Disabling the metadata repository
 [source, groovy, role="multi-language-sample"]
@@ -403,7 +403,7 @@ include::../snippets/gradle/groovy/build.gradle[tags=specify-metadata-repository
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=specify-metadata-repository-file]
 ----
 
-For each library included in the native image, the plugin will automatically search for GraalVM reachability metadata in the repository.
+For each library included in the native image, the plugin will automatically search for GraalVM image build configuration metadata in the repository.
 In some cases, you may need to exclude a particular module from the search.
 This can be done by adding it to the exclude list:
 

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -19,6 +19,17 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 [[changelog]]
 == Changelog
 
+=== Release 0.10.0
+
+==== Gradle plugin
+
+- Update plugin to use metadata repository by default
+
+====Maven plugin
+
+- Update plugin to use metadata repository by default
+
+
 === Release 0.9.28
 
 * Fix path escaping problem for Windows users

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -658,7 +658,7 @@ include::../../../../samples/native-config-integration/pom.xml[tag=metadata-loca
 ----
 <1> The local path can point to an _exploded_ directory, or to a compressed ZIP file.
 
-For each library included in the native image, the plugin will automatically search for GraalVM reachability metadata in the repository that was released together with the plugin.
+For each library included in the native image, the plugin will automatically search for GraalVM image build configuration metadata in the repository that was released together with the plugin.
 In case you want to use another version of the metadata use:
 
 .Choosing a version for the metadata repository

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -631,14 +631,14 @@ This version of the plugin defaults to the using the metadata repository in vers
 e.g. `graalvm-reachability-metadata-{maven-plugin-version}-repository.zip`.
 ====
 
-=== Enabling the metadata repository
+=== Configuring the metadata repository
 
-Support needs to be enabled explicitly by including the following into the `<configuration>` element:
+Metadata repository is enabled by default. Support can be disabled by including the following into the `<configuration>` element:
 
-.Enabling the metadata repository
+.Disabling the metadata repository
 [source,xml,indent=0]
 ----
-include::../../../../samples/metadata-repo-integration/pom.xml[tag=metadata-default]
+include::../../../../samples/metadata-repo-integration/pom.xml[tag=metadata-disable]
 ----
 
 Alternatively, you can use a _remote repository_, in which case you can specify the URL of the ZIP file:
@@ -658,10 +658,8 @@ include::../../../../samples/native-config-integration/pom.xml[tag=metadata-loca
 ----
 <1> The local path can point to an _exploded_ directory, or to a compressed ZIP file.
 
-=== Configuring the metadata repository
-
-Once activated, for each library included in the native image, the plugin will automatically search for GraalVM reachability metadata in the repository that was released together with the plugin.
-In case you want to use another verion of the metadata use:
+For each library included in the native image, the plugin will automatically search for GraalVM reachability metadata in the repository that was released together with the plugin.
+In case you want to use another version of the metadata use:
 
 .Choosing a version for the metadata repository
 [source,xml,indent=0]

--- a/docs/src/docs/snippets/gradle/groovy/build.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/build.gradle
@@ -166,13 +166,13 @@ graalvmNative {
 }
 // end::disable-test-support[]
 
-// tag::enable-metadata-repository[]
+// tag::disable-metadata-repository[]
 graalvmNative {
     metadataRepository {
-        enabled = true
+        enabled = false
     }
 }
-// end::enable-metadata-repository[]
+// end::disable-metadata-repository[]
 
 // tag::specify-metadata-repository-version[]
 graalvmNative {

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/OfficialMetadataRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/OfficialMetadataRepoFunctionalTest.groovy
@@ -46,7 +46,7 @@ import org.gradle.api.logging.LogLevel
 
 class OfficialMetadataRepoFunctionalTest extends AbstractFunctionalTest {
 
-    def "the application runs when using the official metadata repository"() {
+    def "the application runs when using the official metadata repository by default"() {
         given:
         withSample("metadata-repo-integration")
         debug = true
@@ -63,6 +63,20 @@ class OfficialMetadataRepoFunctionalTest extends AbstractFunctionalTest {
         outputContains "[graalvm reachability metadata repository for com.h2database:h2:"
         outputContains "Configuration directory is com.h2database" + File.separator + "h2" + File.separator
         outputDoesNotContain "Falling back to the default repository at"
+    }
+
+    def "the application doesn't run when usage of the official metadata repository is disabled"() {
+        given:
+        withSample("metadata-repo-integration")
+        debug = true
+
+        when:
+        run 'nativeRun', "-Pmetadata.repo.enabled=false",  "-D${NativeImagePlugin.CONFIG_REPO_LOGLEVEL}=${LogLevel.LIFECYCLE}"
+
+        then:
+        tasks {
+            failed ':nativeCompile'
+        }
     }
 
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -585,7 +585,7 @@ public class NativeImagePlugin implements Plugin<Project> {
 
     private void configureNativeConfigurationRepo(ExtensionAware graalvmNative) {
         GraalVMReachabilityMetadataRepositoryExtension configurationRepository = graalvmNative.getExtensions().create("metadataRepository", GraalVMReachabilityMetadataRepositoryExtension.class);
-        configurationRepository.getEnabled().convention(false);
+        configurationRepository.getEnabled().convention(true);
         configurationRepository.getVersion().convention(VersionInfo.METADATA_REPO_VERSION);
         configurationRepository.getUri().convention(configurationRepository.getVersion().map(serializableTransformerOf(this::getReachabilityMetadataRepositoryUrlForVersion)));
         configurationRepository.getExcludedModules().convention(Collections.emptySet());

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -269,6 +269,13 @@ abstract class AbstractFunctionalTest extends Specification {
             }
         }
 
+        void failed(String... tasks) {
+            tasks.each { task ->
+                contains(task)
+                assert result.task(task).outcome == TaskOutcome.FAILED
+            }
+        }
+
         void skipped(String... tasks) {
             tasks.each { task ->
                 contains(task)

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
@@ -96,7 +96,7 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
 
         then:
         buildFailed
-        outputContains " Cannot pull GraalVM reachability metadata repository either from the one specified in the configuration or the default one"
+        outputContains "Cannot pull GraalVM reachability metadata repository either from the one specified in the configuration or the default one"
     }
 
     void "it can exclude dependencies"() {

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
@@ -87,7 +87,7 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         outputContains NATIVE_IMAGE_EXE + " --exclude-config dummy/path/to/file.jar \"*\""
    }
 
-    void "if the path doesn't exist it throws an error"() {
+    void "if the path doesn't exist, the repository cannot be pulled"() {
         given:
         withSample("native-config-integration")
 
@@ -95,9 +95,8 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         mvn '-Pnative,metadataMissing', '-DquickBuild', '-DskipTests', 'package', 'exec:exec@native'
 
         then:
-        buildSucceeded
-        outputContains "GraalVM reachability metadata repository path does not exist"
-        outputContains "Reflection failed"
+        buildFailed
+        outputContains " Cannot pull GraalVM reachability metadata repository either from the one specified in the configuration or the default one"
     }
 
     void "it can exclude dependencies"() {
@@ -163,7 +162,7 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory is org.graalvm.internal" + File.separator + "library-with-reflection" + File.separator + "1"
     }
 
-    void "when pointing to a missing URL, reflection fails"() {
+    void "when pointing to a missing URL, the repository cannot be pulled"() {
         given:
         withSample("native-config-integration")
         withLocalServer()
@@ -172,9 +171,8 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         mvn '-Pnative,metadataUrl', '-DquickBuild', "-Dmetadata.url=https://google.com/notfound", '-DskipTests', 'package', 'exec:exec@native'
 
         then:
-        buildSucceeded
-        outputContains "Reflection failed"
-        outputContains "Failed to download from https://google.com/notfound: 404 Not Found"
+        buildFailed
+        outputContains "Cannot pull GraalVM reachability metadata repository either from the one specified in the configuration or the default one"
     }
 
     void "it can include hints in jar"() {

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/OfficialMetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/OfficialMetadataRepositoryFunctionalTest.groovy
@@ -44,6 +44,7 @@ package org.graalvm.buildtools.maven
 import spock.lang.IgnoreIf
 
 class OfficialMetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
+
     @IgnoreIf({ os.windows })
     void "the application runs when using the official metadata repository"() {
         given:
@@ -81,5 +82,36 @@ class OfficialMetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunct
         and: "finds metadata in the remote repository"
         outputContains "[graalvm reachability metadata repository for com.h2database:h2:"
         outputContains "Configuration directory is com.h2database" + File.separator + "h2" + File.separator
+    }
+
+    @IgnoreIf({ os.windows })
+    void "the application uses specified version of metadata repository without explicit enable"() {
+        given:
+        withSample("metadata-repo-integration")
+
+        when:
+        mvn '-PenableMetadataByDefault', '-DquickBuild', '-DskipTests', 'package', 'exec:exec@native'
+
+        then:
+        buildSucceeded
+
+        and: "the run succeeded and retrieved data from the database"
+        outputContains "Customers in the database"
+
+        and: "finds metadata in the remote repository"
+        outputContains "[graalvm reachability metadata repository for com.h2database:h2:"
+        outputContains "Configuration directory is com.h2database" + File.separator + "h2" + File.separator
+    }
+
+    @IgnoreIf({ os.windows })
+    void "the application doesn't run when metadata repository is disabled"() {
+        given:
+        withSample("metadata-repo-integration")
+
+        when:
+        mvn '-PdisabledMetadataRepo', '-DquickBuild', '-DskipTests', 'package', 'exec:exec@native'
+
+        then:
+        buildFailed
     }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -166,7 +166,7 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
             String metadataUrl = String.format(METADATA_REPO_URL_TEMPLATE, VersionInfo.METADATA_REPO_VERSION);
             try {
                 targetUrl = new URI(metadataUrl).toURL();
-                // TODO investigate if the following line is necessary
+                // TODO investigate if the following line is necessary (Issue: https://github.com/graalvm/native-build-tools/issues/560)
                 metadataRepositoryConfiguration.setUrl(targetUrl);
             } catch (URISyntaxException | MalformedURLException e) {
                 throw new RuntimeException(e);
@@ -199,7 +199,7 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
                     String metadataUrl = String.format(METADATA_REPO_URL_TEMPLATE, version);
                     try {
                         targetUrl = new URI(metadataUrl).toURL();
-                        // TODO investigate if the following line is necessary
+                        // TODO investigate if the following line is necessary (Issue: https://github.com/graalvm/native-build-tools/issues/560)
                         metadataRepositoryConfiguration.setUrl(targetUrl);
                     } catch (URISyntaxException | MalformedURLException e) {
                         throw new RuntimeException(e);

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/MetadataRepositoryConfiguration.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/MetadataRepositoryConfiguration.java
@@ -53,8 +53,8 @@ import java.util.Optional;
 
 public class MetadataRepositoryConfiguration {
 
-    @Parameter(defaultValue = "false")
-    private boolean enabled;
+    @Parameter(defaultValue = "true")
+    private boolean enabled = true;
 
     @Parameter
     private String version;

--- a/samples/metadata-repo-integration/build.gradle
+++ b/samples/metadata-repo-integration/build.gradle
@@ -71,7 +71,9 @@ graalvmNative {
         defaultMode = "standard"
     }
     metadataRepository {
-        enabled = true
+        if (providers.gradleProperty("metadata.repo.enabled").isPresent()) {
+            enabled = providers.gradleProperty("metadata.repo.enabled").map { value -> value.toBoolean()}
+        }
     }
     binaries.all {
         verbose = true

--- a/samples/metadata-repo-integration/pom.xml
+++ b/samples/metadata-repo-integration/pom.xml
@@ -110,13 +110,6 @@
                                 <phase>package</phase>
                             </execution>
                         </executions>
-                        <configuration>
-                            <!-- tag::metadata-default[] -->
-                            <metadataRepository>
-                                <enabled>true</enabled>
-                            </metadataRepository>
-                            <!-- end::metadata-default[] -->
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -146,6 +139,62 @@
                                 <version>0.2.3</version>
                             </metadataRepository>
                             <!-- end::metadata-versioned[] -->
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>disabledMetadataRepo</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>compile-no-fork</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <!-- tag::metadata-disable[] -->
+                            <metadataRepository>
+                                <enabled>false</enabled>
+                            </metadataRepository>
+                            <!-- end::metadata-disable[] -->
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>enableMetadataByDefault</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>compile-no-fork</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <metadataRepository>
+                                <version>0.2.3</version>
+                            </metadataRepository>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
The PR enables usage of metadata repository by default in both Gradle and Maven plugins. See [this](https://github.com/graalvm/native-build-tools/issues/553) issue