### PR TITLE
Avoid Adding Duplicated JUnit Entries on Classpath

### DIFF
--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -62,6 +62,7 @@ import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
 import org.graalvm.buildtools.utils.NativeImageConfigurationUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -297,8 +298,17 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
             .stream()
             .map(ArtifactResult::getArtifact)
             .filter(a -> !modulesAlreadyOnClasspath.contains(new Module(a.getGroupId(), a.getArtifactId())))
+            .filter(a -> imageClasspath.stream().noneMatch(entry -> matchGroup(entry, a.getGroupId()) && matchArtifact(entry, a.getArtifactId())))
             .map(a -> a.getFile().toPath())
             .collect(Collectors.toList());
+    }
+
+    private boolean matchGroup(Path entry, String groupId) {
+        return entry.toString().contains(groupId.replace(".", File.separator));
+    }
+
+    private boolean matchArtifact(Path entry, String artifactId) {
+        return entry.toString().contains(artifactId);
     }
 
     private static final class Module {

--- a/samples/java-application-with-tests/pom.xml
+++ b/samples/java-application-with-tests/pom.xml
@@ -104,6 +104,7 @@
                             <skip>false</skip>
                             <imageName>${imageName}</imageName>
                             <fallback>false</fallback>
+                            <verbose>true</verbose>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Fix for: https://github.com/graalvm/native-build-tools/issues/305

When running `java-application-with-tests` with `mvn -Pnative package` I am getting following results:
- Without this change:

> [INFO] Executing: /.sdkman/candidates/java/21.0.4-graal/bin/native-image -cp /work/native-build-tools/samples/java-application-with-tests/target/classes:/work/native-build-tools/samples/java-application-with-tests/target/test-classes:/.m2/repository/org/junit/jupiter/junit-jupiter/5.10.0/junit-jupiter-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.10.0/junit-jupiter-api-5.10.0.jar:/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/.m2/repository/org/junit/platform/junit-platform-commons/1.10.0/junit-platform-commons-1.10.0.jar:/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.10.0/junit-jupiter-params-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.10.0/junit-jupiter-engine-5.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-engine/1.10.0/junit-platform-engine-1.10.0.jar:/.m2/repository/org/graalvm/buildtools/native-maven-plugin/0.10.7-SNAPSHOT/native-maven-plugin-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/utils/0.10.7-SNAPSHOT/utils-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/graalvm-reachability-metadata/0.10.7-SNAPSHOT/graalvm-reachability-metadata-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/junit-platform-native/0.10.7-SNAPSHOT/junit-platform-native-0.10.7-SNAPSHOT.jar:/.m2/repository/org/junit/platform/junit-platform-console/1.10.0/junit-platform-console-1.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-reporting/1.10.0/junit-platform-reporting-1.10.0.jar:/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/.m2/repository/org/junit/platform/junit-platform-launcher/1.10.0/junit-platform-launcher-1.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-engine/1.10.0/junit-platform-engine-1.10.0.jar:/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/.m2/repository/org/junit/platform/junit-platform-commons/1.10.0/junit-platform-commons-1.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter/5.10.0/junit-jupiter-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.10.0/junit-jupiter-api-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.10.0/junit-jupiter-params-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.10.0/junit-jupiter-engine-5.10.0.jar --no-fallback --verbose -o /work/native-build-tools/samples/java-application-with-tests/target/native-tests -Djunit.platform.listeners.uid.tracking.output.dir=/work/native-build-tools/samples/java-application-with-tests/target/test-ids --features=org.graalvm.junit.platform.JUnitPlatformFeature org.graalvm.junit.platform.NativeImageJUnitLauncher


- With this change:

> [INFO] Executing: /.sdkman/candidates/java/21.0.4-graal/bin/native-image -cp /work/native-build-tools/samples/java-application-with-tests/target/classes:/work/native-build-tools/samples/java-application-with-tests/target/test-classes:/.m2/repository/org/junit/jupiter/junit-jupiter/5.10.0/junit-jupiter-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.10.0/junit-jupiter-api-5.10.0.jar:/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/.m2/repository/org/junit/platform/junit-platform-commons/1.10.0/junit-platform-commons-1.10.0.jar:/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.10.0/junit-jupiter-params-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.10.0/junit-jupiter-engine-5.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-engine/1.10.0/junit-platform-engine-1.10.0.jar:/.m2/repository/org/graalvm/buildtools/native-maven-plugin/0.10.7-SNAPSHOT/native-maven-plugin-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/utils/0.10.7-SNAPSHOT/utils-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/graalvm-reachability-metadata/0.10.7-SNAPSHOT/graalvm-reachability-metadata-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/junit-platform-native/0.10.7-SNAPSHOT/junit-platform-native-0.10.7-SNAPSHOT.jar:/.m2/repository/org/junit/platform/junit-platform-console/1.10.0/junit-platform-console-1.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-reporting/1.10.0/junit-platform-reporting-1.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-launcher/1.10.0/junit-platform-launcher-1.10.0.jar --no-fallback --verbose -o /work/native-build-tools/samples/java-application-with-tests/target/native-tests -Djunit.platform.listeners.uid.tracking.output.dir=/work/native-build-tools/samples/java-application-with-tests/target/test-ids --features=org.graalvm.junit.platform.JUnitPlatformFeature org.graalvm.junit.platform.NativeImageJUnitLauncher

- When I update `junitPlatform` and `junitJupiter` versions [in the project](https://github.com/graalvm/native-build-tools/blob/master/gradle/libs.versions.toml#L14) to `1.11.0` and `5.11.0` :
> [INFO] Executing: /.sdkman/candidates/java/21.0.4-graal/bin/native-image -cp /work/native-build-tools/samples/java-application-with-tests/target/classes:/work/native-build-tools/samples/java-application-with-tests/target/test-classes:/.m2/repository/org/junit/jupiter/junit-jupiter/5.10.0/junit-jupiter-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.10.0/junit-jupiter-api-5.10.0.jar:/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/.m2/repository/org/junit/platform/junit-platform-commons/1.10.0/junit-platform-commons-1.10.0.jar:/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.10.0/junit-jupiter-params-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.10.0/junit-jupiter-engine-5.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-engine/1.10.0/junit-platform-engine-1.10.0.jar:/.m2/repository/org/graalvm/buildtools/native-maven-plugin/0.10.7-SNAPSHOT/native-maven-plugin-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/utils/0.10.7-SNAPSHOT/utils-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/graalvm-reachability-metadata/0.10.7-SNAPSHOT/graalvm-reachability-metadata-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/junit-platform-native/0.10.7-SNAPSHOT/junit-platform-native-0.10.7-SNAPSHOT.jar:/.m2/repository/org/junit/platform/junit-platform-console/1.11.0/junit-platform-console-1.11.0.jar:/.m2/repository/org/junit/platform/junit-platform-reporting/1.11.0/junit-platform-reporting-1.11.0.jar:/.m2/repository/org/junit/platform/junit-platform-launcher/1.11.0/junit-platform-launcher-1.11.0.jar --no-fallback --verbose -o /work/native-build-tools/samples/java-application-with-tests/target/native-tests -Djunit.platform.listeners.uid.tracking.output.dir=/work/native-build-tools/samples/java-application-with-tests/target/test-ids --features=org.graalvm.junit.platform.JUnitPlatformFeature org.graalvm.junit.platform.NativeImageJUnitLauncher

From the output we see that there are no `5.11.0` entries because this sample sets its own JUnit version through [gradle.properties](https://github.com/graalvm/native-build-tools/blob/master/samples/java-application-with-tests/gradle.properties#L2) file. With this fix we are giving the advantage to the user's declared version (illustrated in the example above).

**Possible problem**: If we update hardcoded JUnit version to `5.11.0` [here](https://github.com/graalvm/native-build-tools/blob/master/gradle/libs.versions.toml#L15) (for example to support `@FieldSource` annotation - like I did in [this PR](https://github.com/graalvm/native-build-tools/pull/693/files#diff-7b2f9d1eea335da0c18259129c76170dfd6e022048a993d867e121cfe1a23eb7R99)) and user declared earlier JUnit version in its project (for example `5.10.0`) we won't have `5.11.0` artifact on the classpath, and therefore we will get `NoClassDefFoundError` since `FieldSource` is not available before `5.11.0` version. 
In that case we can catch and ignore `NoClassDefFoundError` when supporting annotations from newer JUnit versions. The question is: can this harm existing projects if we suddenly remove "duplicates" (same artifacts but with different versions)? Are we currently relying on some JUnit features that are only available from JUnit `5.10.0`? cc @melix @sbrannen 