### PR TITLE
Upgrade Maven dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,22 +5,21 @@ metadataRepository = "0.3.15"
 
 # External dependencies
 spock = "2.1-groovy-3.0"
-maven = "3.8.6"
+maven = "3.9.9"
 mavenAnnotations = "3.6.4"
-mavenEmbedder = "3.8.6"
-mavenWagon = "3.4.3"
+mavenEmbedder = "3.9.9"
+mavenResolver = "1.9.22"
 graalvm = "23.0.2"
 openjson = "1.0.13"
 junitPlatform = "1.10.0"
 junitJupiter = "5.10.0"
-aether = "1.1.0"
 slf4j = "1.7.9"
 groovy = "3.0.11"
 jetty = "11.0.11"
-plexusUtils = "4.0.0"
+plexusUtils = "4.0.2"
 plexusXml = "4.0.2"
-cyclonedxMaven = "2.8.1"
-pluginExecutorMaven = "2.4.0"
+cyclonedxMaven = "2.9.1"
+pluginExecutorMaven = "2.4.1"
 
 [libraries]
 # Local projects
@@ -50,11 +49,9 @@ maven-core = { module = "org.apache.maven:maven-core", version.ref = "maven" }
 maven-artifact = { module = "org.apache.maven:maven-artifact", version.ref = "maven" }
 maven-compat = { module = "org.apache.maven:maven-compat", version.ref = "maven" }
 maven-embedder = { module = "org.apache.maven:maven-embedder", version.ref = "mavenEmbedder" }
-maven-aether-connector = { module = "org.eclipse.aether:aether-connector-basic", version.ref = "aether" }
-maven-aether-wagon = { module = "org.eclipse.aether:aether-transport-wagon", version.ref = "aether" }
-maven-wagon-file = { module = "org.apache.maven.wagon:wagon-file", version.ref = "mavenWagon" }
-maven-wagon-http = { module = "org.apache.maven.wagon:wagon-http", version.ref = "mavenWagon" }
-maven-wagon-provider = { module = "org.apache.maven.wagon:wagon-provider-api", version.ref = "mavenWagon" }
+maven-resolver-basic = { module = "org.apache.maven.resolver:maven-resolver-connector-basic", version.ref = "mavenResolver"}
+maven-resolver-transport-http = { module = "org.apache.maven.resolver:maven-resolver-transport-http", version.ref = "mavenResolver"}
+maven-resolver-transport-file = { module = "org.apache.maven.resolver:maven-resolver-transport-file", version.ref = "mavenResolver"}
 
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 

--- a/native-maven-plugin/build.gradle.kts
+++ b/native-maven-plugin/build.gradle.kts
@@ -63,22 +63,20 @@ dependencies {
     implementation(libs.utils)
     implementation(libs.openjson)
     implementation(libs.jvmReachabilityMetadata)
-    implementation(libs.plexus.utils)
-    implementation(libs.plexus.xml)
     implementation(libs.cyclonedx.maven.plugin)
     implementation(libs.plugin.executor.maven)
 
+    compileOnly(libs.plexus.utils)
+    compileOnly(libs.plexus.xml)
     compileOnly(libs.maven.pluginApi)
     compileOnly(libs.maven.core)
     compileOnly(libs.maven.artifact)
     compileOnly(libs.maven.pluginAnnotations)
 
     mavenEmbedder(libs.maven.embedder)
-    mavenEmbedder(libs.maven.aether.connector)
-    mavenEmbedder(libs.maven.aether.wagon)
-    mavenEmbedder(libs.maven.wagon.http)
-    mavenEmbedder(libs.maven.wagon.file)
-    mavenEmbedder(libs.maven.wagon.provider)
+    mavenEmbedder(libs.maven.resolver.basic)
+    mavenEmbedder(libs.maven.resolver.transport.http)
+    mavenEmbedder(libs.maven.resolver.transport.file)
     mavenEmbedder(libs.maven.compat)
     mavenEmbedder(libs.slf4j.simple)
 
@@ -180,4 +178,3 @@ tasks.withType<Checkstyle>().configureEach {
     // generated code
     exclude("**/RuntimeMetadata*")
 }
-


### PR DESCRIPTION
- Bump the test maven runtime to 3.9.9
- Remove use of old aether APIs (used only in tests)
- Upgrade CycloneDX and executor plugins
- Upgrade plexus utils
- Fix plexus utils appearing in runtime when it should be provided