### PR TITLE
Update reachability metadata repository version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Project versions
 nativeBuildTools = "0.10.6-SNAPSHOT"
-metadataRepository = "0.3.15"
+metadataRepository = "0.3.18"
 
 # External dependencies
 spock = "2.1-groovy-3.0"


### PR DESCRIPTION
Updates reachability metadata version to the [latest available release](https://github.com/oracle/graalvm-reachability-metadata/releases/tag/0.3.18) (`0.3.18`)