### PR TITLE
Fix command for native compile in gradle-plugin-quickstart.adoc

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin-quickstart.adoc
@@ -213,7 +213,7 @@ graalvmNative {
 +
 [source,shell]
 ----
-./gradlew nativeRun
+./gradlew nativeCompile
 ----
 +
 The native executable, named _fortune_, is created in the _/fortune/build/native/nativeCompile_ directory.


### PR DESCRIPTION
This PR fixes command for native compile in the `gradle-plugin-quickstart.adoc`.