### PR TITLE
Fixes the issue that nativeTest cannot be executed using Junit 5.11.0-M2

### DIFF
--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/platform/PlatformConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/platform/PlatformConfigProvider.java
@@ -60,7 +60,9 @@ public class PlatformConfigProvider implements PluginConfigProvider {
                 "org.junit.platform.engine.UniqueIdFormat",
                 "org.junit.platform.commons.util.ReflectionUtils",
                 // https://github.com/graalvm/native-build-tools/issues/300
-                "org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener"
+                "org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener",
+                // https://github.com/graalvm/native-build-tools/issues/602
+                "org.junit.platform.commons.util.LruCache"
         );
 
         if (getMajorJDKVersion() >= 21) {


### PR DESCRIPTION
- Fixes #602 .
- Fixes the issue that nativeTest cannot be executed using Junit 5.11.0-M2.
- The project's gradle toolchain actively looks for a random jdk17 release, such as Microsoft OpenJDK 17. Setting up a GraalVM version of JDK11 can be very confusing.