### PR TITLE
Improve GraalVM version check.

### DIFF
--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
@@ -60,7 +60,7 @@ public class NativeImageUtils {
 
     private static final Pattern requiredVersionPattern = Pattern.compile("^([0-9]+)(?:\\.([0-9]+)?)?(?:\\.([0-9]+)?)?$");
 
-    private static final Pattern graalvmVersionPattern = Pattern.compile("^(GraalVM|native-image) ([0-9]+)\\.([0-9]+)\\.([0-9]+).*");
+    private static final Pattern graalvmVersionPattern = Pattern.compile("^(GraalVM|native-image) ([0-9]+)\\.([0-9]+)\\.([0-9]+).*", Pattern.DOTALL);
 
     private static final Pattern javaVersionPattern = Pattern.compile("^native-image ([0-9]+).*", Pattern.DOTALL);
     private static final Pattern javaVersionLegacyPattern = Pattern.compile(".* \\(Java Version ([0-9]+)\\.([0-9]+)\\.([0-9]+).*");

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageUtilsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageUtilsTest.java
@@ -138,6 +138,17 @@ class NativeImageUtilsTest {
     }
 
     @Test
+    void checkOtherGraalVMVersion() {
+        String otherGraalVMForJDK23 = "native-image 23.0.1 2024-10-15\nJava(TM) SE Runtime Environment Foo Bar 23.0.1+11.1 (build 23.0.1+11-foo-bar-jvmci-b01)\n" +
+                "Java HotSpot(TM) 64-Bit Server VM Foo Bar 23.0.1+11.1 (build 23.0.1+11-foo-bar-jvmci-b01, mixed mode, sharing)";
+        NativeImageUtils.checkVersion("22.3.0", otherGraalVMForJDK23);
+        NativeImageUtils.checkVersion("23", otherGraalVMForJDK23);
+        NativeImageUtils.checkVersion("23.0", otherGraalVMForJDK23);
+        NativeImageUtils.checkVersion("23.0.1", otherGraalVMForJDK23);
+        Assertions.assertEquals(23, NativeImageUtils.getMajorJDKVersion(otherGraalVMForJDK23));
+    }
+
+    @Test
     void checkGreaterVersion() {
         NativeImageUtils.checkVersion("22", "GraalVM 23.2.1");
         NativeImageUtils.checkVersion("23.1", "GraalVM 23.2.1");


### PR DESCRIPTION
Fix for Issue #644 

Building a native image with "non Oracle" GraalVM fails with the following error. 

The problem was a regular expression.

```
$ mvn -Pnative package
...
[ERROR] Failed to execute goal org.graalvm.buildtools:native-maven-plugin:0.10.3:compile-no-fork (build-native) on project spring-boot-initial: Execution build-native of goal org.graalvm.buildtools:native-maven-plugin:0.10.3:compile-no-fork failed: Version to check 'native-image 23.0.1 2024-10-15
[ERROR] Java(TM) SE Runtime Environment MicroDoc GraalVM Embedded 23.0.1+11.1 (build 23.0.1+11-microdoc-p111200-t20241029n1-evaluation-linux-amd64-le-gcc11.2-gnu-glibc-jvmci-b01)
[ERROR] Java HotSpot(TM) 64-Bit Server VM MicroDoc GraalVM Embedded 23.0.1+11.1 (build 23.0.1+11-microdoc-p111200-t20241029n1-evaluation-linux-amd64-le-gcc11.2-gnu-glibc-jvmci-b01, mixed mode)' can't be parsed.
```

And for reference, here is the version reported by our native-image:

```
$ $JAVA_HOME/bin/native-image --version
native-image 23.0.1 2024-10-15
Java(TM) SE Runtime Environment MicroDoc GraalVM Embedded 23.0.1+11.1 (build 23.0.1+11-microdoc-p111200-t20241029n1-evaluation-linux-amd64-le-gcc11.2-gnu-glibc-jvmci-b01)
Java HotSpot(TM) 64-Bit Server VM MicroDoc GraalVM Embedded 23.0.1+11.1 (build 23.0.1+11-microdoc-p111200-t20241029n1-evaluation-linux-amd64-le-gcc11.2-gnu-glibc-jvmci-b01, mixed mode)
```