### PR TITLE
Bump metadata repository version to 0.3.9

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -22,6 +22,8 @@ If you are using alternative build systems, see <<alternative-build-systems.adoc
 === Release 0.10.3
 
 - Remove usage of macro from merger tool initialization and throw better error if executable does not exist
+- Add support for the new reachability-metadata.json config file
+- Remove custom post-processing task for filtering config files entries and use access-filter.json instead
 
 ==== Gradle plugin
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Project versions
 nativeBuildTools = "0.10.3-SNAPSHOT"
-metadataRepository = "0.3.8"
+metadataRepository = "0.3.9"
 
 # External dependencies
 spock = "2.1-groovy-3.0"


### PR DESCRIPTION
Besides updating metadata version, I added missing changelog entries for [this PR](https://github.com/graalvm/native-build-tools/pull/614)