### PR TITLE
Add proivded dependencies on classpath

### DIFF
--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
@@ -41,6 +41,7 @@
 
 package org.graalvm.buildtools.maven
 
+import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 class JavaApplicationWithTestsFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
@@ -153,6 +154,7 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractGraalVMMavenFunctio
         outputContains "SurefirePlugin - Tests run: 8, Failures: 0, Errors: 0, Skipped: 0"
     }
 
+    @IgnoreIf({ os.windows })
     def "dependencies with scope provided are on classpath for test binary"() {
         withSample("java-application-with-tests")
 
@@ -166,6 +168,7 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractGraalVMMavenFunctio
         outputContains expectedOutput
     }
 
+    @IgnoreIf({ os.windows })
     def "dependencies with scope provided are not on classpath for main binary"() {
         withSample("java-application-with-tests")
 

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
@@ -153,4 +153,26 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractGraalVMMavenFunctio
         outputContains "SurefirePlugin - Tests run: 8, Failures: 0, Errors: 0, Skipped: 0"
     }
 
+    def "dependencies with scope provided are on classpath for test binary"() {
+        withSample("java-application-with-tests")
+
+        when:
+        mvn '-Pnative', '-DquickBuild', 'test'
+
+        then:
+        buildSucceeded
+        outputContains "local-repo/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"
+    }
+
+    def "dependencies with scope provided are not on classpath for main binary"() {
+        withSample("java-application-with-tests")
+
+        when:
+        mvn '-Pnative', '-DquickBuild', '-DskipNativeTests', 'package'
+
+        then:
+        buildSucceeded
+        outputDoesNotContain "local-repo/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"
+    }
+
 }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
@@ -159,9 +159,11 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractGraalVMMavenFunctio
         when:
         mvn '-Pnative', '-DquickBuild', 'test'
 
+        def expectedOutput = ["local-repo", "org", "apache", "commons", "commons-lang3", "3.12.0", "commons-lang3-3.12.0.jar"].join(File.separator)
+
         then:
         buildSucceeded
-        outputContains "local-repo/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"
+        outputContains expectedOutput
     }
 
     def "dependencies with scope provided are not on classpath for main binary"() {
@@ -170,9 +172,11 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractGraalVMMavenFunctio
         when:
         mvn '-Pnative', '-DquickBuild', '-DskipNativeTests', 'package'
 
+        def expectedOutput = ["local-repo", "org", "apache", "commons", "commons-lang3", "3.12.0", "commons-lang3-3.12.0.jar"].join(File.separator)
+
         then:
         buildSucceeded
-        outputDoesNotContain "local-repo/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"
+        outputDoesNotContain expectedOutput
     }
 
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -113,7 +113,8 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
             Artifact.SCOPE_COMPILE,
             Artifact.SCOPE_RUNTIME,
             Artifact.SCOPE_TEST,
-            Artifact.SCOPE_COMPILE_PLUS_RUNTIME
+            Artifact.SCOPE_COMPILE_PLUS_RUNTIME,
+            Artifact.SCOPE_PROVIDED
         );
     }
 

--- a/samples/java-application-with-tests/pom.xml
+++ b/samples/java-application-with-tests/pom.xml
@@ -60,6 +60,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.jupiter.version}</version>


### PR DESCRIPTION
Fixes: https://github.com/graalvm/native-build-tools/issues/601 and https://github.com/graalvm/native-build-tools/issues/562

I tested this on the `java-application-with-resources` sample. If I set `<scope>` of `org.apache.commons` to `provided`:

- without this fix classpath looks like this:
> [INFO] Executing: /.sdkman/candidates/java/21.0.4-graal/bin/native-image -cp /native-build-tools/samples/java-application-with-resources/target/classes:/native-build-tools/samples/java-application-with-resources/target/test-classes:/native-build-tools/samples/java-application-with-resources/src/test/resources:/.m2/repository/org/junit/jupiter/junit-jupiter/5.10.0/junit-jupiter-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.10.0/junit-jupiter-api-5.10.0.jar:/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/.m2/repository/org/junit/platform/junit-platform-commons/1.10.0/junit-platform-commons-1.10.0.jar:/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.10.0/junit-jupiter-params-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.10.0/junit-jupiter-engine-5.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-engine/1.10.0/junit-platform-engine-1.10.0.jar:/.m2/repository/org/graalvm/buildtools/native-maven-plugin/0.10.7-SNAPSHOT/native-maven-plugin-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/utils/0.10.7-SNAPSHOT/utils-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/graalvm-reachability-metadata/0.10.7-SNAPSHOT/graalvm-reachability-metadata-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/junit-platform-native/0.10.7-SNAPSHOT/junit-platform-native-0.10.7-SNAPSHOT.jar:/.m2/repository/org/junit/platform/junit-platform-console/1.10.0/junit-platform-console-1.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-reporting/1.10.0/junit-platform-reporting-1.10.0.jar:/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/.m2/repository/org/junit/platform/junit-platform-launcher/1.10.0/junit-platform-launcher-1.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-engine/1.10.0/junit-platform-engine-1.10.0.jar:/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/.m2/repository/org/junit/platform/junit-platform-commons/1.10.0/junit-platform-commons-1.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter/5.10.0/junit-jupiter-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.10.0/junit-jupiter-api-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.10.0/junit-jupiter-params-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.10.0/junit-jupiter-engine-5.10.0.jar --no-fallback -o /native-build-tools/samples/java-application-with-resources/target/native-tests -Djunit.platform.listeners.uid.tracking.output.dir=/native-build-tools/samples/java-application-with-resources/target/test-ids --features=org.graalvm.junit.platform.JUnitPlatformFeature -H:ConfigurationFileDirectories=/native-build-tools/samples/java-application-with-resources/target/native/generated/generateTestResourceConfig org.graalvm.junit.platform.NativeImageJUnitLauncher

