### PR TITLE
Fix sporadic failures with: access-filter.json already exists

### DIFF
--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -167,7 +167,7 @@ public class AgentConfiguration implements Serializable {
             }
 
             long pid = ProcessHandle.current().pid();
-            long time = System.currentTimeMillis();
+            long time = System.nanoTime();
             Path tmpAccessFilter = agentDir.resolve(ACCESS_FILTER_PREFIX + '_' + pid  + '_' + time  + '_' + ACCESS_FILTER_SUFFIX);
             Files.copy(accessFilterData, tmpAccessFilter);
 


### PR DESCRIPTION
It appears that our previous implementation with `milliseconds` doesn't work because there is still a chance that two threads can make an access-filter-file within the same millisecond. 

This PR replaces usage of milliseconds with nano time. 

The PR fixes: https://github.com/graalvm/native-build-tools/issues/653 and https://github.com/graalvm/native-build-tools/issues/626