### PR TITLE
Fix type issue in SBOM integration test

### DIFF
--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/SBOMFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/SBOMFunctionalTest.groovy
@@ -170,7 +170,14 @@ class SBOMFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
             assert mainComponentDependency.get('dependsOn').isEmpty()
 
             // Check that the main component is not found in "components"
-            assert !rootNode.get('components').any { it.get('bom-ref').asText() == mainComponentId }
+            assert !rootNode.get('components').any { component ->
+                def bomRef = component.get('bom-ref')
+                if (!bomRef) {
+                    return false
+                }
+                def bomRefValue = bomRef instanceof String ? bomRef : bomRef.asText()
+                bomRefValue == mainComponentId
+            }
 
             return true
         } catch (AssertionError | Exception e) {


### PR DESCRIPTION
[The failure](https://github.com/graalvm/native-build-tools/actions/runs/12787471981/job/35659952126?pr=662#step:5:10486) seems to be caused by `it.get('bom-ref')` returning a String rather than a jackson `JsonNode`. This is surprising behavior since it should, as far as I can see, always be a `JsonNode`. If you need a quick fix, this diff should solve it. 