### PR TITLE
Disable sbom tests that cause transient failures

### DIFF
--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/SBOMFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/SBOMFunctionalTest.groovy
@@ -44,6 +44,7 @@ package org.graalvm.buildtools.maven
 import com.github.openjson.JSONObject
 import org.graalvm.buildtools.maven.sbom.SBOMGenerator
 import org.graalvm.buildtools.utils.NativeImageUtils
+import spock.lang.Ignore
 import spock.lang.Requires
 
 class SBOMFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
@@ -67,6 +68,7 @@ class SBOMFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
         EE() && jdkVersionSupportsAugmentedSBOM()
     }
 
+    @Ignore
     @Requires({ supportedAugmentedSBOMVersion() })
     def "sbom is exported and embedded when buildArg '--enable-sbom=export,embed' is used"() {
         withSample 'java-application'
@@ -91,6 +93,7 @@ class SBOMFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
      * If user sets {@link NativeCompileNoForkMojo#AUGMENTED_SBOM_PARAM_NAME} to true then Native Image should be
      * invoked with '--enable-sbom' and an SBOM should be embedded in the image.
      */
+    @Ignore
     @Requires({ supportedAugmentedSBOMVersion() })
     def "sbom is embedded when only the augmented sbom parameter is used (but not the '--enable-sbom' buildArg)"() {
         withSample 'java-application'


### PR DESCRIPTION
Disabled until the following ticket gets resolved: https://github.com/graalvm/native-build-tools/issues/698