### PR TITLE
[cleanup] fix small mistake in doc

### DIFF
--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -13,7 +13,7 @@ You can find sample applications in the https://github.com/graalvm/native-build-
 [[adding-the-plugin]]
 == Adding the Plugin
 
-Refer to the <<end-to-end-maven-guide.adoc#,Getting Started Maven Guide>> which provides step-by-step directions on adding the Gradle plugin to your project, building your first native image, and running it.
+Refer to the <<end-to-end-maven-guide.adoc#,Getting Started Maven Guide>> which provides step-by-step directions on adding the Maven plugin to your project, building your first native image, and running it.
 
 [NOTE]
 ====


### PR DESCRIPTION
Hello,

I'm reading a bunch of documentation and found a few mistakes.
The committed one was a fairly easy fix, but others are not.
I'd love to do more, but I'll need some support for that !

Here are the other ones I found so far:
https://github.com/graalvm/native-build-tools/blob/master/docs/src/docs/asciidoc/maven-plugin.adoc
- There's another gradle reference at the start of the file `:highlighjsdir: {gradle-relative-srcdir}/highlight` that doesn't seem to render. I don't know this syntax.
- The javadoc link at the end of the file is broken.

The snippet in those two files seems reversed.
- this one references gradle instead of maven: https://github.com/graalvm/native-build-tools/blob/master/native-maven-plugin/README.md 
- this one references gradle instead of maven: https://github.com/graalvm/native-build-tools/blob/master/native-maven-plugin/README.md
If someone could confirm that this is indeed just reversed, I can commit it quickly.

I have signed the OCA a couple of years ago, seems to never have been fvalidated.
I did it again yesterday.

Have a nice day !