### PR TITLE
Fix workflow trigger

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -2,7 +2,7 @@ name: "Deploy snapshots"
 
 on:
   workflow_run:
-    workflows: [ "deploy-documentation", "test-native-gradle-plugin", "test-native-maven-plugin", "test-junit-platform-native" ]
+    workflows: [ "Deploy documentation to website", "Test native-gradle-plugin", "Test native-maven-plugin", "Test junit-platform-native" ]
     branches: [ "master" ]
     types:
       - completed


### PR DESCRIPTION
Fixes #670

@dnestoro I think the issue comes from the fact that we should use the names of the workflows, not their ids, in the list.
