### PR TITLE
334 - Fix module path and image classpath for native image generation

### DIFF
--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -160,6 +160,14 @@ Build Configuration]. It is also possible to customize the plugin within a
 ----
 <verbose>true</verbose>
 ----
+`<experimentalInferModulePath>`::
+If you want to enable module path inference during native-image building supply the following in the configuration of the plugin:
+[source,xml]
+----
+<experimentalInferModulePath>true</experimentalInferModulePath>
+----
+Module path inference will detect which dependencies are modules and configure the module path accordingly. The identified modules will then be removed from the usual classpath.
+NOTE: This is an experimental feature.
 `<sharedLibrary>`::
    If you want to build image as a shared library supply the following in the configuration of the plugin:
 [source,xml]

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -126,6 +126,9 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     protected final List<Path> imageClasspath;
     protected final List<Path> imageModulepath;
 
+    @Parameter(property = "inferModulePath", defaultValue = "false")
+    protected boolean inferModulePath;
+
     @Parameter(property = "debug", defaultValue = "false")
     protected boolean debug;
 
@@ -216,8 +219,11 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
         cliArgs.add("-cp");
         cliArgs.add(getClasspath());
 
-        cliArgs.add("--module-path");
-        cliArgs.add(getModulepath());
+        if(inferModulePath) {
+            logger.info("Module path inference: enabled");
+            cliArgs.add("--module-path");
+            cliArgs.add(getModulepath());
+        }
 
         if (debug) {
             cliArgs.add("-g");
@@ -347,7 +353,7 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
         try (FileSystem jarFS = openFileSystem(jarFileURI)) {
             // check if this is a module!
             Path moduleInfoClass = jarFS.getPath("/" + MODULE_INFO_CLASS);
-            module = Files.exists(moduleInfoClass);
+            module = inferModulePath && Files.exists(moduleInfoClass);
             Path nativeImageMetaInfBase = jarFS.getPath("/" + NATIVE_IMAGE_META_INF);
             if (Files.isDirectory(nativeImageMetaInfBase)) {
                 try (Stream<Path> stream = Files.walk(nativeImageMetaInfBase)) {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -126,8 +126,9 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     protected final List<Path> imageClasspath;
     protected final List<Path> imageModulepath;
 
-    @Parameter(property = "inferModulePath", defaultValue = "false")
-    protected boolean inferModulePath;
+    // Experimental feature
+    @Parameter(property = "experimentalInferModulePath", defaultValue = "false")
+    protected boolean experimentalInferModulePath;
 
     @Parameter(property = "debug", defaultValue = "false")
     protected boolean debug;
@@ -219,7 +220,7 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
         cliArgs.add("-cp");
         cliArgs.add(getClasspath());
 
-        if(inferModulePath) {
+        if(experimentalInferModulePath) {
             logger.info("Module path inference: enabled");
             cliArgs.add("--module-path");
             cliArgs.add(getModulepath());
@@ -353,7 +354,7 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
         try (FileSystem jarFS = openFileSystem(jarFileURI)) {
             // check if this is a module!
             Path moduleInfoClass = jarFS.getPath("/" + MODULE_INFO_CLASS);
-            module = inferModulePath && Files.exists(moduleInfoClass);
+            module = experimentalInferModulePath && Files.exists(moduleInfoClass);
             Path nativeImageMetaInfBase = jarFS.getPath("/" + NATIVE_IMAGE_META_INF);
             if (Files.isDirectory(nativeImageMetaInfBase)) {
                 try (Stream<Path> stream = Files.walk(nativeImageMetaInfBase)) {


### PR DESCRIPTION
This PR should fix the issue related in #334.

This allows to simplify native image generation via Maven with such build args inside the pom.xml file:
```xml
                    <plugin>
                        <groupId>org.graalvm.buildtools</groupId>
                        <artifactId>native-maven-plugin</artifactId>
                        <version>${native.maven.plugin.version}</version>
                        <executions>
                            <execution>
                                <id>build-native</id>
                                <goals>
                                    <goal>compile-no-fork</goal>
                                </goals>
                                <phase>package</phase>
                            </execution>
                            <execution>
                                <id>test-native</id>
                                <goals>
                                    <goal>test</goal>
                                </goals>
                                <phase>test</phase>
                            </execution>
                        </executions>
                        <configuration>
                            <verbose>true</verbose>
                            <skip>false</skip>
                            <imageName>${imageName}</imageName>
                            <fallback>false</fallback>
                            <agent>
                                <enabled>false</enabled>
                            </agent>
                            <buildArgs>
                                --module-path target/connectme-1.0.0.jar
                                -Ob
                                -march=native
                                --initialize-at-build-time=com.oracle.connect/com.oracle.connect.Main
                                --add-modules javafx.controls
                                --add-modules javafx.fxml
                                --add-modules com.oracle.connect
                                --module com.oracle.connect/com.oracle.connect.Main
                            </buildArgs>
                        </configuration>
                    </plugin>
```

The modification includes: 
- detecting properly if a dependency is a module (analyze jar file and look for the presence of `/module-info.class`
- if it is a module, then populate `--module-path` arg list else populate `-cp` arg list