### PR TITLE
Update ubuntu version used in github actions

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [ 17 ]
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-22.04 ]
     steps:
       - name: "☁  Checkout repository"
         uses: actions/checkout@v4

--- a/.github/workflows/test-graalvm-metadata.yml
+++ b/.github/workflows/test-graalvm-metadata.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [ 17 ]
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-22.04 ]
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@v4

--- a/.github/workflows/test-junit-platform-native.yml
+++ b/.github/workflows/test-junit-platform-native.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [ 17 ]
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-22.04 ]
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@v4

--- a/.github/workflows/test-native-gradle-plugin.yml
+++ b/.github/workflows/test-native-gradle-plugin.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   populate-matrix:
     name: "Set matrix"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -70,7 +70,7 @@ jobs:
 
   populate-cache-matrix:
     name: "Set cache matrix"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -115,13 +115,13 @@ jobs:
 
   test-native-gradle-plugin:
     name: "Sanity checks"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:
         java-version: [ 17 ]
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-22.04 ]
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@v4
@@ -147,7 +147,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [ 17 ]
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-22.04 ]
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@v4

--- a/.github/workflows/test-native-maven-plugin.yml
+++ b/.github/workflows/test-native-maven-plugin.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   populate-matrix:
     name: "Set matrix"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [ 17 ]
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-22.04 ]
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@v4

--- a/build-logic/common-plugins/src/main/groovy/org.graalvm.build.github-actions-helper.gradle
+++ b/build-logic/common-plugins/src/main/groovy/org.graalvm.build.github-actions-helper.gradle
@@ -2,7 +2,7 @@ import groovy.json.JsonOutput
 
 def matrixDefault = [
         "java-version": [ "17" ],
-        "os": [ "ubuntu-20.04", "windows-latest" ]
+        "os": [ "ubuntu-22.04", "windows-latest" ]
 ]
 
 // # Following versions are disabled temporarily in order to speed up PR testing  "7.3.3", "7.2", "7.1", "6.8.3",


### PR DESCRIPTION
- As per [this issue](https://github.com/actions/runner-images/issues/11101) github actions are no longer support `Ubuntu 20.04`.
- We already have [jobs canceled](https://github.com/graalvm/native-build-tools/actions/runs/13657080506/job/38178889602?pr=693) with the following error:  This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01. For more details, see https://github.com/actions/runner-images/issues/11101

This PR updates Ubuntu version used in github actions from `20.04` to `22.04`