### PR TITLE
Reduce verbosity of maven logs

### DIFF
--- a/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/IsolatedMavenExecutor.groovy
+++ b/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/IsolatedMavenExecutor.groovy
@@ -109,7 +109,7 @@ class IsolatedMavenExecutor {
         // adhoc filtering of Maven's download progress which is only
         // possible to silence since 3.6.5+
         return input.replaceAll("[0-9]+/[0-9]+ [KMG]?B\\s+", "")
-                .replaceAll("^Download(ing|ed)( from)? : .+\$", "")
+                .replaceAll("^Download(ing|ed)( from)? (seed|common): .+\$", "")
                 .replaceAll("^Progress \\([0-9]+\\).+\$", "")
                 .trim()
     }


### PR DESCRIPTION
This PR updates regex that filters maven logs. It removes lines like `Downloading from seed:` or `Downloading from common:` that are printed frequently when running functional tests 