### PR TITLE
Make accessFilter file registration thread safe

### DIFF
--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -154,13 +154,13 @@ public class AgentConfiguration implements Serializable {
 
         try(InputStream accessFilterData = AgentConfiguration.class.getResourceAsStream(DEFAULT_ACCESS_FILTER_FILE_LOCATION)) {
             if (accessFilterData == null) {
-                throw new IOException("Cannot find access-filter.json on default location: " + DEFAULT_ACCESS_FILTER_FILE_LOCATION);
+                throw new IOException("Cannot access data from: " + DEFAULT_ACCESS_FILTER_FILE_LOCATION);
             }
 
             try {
                 Files.createDirectory(agentDir);
             } catch (FileAlreadyExistsException e) {
-                logger.info("Ignore directory creation because " + agentDir + " directory is already created.");
+                logger.info("Skip creation of directory " + agentDir + " (already created).");
             }
 
             long pid = ProcessHandle.current().pid();
@@ -172,7 +172,7 @@ public class AgentConfiguration implements Serializable {
                 Files.move(tmpAccessFilter, accessFilterFile, StandardCopyOption.ATOMIC_MOVE);
             } catch (FileAlreadyExistsException e) {
                 Files.delete(tmpAccessFilter);
-                logger.info("Access-filter file already exists. Delete the temporary one.");
+                logger.info(accessFilterFile + " already exists. Delete " + tmpAccessFilter);
             }
 
             accessFilterFiles.add(accessFilterFile.toString());


### PR DESCRIPTION
This PR should fix https://github.com/graalvm/native-build-tools/issues/626

Described issue probably occurs in multi-threaded environment because the reported error throws `FileAlreadyExistsException`  even though [we checked first that file doesn't exist](https://github.com/graalvm/native-build-tools/blob/master/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java#L155). 

As per documentation of `java.nio.file.Files#createDirectory`:
> Creates a new directory. The check for the existence of the file and the creation of the directory if it does not exist are a single operation that is atomic with respect to all other filesystem activities that might affect the directory

Since we only care that directory with the given name exists, we can just catch and ignore `FileAlreadyExistsException` in this case. 