### PR TITLE
supporting jdk toolchain configuration

### DIFF
--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -171,6 +171,13 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     @Component
     protected ToolchainManager toolchainManager;
 
+    /**
+        Set this to true to ensure that native-image is found in your toolchain and not in an unrelated JDK or in your PATH.
+        Will fail the build in case no toolchain was found or if it does not contain native-image.
+    */
+    @Parameter(property = "enforceToolchain")
+    protected boolean enforceToolchain;
+
     @Inject
     protected AbstractNativeImageMojo() {
         imageClasspath = new ArrayList<>();
@@ -411,7 +418,7 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
 
     protected void buildImage() throws MojoExecutionException {
         checkRequiredVersionIfNeeded();
-        Path nativeImageExecutable = NativeImageConfigurationUtils.getNativeImage(logger);
+        Path nativeImageExecutable = NativeImageConfigurationUtils.getNativeImageSupportingToolchain(logger, toolchainManager, session, enforceToolchain);
 
         try {
             ProcessBuilder processBuilder = new ProcessBuilder(nativeImageExecutable.toString());


### PR DESCRIPTION
Use the jdk defined in the toolchain configuration (if it exist is a GraalVM jdk). 
A property "enforceToolchain" with default false was added in the Mojos to enforce that a toolchain jdk exists and is a GraalVM jdk.