### PR TITLE
Add exclusions to Maven plugin

### DIFF
--- a/docs/src/docs/asciidoc/changelog.adoc
+++ b/docs/src/docs/asciidoc/changelog.adoc
@@ -7,6 +7,10 @@
 
 - Added options to override parameters from command line
 
+=== Maven plugin
+
+- Add support for dependency exclusions
+
 == Release 0.10.5
 
 - Add missing getters to `DirectoryConfiguration`

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -137,6 +137,16 @@ The following configuration options are available:
     <param>path/to/classes</param>
 </classpath>
 ----
+`<exclusions>`::
+   This can be used to exclude artifacts from native-image compilation.
+----
+<exclusions>
+    <exclusion>
+       <groupId>org.example</groupId>
+       <artifactId>example</artifactId>
+    </exclusion>
+</exclusions>
+----
 `<classesDirectory>`::
    If you want to specify custom path to the JAR, or a custom directory that contains
 only application classes, but you want the plugin to still automatically add classpath entries for

--- a/native-maven-plugin/reproducers/issue-612/pom.xml
+++ b/native-maven-plugin/reproducers/issue-612/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+  ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  ~
+  ~ The Universal Permissive License (UPL), Version 1.0
+  ~
+  ~ Subject to the condition set forth below, permission is hereby granted to any
+  ~ person obtaining a copy of this software, associated documentation and/or
+  ~ data (collectively the "Software"), free of charge and under any and all
+  ~ copyright rights in the Software, and any and all patent rights owned or
+  ~ freely licensable by each licensor hereunder covering either (i) the
+  ~ unmodified Software as contributed to or provided by such licensor, or (ii)
+  ~ the Larger Works (as defined below), to deal in both
+  ~
+  ~ (a) the Software, and
+  ~
+  ~ (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+  ~ one is included with the Software each a "Larger Work" to which the Software
+  ~ is contributed by such licensors),
+  ~
+  ~ without restriction, including without limitation the rights to copy, create
+  ~ derivative works of, display, perform, and distribute the Software and make,
+  ~ use, sell, offer for sale, import, export, have made, and have sold the
+  ~ Software and the Larger Work(s), and to sublicense the foregoing rights on
+  ~ either these or other terms.
+  ~
+  ~ This license is subject to the following condition:
+  ~
+  ~ The above copyright notice and either this complete permission notice or at a
+  ~ minimum a reference to the UPL must be included in all copies or substantial
+  ~ portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <groupId>org.graalvm.buildtools.examples</groupId>
+    <artifactId>issue-612</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <java.version>1.8</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <native.maven.plugin.version>0.10.5-SNAPSHOT</native.maven.plugin.version>
+        <imageName>example-app</imageName>
+        <mainClass>org.graalvm.demo.Application</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.3</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>compile-no-fork</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skip>false</skip>
+                            <imageName>${imageName}</imageName>
+                            <fallback>false</fallback>
+                            <exclusions>
+                                <exclusion>
+                                    <groupId>org.yaml</groupId>
+                                    <artifactId>snakeyaml</artifactId>
+                                </exclusion>
+                            </exclusions>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.8.1</version>
+                        <configuration>
+                            <source>${java.version}</source>
+                            <target>1.8</target>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>3.2.2</version>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addClasspath>false</addClasspath>
+                                    <mainClass>${mainClass}</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/native-maven-plugin/reproducers/issue-612/src/main/java/org/graalvm/demo/Application.java
+++ b/native-maven-plugin/reproducers/issue-612/src/main/java/org/graalvm/demo/Application.java
@@ -1,0 +1,11 @@
+package org.graalvm.demo;
+
+public class Application {
+    static String getMessage() {
+        return "Hello, native!";
+    }
+
+    public static void main(String[] args) {
+        System.out.println(getMessage());
+    }
+}

--- a/native-maven-plugin/reproducers/issue-612/src/main/java/org/graalvm/demo/Calculator.java
+++ b/native-maven-plugin/reproducers/issue-612/src/main/java/org/graalvm/demo/Calculator.java
@@ -1,0 +1,9 @@
+package org.graalvm.demo;
+
+public class Calculator {
+
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+}

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/issues/ExcludeDependenciesFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/issues/ExcludeDependenciesFunctionalTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.maven.issues
+
+import org.graalvm.buildtools.maven.AbstractGraalVMMavenFunctionalTest
+
+class ExcludeDependenciesFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
+    def "can exclude dependencies from native image classpath"() {
+        withReproducer("issue-612")
+
+        when:
+        mvn '-Pnative', '-Ddebug', '-Dverbose', '-DquickBuild', 'package'
+
+        then:
+        buildSucceeded
+        var imagecpLineIdx = outputLines.findIndexOf { it.startsWith('-imagecp') }
+        var imagecpLine = outputLines[imagecpLineIdx+1]
+        imagecpLine != null
+        imagecpLine.contains("issue-612-1.0.0-SNAPSHOT.jar")
+        !imagecpLine.contains("snakeyaml")
+    }
+
+}

--- a/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/AbstractGraalVMMavenFunctionalTest.groovy
+++ b/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/AbstractGraalVMMavenFunctionalTest.groovy
@@ -228,6 +228,10 @@ abstract class AbstractGraalVMMavenFunctionalTest extends Specification {
         !normalizeString(result.stdOut).contains(normalizeString(text))
     }
 
+    List<String> getOutputLines() {
+        return normalizeString(result.stdOut).split("\n")
+    }
+
     static boolean matches(String actual, String expected) {
         normalizeString(actual) == normalizeString(expected)
     }


### PR DESCRIPTION
This commit adds an `exclusions` parameter to the Maven plugin, which can be used to exclude dependencies from the compile classpath of native image.

It can be used to remove some dependencies from compilation, such as these injected by Spring Boot for development. Note, however, that if the main jar is configured to have the manifest with `addClaspath` to true, then the manifest file will still reference the jar, and native compile will issue a warning (because the jar will be missing from classpath).

Fixes #612