### PR TITLE
[GR-51916] Add missing JUnit 5 init policies.

### DIFF
--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/platform/PlatformConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/platform/PlatformConfigProvider.java
@@ -64,7 +64,7 @@ public class PlatformConfigProvider implements PluginConfigProvider {
         );
 
         if (getMajorJDKVersion() >= 21) {
-            /* new with simulated class initialization */
+            /* new with --strict-image-heap */
             config.initializeAtBuildTime(
                     "org.junit.platform.engine.support.descriptor.ClassSource",
                     "org.junit.platform.engine.support.descriptor.MethodSource",
@@ -75,15 +75,21 @@ public class PlatformConfigProvider implements PluginConfigProvider {
                     "org.junit.platform.launcher.core.DefaultLauncher",
                     "org.junit.platform.launcher.core.DefaultLauncherConfig",
                     "org.junit.platform.launcher.core.EngineExecutionOrchestrator",
+                    "org.junit.platform.launcher.core.LauncherConfigurationParameters$ParameterProvider$1",
                     "org.junit.platform.launcher.core.LauncherConfigurationParameters$ParameterProvider$2",
                     "org.junit.platform.launcher.core.LauncherConfigurationParameters$ParameterProvider$3",
+                    "org.junit.platform.launcher.core.LauncherConfigurationParameters$ParameterProvider$4",
                     "org.junit.platform.launcher.core.LauncherDiscoveryResult",
                     "org.junit.platform.launcher.core.LauncherListenerRegistry",
                     "org.junit.platform.launcher.core.ListenerRegistry",
                     "org.junit.platform.launcher.core.SessionPerRequestLauncher",
                     "org.junit.platform.launcher.LauncherSessionListener$1",
                     "org.junit.platform.launcher.listeners.UniqueIdTrackingListener",
-                    "org.junit.platform.reporting.shadow.org.opentest4j.reporting.events.api.DocumentWriter$1"
+                    "org.junit.platform.reporting.shadow.org.opentest4j.reporting.events.api.DocumentWriter$1",
+                    "org.junit.platform.suite.engine.SuiteEngineDescriptor",
+                    "org.junit.platform.suite.engine.SuiteLauncher",
+                    "org.junit.platform.suite.engine.SuiteTestDescriptor",
+                    "org.junit.platform.suite.engine.SuiteTestEngine"
             );
         }
 

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -19,6 +19,11 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 [[changelog]]
 == Changelog
 
+=== Release 0.10.1
+
+- Mark additional JUnit 5 types for build-time initialization for compatibility with Native Image's `--strict-image-heap` option.
+
+
 === Release 0.10.0
 
 - Update version of GraalVM dependency to 22.3.5


### PR DESCRIPTION
This PR marks additional JUnit 5 types for build-time init, allowing them to become part of the image heap. This is required for `--strict-image-heap`. These additional types, however, aren't allocated as part of the NBT test harness. I have found those running `./gradlew :test-suite-http-server-tck-netty:nativeTestCompile` on the `4.2.x` branch in the [micronaut-core repo](https://github.com/micronaut-projects/micronaut-core). The corresponding CI builds are [currently failing due to this](https://github.com/micronaut-projects/micronaut-core/actions/runs/7080784399/job/19269188760#step:4:319).