### PR TITLE
Refactor Initialization of Configuration File Merger

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -21,6 +21,8 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 
 === Release 0.10.3
 
+- Remove usage of macro from merger tool initialization and throw better error if executable does not exist
+
 ==== Gradle plugin
 
 - Add retries when downloading the metadata repository when using a URL directly

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
@@ -50,12 +50,10 @@ import org.graalvm.buildtools.agent.StandardAgentMode;
 import org.graalvm.buildtools.maven.config.AbstractMergeAgentFilesMojo;
 import org.graalvm.buildtools.maven.config.agent.AgentConfiguration;
 import org.graalvm.buildtools.maven.config.agent.MetadataCopyConfiguration;
-import org.graalvm.buildtools.utils.NativeImageConfigurationUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -113,8 +111,6 @@ public class MetadataCopyMojo extends AbstractMergeAgentFilesMojo {
                 }
             }
 
-            Path nativeImageExecutable = NativeImageConfigurationUtils.getNativeImage(logger);
-            tryInstallMergeExecutable(nativeImageExecutable);
             executeCopy(buildDirectory, destinationDir);
             getLog().info("Metadata copy process finished.");
         }
@@ -155,7 +151,7 @@ public class MetadataCopyMojo extends AbstractMergeAgentFilesMojo {
         logger.info("Copying files from: " + sourceDirsInfo);
 
         List<String> nativeImageConfigureOptions = new StandardAgentMode().getNativeImageConfigureOptions(sourceDirectories, Collections.singletonList(destinationDir));
-        nativeImageConfigureOptions.add(0, mergerExecutable.getAbsolutePath());
+        nativeImageConfigureOptions.add(0, getMergerExecutable().getAbsolutePath());
         ProcessBuilder processBuilder = new ProcessBuilder(nativeImageConfigureOptions);
 
         try {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/AbstractMergeAgentFilesMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/AbstractMergeAgentFilesMojo.java
@@ -71,11 +71,11 @@ public abstract class AbstractMergeAgentFilesMojo extends AbstractMojo {
     private void initializeMergerExecutable() throws MojoExecutionException {
         Path nativeImage = NativeImageConfigurationUtils.getNativeImage(logger);
         File nativeImageExecutable = nativeImage.toAbsolutePath().toFile();
-        String configureFileName = nativeImageConfigureFileName();
-        File mergerExecutable = new File(nativeImageExecutable.getParentFile(), configureFileName);
+        String nativeImageConfigureFileName = nativeImageConfigureFileName();
+        File mergerExecutable = new File(nativeImageExecutable.getParentFile(), nativeImageConfigureFileName);
         if (!mergerExecutable.exists()) {
-            throw new MojoExecutionException("'" + configureFileName + "' tool was not found in your " + nativeImage + "." +
-                    "This probably means that the JDK at '" + nativeImage + "' is not a GraalVM distribution."
+            throw new MojoExecutionException("'" + nativeImageConfigureFileName + "' tool was not found in the GraalVM JDK at '" + nativeImageExecutable.getParentFile().getParentFile() + "'." +
+                    "This probably means that you are using a GraalVM distribution that is not fully supported by the Native Build Tools."
             );
         }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/AbstractMergeAgentFilesMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/AbstractMergeAgentFilesMojo.java
@@ -74,8 +74,9 @@ public abstract class AbstractMergeAgentFilesMojo extends AbstractMojo {
         String nativeImageConfigureFileName = nativeImageConfigureFileName();
         File mergerExecutable = new File(nativeImageExecutable.getParentFile(), nativeImageConfigureFileName);
         if (!mergerExecutable.exists()) {
-            throw new MojoExecutionException("'" + nativeImageConfigureFileName + "' tool was not found in the GraalVM JDK at '" + nativeImageExecutable.getParentFile().getParentFile() + "'." +
-                    "This probably means that you are using a GraalVM distribution that is not fully supported by the Native Build Tools."
+            throw new MojoExecutionException("The '" + nativeImageConfigureFileName + "' tool was not found in the GraalVM JDK at '" + nativeImageExecutable.getParentFile().getParentFile() + "'." +
+                    "This probably means that you are using a GraalVM distribution that is not fully supported by the Native Build Tools. " +
+                    "Please try again, for example, with Oracle GraalVM or GraalVM Community Edition."
             );
         }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/AbstractMergeAgentFilesMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/AbstractMergeAgentFilesMojo.java
@@ -71,9 +71,10 @@ public abstract class AbstractMergeAgentFilesMojo extends AbstractMojo {
     private void initializeMergerExecutable() throws MojoExecutionException {
         Path nativeImage = NativeImageConfigurationUtils.getNativeImage(logger);
         File nativeImageExecutable = nativeImage.toAbsolutePath().toFile();
-        File mergerExecutable = new File(nativeImageExecutable.getParentFile(), nativeImageConfigureFileName());
+        String configureFileName = nativeImageConfigureFileName();
+        File mergerExecutable = new File(nativeImageExecutable.getParentFile(), configureFileName);
         if (!mergerExecutable.exists()) {
-            throw new MojoExecutionException("'" + nativeImageConfigureFileName() + "' tool was not found in your " + nativeImage + "." +
+            throw new MojoExecutionException("'" + configureFileName + "' tool was not found in your " + nativeImage + "." +
                     "This probably means that the JDK at '" + nativeImage + "' is not a GraalVM distribution."
             );
         }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/NativeImageConfigurationUtils.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/NativeImageConfigurationUtils.java
@@ -128,8 +128,8 @@ public abstract class NativeImageConfigurationUtils implements SharedConstants {
         }
 
         if (nativeImage == null) {
-            throw new RuntimeException("GraalVM native-image is missing on your system. " + System.lineSeparator() +
-                    "Make sure that GRAALVM_HOME environment variable is present.");
+            throw new RuntimeException("The 'native-image' tool was not found on your system. " + System.lineSeparator() +
+                    "Make sure that the JAVA_HOME or GRAALVM_HOME environment variables point to a GraalVM JDK, or that 'native-image' is on the system path.");
         }
 
         nativeImageExeCache = nativeImage;

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/NativeImageConfigurationUtils.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/NativeImageConfigurationUtils.java
@@ -128,7 +128,7 @@ public abstract class NativeImageConfigurationUtils implements SharedConstants {
         }
 
         if (nativeImage == null) {
-            throw new RuntimeException("The 'native-image' tool was not found on your system. " + System.lineSeparator() +
+            throw new RuntimeException("The 'native-image' tool was not found on your system. " +
                     "Make sure that the JAVA_HOME or GRAALVM_HOME environment variables point to a GraalVM JDK, or that 'native-image' is on the system path.");
         }
 


### PR DESCRIPTION
Remove macro from merger init and throw better error if executable does not exist