### PR TITLE
Bump metadata repository version to 0.3.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Project versions
 nativeBuildTools = "0.9.29-SNAPSHOT"
-metadataRepository = "0.3.5"
+metadataRepository = "0.3.6"
 
 # External dependencies
 spock = "2.1-groovy-3.0"


### PR DESCRIPTION
Bump metadata repository version to 0.3.6 as a part of preparation for the next release