### PR TITLE
Delete old stale args file

### DIFF
--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
@@ -121,6 +121,14 @@ class JavaApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
         then:
         buildSucceeded
         outputContains "Args file written to: target" + File.separator + "native-image"
+
+        when:
+        mvn '-DquickBuild', '-Pnative', 'native:write-args-file'
+
+        then:
+        buildSucceeded
+        outputContains "Args file written to: target" + File.separator + "native-image"
+        file("target/").listFiles().findAll(x->x.name.contains("native-image") && x.name.endsWith(".args")).size() == 1
     }
 
 }


### PR DESCRIPTION
Problem:
Copying args file into Docker with something similar to 
```COPY *.args /home/app/graalvm-native-image.args``` causes problem because there might be more then one generated args file. This is required because `convertToArgsFile` creates temporary file that contains contains random integer in the name.

Solution:
- Maven write-args-file task should delete old stale args file before generating a new one.