and there is no `org.apache.commons` dependency.

- with this fix classpath looks like this:
> [INFO] Executing: /.sdkman/candidates/java/21.0.4-graal/bin/native-image -cp /native-build-tools/samples/java-application-with-resources/target/classes:/native-build-tools/samples/java-application-with-resources/target/test-classes:/native-build-tools/samples/java-application-with-resources/src/test/resources:/.m2/repository/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter/5.10.0/junit-jupiter-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.10.0/junit-jupiter-api-5.10.0.jar:/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/.m2/repository/org/junit/platform/junit-platform-commons/1.10.0/junit-platform-commons-1.10.0.jar:/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.10.0/junit-jupiter-params-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.10.0/junit-jupiter-engine-5.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-engine/1.10.0/junit-platform-engine-1.10.0.jar:/.m2/repository/org/graalvm/buildtools/native-maven-plugin/0.10.7-SNAPSHOT/native-maven-plugin-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/utils/0.10.7-SNAPSHOT/utils-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/graalvm-reachability-metadata/0.10.7-SNAPSHOT/graalvm-reachability-metadata-0.10.7-SNAPSHOT.jar:/.m2/repository/org/graalvm/buildtools/junit-platform-native/0.10.7-SNAPSHOT/junit-platform-native-0.10.7-SNAPSHOT.jar:/.m2/repository/org/junit/platform/junit-platform-console/1.10.0/junit-platform-console-1.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-reporting/1.10.0/junit-platform-reporting-1.10.0.jar:/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/.m2/repository/org/junit/platform/junit-platform-launcher/1.10.0/junit-platform-launcher-1.10.0.jar:/.m2/repository/org/junit/platform/junit-platform-engine/1.10.0/junit-platform-engine-1.10.0.jar:/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/.m2/repository/org/junit/platform/junit-platform-commons/1.10.0/junit-platform-commons-1.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter/5.10.0/junit-jupiter-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.10.0/junit-jupiter-api-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.10.0/junit-jupiter-params-5.10.0.jar:/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.10.0/junit-jupiter-engine-5.10.0.jar --no-fallback -o /native-build-tools/samples/java-application-with-resources/target/native-tests -Djunit.platform.listeners.uid.tracking.output.dir=/native-build-tools/samples/java-application-with-resources/target/test-ids --features=org.graalvm.junit.platform.JUnitPlatformFeature -H:ConfigurationFileDirectories=/native-build-tools/samples/java-application-with-resources/target/native/generated/generateTestResourceConfig org.graalvm.junit.platform.NativeImageJUnitLauncher

and we can see that there is an entry for`org.apache.commons`  (`/.m2/repository/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar`)


**NOTE**: when I run `mvn -Pnative package -DskipNativeTests` classpath doesn't have `org.apache.commons` dependency if it has `<scope>provided</scope>`:
>[INFO] Executing: /.sdkman/candidates/java/21.0.4-graal/bin/native-image -cp /native-build-tools/samples/java-application-with-resources/target/maven-app-with-tests.jar --no-fallback -o /native-build-tools/samples/java-application-with-resources/target/example-app -H:ConfigurationFileDirectories=/native-build-tools/samples/java-application-with-resources/target/native/generated/generateTestResourceConfig,/native-build-tools/samples/java-application-with-resources/target/native/generated/generateResourceConfig -H:ConfigurationFileDirectories=/native-build-tools/samples/java-application-with-resources/target/native/generated/generateTestResourceConfig,/native-build-tools/samples/java-application-with-resources/target/native/generated/generateResourceConfig -H:ConfigurationFileDirectories=/native-build-tools/samples/java-application-with-resources/target/native/generated/generateTestResourceConfig,/native-build-tools/samples/java-application-with-resources/target/native/generated/generateResourceConfig org.graalvm.demo.Application

(without explicitly defined `<scope>` the dependency appears on classpath)