### PR TITLE
Update Default Target Directory for MetadataCopy Task

### DIFF
--- a/docs/src/docs/snippets/gradle/groovy/build.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/build.gradle
@@ -99,7 +99,7 @@ graalvmNative {
         // Copies metadata collected from tasks into the specified directories.
         metadataCopy {
             inputTaskNames.add("test") // Tasks previously executed with the agent attached.
-            outputDirectories.add("src/main/resources/META-INF/native-image")
+            outputDirectories.add("src/main/resources/META-INF/native-image/<groupId>/<artifactId>/") // Replace <groupId> and <artifactId> with GAV coordinates of your project
             mergeWithExisting = true // Instead of copying, merge with existing metadata in the output directories.
         }
 

--- a/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
+++ b/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
@@ -100,7 +100,7 @@ graalvmNative {
         // Copies metadata collected from tasks into the specified directories.
         metadataCopy {
             inputTaskNames.add("test") // Tasks previously executed with the agent attached.
-            outputDirectories.add("src/main/resources/META-INF/native-image")
+            outputDirectories.add("src/main/resources/META-INF/native-image/<groupId>/<artifactId>/") // Replace <groupId> and <artifactId> with GAV coordinates of your project
             mergeWithExisting.set(true) // Instead of copying, merge with existing metadata in the output directories.
         }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
@@ -98,7 +98,10 @@ public class MetadataCopyMojo extends AbstractMergeAgentFilesMojo {
             String buildDirectory = project.getBuild().getDirectory() + "/native/agent-output/";
             String destinationDir = config.getOutputDirectory();
             if (destinationDir == null) {
-                destinationDir = project.getBuild().getOutputDirectory() + DEFAULT_OUTPUT_DIRECTORY;
+                destinationDir = project.getBuild().getOutputDirectory()
+                        .concat(DEFAULT_OUTPUT_DIRECTORY).concat("/")
+                        .concat(project.getGroupId()).concat("/")
+                        .concat(project.getArtifactId());
             }
 
             if (!Files.isDirectory(Paths.get(destinationDir))) {


### PR DESCRIPTION
As described in [this issue](https://github.com/graalvm/native-build-tools/issues/579) we should specify default output directory for metadataCopy task according to the recommendation from [GraalVM website](https://www.graalvm.org/latest/reference-manual/native-image/overview/BuildConfiguration/) 

Note: currently we don't have default value for the Gradle plugin, while we do have one for the Maven