### PR TITLE
Experimental support for layered images

### DIFF
--- a/common/utils/src/main/java/org/graalvm/buildtools/model/resources/NativeImageFlags.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/model/resources/NativeImageFlags.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.model.resources;
+
+public abstract class NativeImageFlags {
+    public static final String BUILD_OUTPUT_COLORFUL = "-H:+BuildOutputColorful";
+    public static final String COLOR = "--color";
+    public static final String CONFIGURATION_FILE_DIRECTORIES = "-H:ConfigurationFileDirectories";
+    public static final String LAYER_CREATE = "-H:LayerCreate";
+    public static final String LAYER_USE = "-H:LayerUse";
+    public static final String NO_FALLBACK = "--no-fallback";
+    public static final String PGO_INSTRUMENT = "--pgo-instrument";
+    public static final String QUICK_BUILD = "-Ob";
+    public static final String SHARED = "--shared";
+    public static final String UNLOCK_EXPERIMENTAL_VMOPTIONS = "-H:+UnlockExperimentalVMOptions";
+    public static final String VERBOSE = "--verbose";
+
+    private NativeImageFlags() {
+
+    }
+}

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/JarMetadata.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/JarMetadata.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.graalvm.buildtools.utils;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+public class JarMetadata {
+    private final List<String> packageList;
+
+    public JarMetadata(List<String> packageList) {
+        this.packageList = packageList;
+    }
+
+    public List<String> getPackageList() {
+        return packageList;
+    }
+
+    public static JarMetadata readFrom(Path propertiesFile) {
+        Properties props = new Properties();
+        try (InputStream is = Files.newInputStream(propertiesFile)) {
+            props.load(is);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to read metadata from properties file " + propertiesFile, e);
+        }
+        String packages = (String) props.get("packages");
+        List<String> packageList = packages == null ? List.of() : Arrays.asList(packages.split(","));
+        return new JarMetadata(packageList);
+    }
+}

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/JarScanner.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/JarScanner.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.graalvm.buildtools.utils;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+/**
+ * Performs scanning of a JAR file and extracts some metadata in the
+ * form of a properties file. For now this type only extracts the list
+ * of packages from a jar.
+ */
+public class JarScanner {
+    /**
+     * Scans a jar and creates a properties file with metadata about the jar contents.
+     * @param inputJar the input jar
+     * @param outputFile the output file
+     * @throws IOException
+     */
+    public static void scanJar(Path inputJar, Path outputFile) throws IOException {
+        try (Writer fileWriter = Files.newBufferedWriter(outputFile); PrintWriter writer = new PrintWriter(fileWriter)) {
+            Set<String> packageList = new TreeSet<>();
+            try (FileSystem jarFileSystem = FileSystems.newFileSystem(inputJar, null)) {
+                Path root = jarFileSystem.getPath("/");
+                try (Stream<Path> files = Files.walk(root)) {
+                    files.forEach(path -> {
+                        if (path.toString().endsWith(".class") && !path.toString().contains("META-INF")) {
+                            Path relativePath = root.relativize(path);
+                            String className = relativePath.toString()
+                                .replace('/', '.')
+                                .replace('\\', '.')
+                                .replaceAll("[.]class$", "");
+                            var lastDot = className.lastIndexOf(".");
+                            if (lastDot > 0) {
+                                var packageName = className.substring(0, lastDot);
+                                packageList.add(packageName);
+                            }
+                        }
+                    });
+                }
+            }
+            writer.println("packages=" + String.join(",", packageList));
+        } catch (IOException ex) {
+            throw new RuntimeException("Unable to write JAR analysis", ex);
+        }
+    }
+}

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/JarScanner.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/JarScanner.java
@@ -41,7 +41,7 @@ public class JarScanner {
     public static void scanJar(Path inputJar, Path outputFile) throws IOException {
         try (Writer fileWriter = Files.newBufferedWriter(outputFile); PrintWriter writer = new PrintWriter(fileWriter)) {
             Set<String> packageList = new TreeSet<>();
-            try (FileSystem jarFileSystem = FileSystems.newFileSystem(inputJar, null)) {
+            try (FileSystem jarFileSystem = FileSystems.newFileSystem(inputJar, (ClassLoader) null)) {
                 Path root = jarFileSystem.getPath("/");
                 try (Stream<Path> files = Files.walk(root)) {
                     files.forEach(path -> {

--- a/docs/src/docs/asciidoc/changelog.adoc
+++ b/docs/src/docs/asciidoc/changelog.adoc
@@ -5,6 +5,10 @@
 
 This version introduces a breaking change: the plugin now requires Java 17 to run.
 
+=== Gradle plugin
+
+- Added experimental support for layered images
+
 == Release 0.10.6
 
 === Gradle plugin

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JUnitFunctionalTests.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JUnitFunctionalTests.groovy
@@ -45,7 +45,7 @@ import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 
 class JUnitFunctionalTests extends AbstractFunctionalTest {
     def "test if JUint support works with various annotations, reflection and resources"() {
-
+        debug=true
         given:
         withSample("junit-tests")
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.gradle
+
+import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
+import org.graalvm.buildtools.gradle.fixtures.GraalVMSupport
+import org.graalvm.buildtools.utils.NativeImageUtils
+import spock.lang.Requires
+
+@Requires(
+        { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
+)
+class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
+    def "can build a native image using layers"() {
+        def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
+
+        given:
+        withSample("layered-java-application")
+
+        when:
+        run 'nativeLibdependenciesCompile'
+
+        then:
+        tasks {
+            succeeded ':nativeLibdependenciesCompile'
+        }
+        outputContains "'-H:LayerCreate' (origin(s): command line)"
+
+        when:
+        run 'nativeRun', '-Pmessage="Hello, layered images!"'
+
+        then:
+        tasks {
+            upToDate ':nativeLibdependenciesCompile'
+            succeeded ':nativeCompile'
+        }
+        nativeApp.exists()
+
+        and:
+        outputContains "- '-H:LayerUse' (origin(s): command line)"
+        outputContains "Hello, layered images!"
+
+        when: "Updating the application without changing the dependencies"
+        file("src/main/java/org/graalvm/demo/Application.java").text = """
+package org.graalvm.demo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Application {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);
+
+    public static void main(String[] args) {
+        LOGGER.info("App started with args {}", String.join(", ", args));
+    }
+
+}
+
+"""
+        run 'nativeRun', '-Pmessage="Hello, layered images!"'
+
+        then:
+        tasks {
+            // Base layer is not rebuilt
+            upToDate ':nativeLibdependenciesCompile'
+            // Application layer is recompiled
+            succeeded ':nativeCompile'
+        }
+
+        outputContains "- '-H:LayerUse' (origin(s): command line)"
+        outputContains "Hello, layered images!"
+    }
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -348,7 +348,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                 var useLayers = options.getLayers()
                     .stream()
                     .filter(layer -> layer instanceof UseLayerOptions)
-                    .collect(Collectors.toList());
+                    .toList();
                 if (!useLayers.isEmpty()) {
                     var libsDirs = project.getObjects().fileCollection();
                     libsDirs.from(useLayers
@@ -356,7 +356,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                         .map(l -> l.getLayerName().flatMap(layerName -> tasks.named(compileTaskNameForBinary(layerName), BuildNativeImageTask.class))
                             .map(t -> t.getOutputDirectory().getAsFile())
                         )
-                        .collect(Collectors.toList()));
+                        .toList());
                     if (IS_WINDOWS) {
                         var pathVariable = providers.environmentVariable("PATH");
                         task.getEnvironment().put("PATH", pathVariable.map(path -> path + ";" + libsDirs.getAsPath()).orElse(providers.provider(libsDirs::getAsPath)));

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DelegatingCompileOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DelegatingCompileOptions.java
@@ -43,6 +43,10 @@ package org.graalvm.buildtools.gradle.internal;
 import org.graalvm.buildtools.gradle.dsl.NativeImageCompileOptions;
 import org.graalvm.buildtools.gradle.dsl.NativeResourcesOptions;
 import org.graalvm.buildtools.gradle.dsl.agent.DeprecatedAgentOptions;
+import org.graalvm.buildtools.gradle.tasks.CreateLayerOptions;
+import org.graalvm.buildtools.gradle.tasks.LayerOptions;
+import org.gradle.api.Action;
+import org.gradle.api.DomainObjectSet;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.ListProperty;
@@ -170,5 +174,25 @@ public class DelegatingCompileOptions implements NativeImageCompileOptions {
     @Override
     public DirectoryProperty getPgoProfilesDirectory() {
         return options.getPgoProfilesDirectory();
+    }
+
+    @Override
+    public DomainObjectSet<LayerOptions> getLayers() {
+        return options.getLayers();
+    }
+
+    @Override
+    public void layers(Action<? super DomainObjectSet<LayerOptions>> spec) {
+        options.layers(spec);
+    }
+
+    @Override
+    public void useLayer(String name) {
+        options.useLayer(name);
+    }
+
+    @Override
+    public void createLayer(Action<? super CreateLayerOptions> spec) {
+        options.createLayer(spec);
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -234,8 +234,8 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
 
         List<String> actualCliArgs;
         if (useArgFile.getOrElse(true)) {
-            Path argFileDir = Paths.get(workingDirectory.get());
-            actualCliArgs = new ArrayList<>(NativeImageUtils.convertToArgsFile(cliArgs, argFileDir, argFileDir));
+            Path argFileDir = Paths.get(System.getProperty("java.io.tmpdir"));
+            actualCliArgs = new ArrayList<>(NativeImageUtils.convertToArgsFile(cliArgs, argFileDir, Paths.get(workingDirectory.get())));
         } else {
             actualCliArgs = cliArgs;
         }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -42,8 +42,12 @@
 package org.graalvm.buildtools.gradle.internal;
 
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
+import org.graalvm.buildtools.gradle.tasks.CreateLayerOptions;
+import org.graalvm.buildtools.gradle.tasks.LayerOptions;
+import org.graalvm.buildtools.gradle.tasks.UseLayerOptions;
 import org.graalvm.buildtools.utils.NativeImageUtils;
 import org.gradle.api.Transformer;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.RegularFile;
@@ -52,6 +56,8 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Nested;
 import org.gradle.process.CommandLineArgumentProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -63,6 +69,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class NativeImageCommandLineProvider implements CommandLineArgumentProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(NativeImageCommandLineProvider.class);
+
     private static final Transformer<Boolean, Boolean> NEGATE = b -> !b;
 
     private final Provider<NativeImageOptions> options;
@@ -116,10 +124,68 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
     public List<String> asArguments() {
         NativeImageOptions options = getOptions().get();
         List<String> cliArgs = new ArrayList<>(20);
+        boolean hasLayers = !options.getLayers().isEmpty();
+        String layerCreateName = null;
+        ConfigurableFileCollection jarsClasspath = null;
+        if (hasLayers) {
+            LOGGER.warn("Experimental support for layered images enabled. DSL may change at any time.");
+            cliArgs.add("-H:+UnlockExperimentalVMOptions");
+            var layers = options.getLayers();
+            var arg = new StringBuilder();
+            for (LayerOptions layer : layers) {
+                if (arg.length() > 0) {
+                    arg.append(" ");
+                }
+                if (layer instanceof CreateLayerOptions) {
+                    var create = (CreateLayerOptions) layer;
+                    layerCreateName = layer.getLayerName().get();
+                    arg.append("-H:LayerCreate=");
+                    arg.append(layerCreateName).append(".nil");
+                    var modules = create.getModules().get();
+                    jarsClasspath = create.getJars();
+                    boolean hasModules = !modules.isEmpty();
+                    boolean hasPackage = create.getPackages().isPresent() && !create.getPackages().get().isEmpty();
+                    var createLayerJars = jarsClasspath.getFiles();
+                    boolean hasJars = !createLayerJars.isEmpty();
+                    if (hasModules || hasPackage || hasJars) {
+                        var packages = create.getPackages().get();
+                        arg.append(",");
+                        if (hasModules) {
+                            arg.append(modules.stream().map(m -> "module=" + m).collect(Collectors.joining(",")));
+                        }
+                        if (hasPackage) {
+                            if (hasModules) {
+                                arg.append(",");
+                            }
+                            arg.append(packages.stream().map(p -> "package=" + p).collect(Collectors.joining(",")));
+                        }
+                        if (hasJars) {
+                            if (hasModules || hasPackage) {
+                                arg.append(",");
+                            }
+                            arg.append(jarsClasspath.getFiles().stream().map(p -> "path=" + p).collect(Collectors.joining(",")));
+                        }
+                    }
+                } else {
+                    var layerUse = (UseLayerOptions) layer;
+                    arg.append("-H:LayerUse=");
+                    arg.append(layerUse.getLayerFile().getAsFile().get().getAbsolutePath());
+                }
+            }
+            cliArgs.add(arg.toString());
+        }
         cliArgs.addAll(options.getExcludeConfigArgs().get());
-        cliArgs.add("-cp");
-        String classpathString = buildClasspathString(options);
-        cliArgs.add(classpathString);
+        String classpathString = buildClasspathString(options).trim();
+        if (!classpathString.isEmpty()) {
+            cliArgs.add("-cp");
+            cliArgs.add(classpathString);
+        } else if (jarsClasspath != null && !jarsClasspath.isEmpty()) {
+            // This is a shortcut in case of the creation of a layer using the "jars" mode (e.g, not package, nor modules)
+            // in which case the classpath must replicate the jars so we want to avoid that the user has to configure
+            // things twice
+            cliArgs.add("-cp");
+            cliArgs.add(jarsClasspath.getAsPath());
+        }
         appendBooleanOption(cliArgs, options.getDebug(), "-g");
         appendBooleanOption(cliArgs, options.getFallback().map(NEGATE), "--no-fallback");
         appendBooleanOption(cliArgs, options.getVerbose(), "--verbose");
@@ -131,12 +197,14 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         appendBooleanOption(cliArgs, options.getPgoInstrument(), "--pgo-instrument");
 
         String targetOutputPath = getExecutableName().get();
+        if (layerCreateName != null) {
+            targetOutputPath = layerCreateName;
+        }
         if (getOutputDirectory().isPresent()) {
             targetOutputPath = getOutputDirectory().get() + File.separator + targetOutputPath;
         }
         cliArgs.add("-o");
         cliArgs.add(targetOutputPath);
-
         options.getSystemProperties().get().forEach((n, v) -> {
             if (v != null) {
                 cliArgs.add("-D" + n + "=\"" + v + "\"");
@@ -146,12 +214,12 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         options.getJvmArgs().get().forEach(jvmArg -> cliArgs.add("-J" + jvmArg));
 
         String configFiles = options.getConfigurationFileDirectories()
-                .getElements()
-                .get()
-                .stream()
-                .map(FileSystemLocation::getAsFile)
-                .map(File::getAbsolutePath)
-                .collect(Collectors.joining(","));
+            .getElements()
+            .get()
+            .stream()
+            .map(FileSystemLocation::getAsFile)
+            .map(File::getAbsolutePath)
+            .collect(Collectors.joining(","));
         if (!configFiles.isEmpty()) {
             cliArgs.add("-H:ConfigurationFileDirectories=" + configFiles);
         }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CreateLayerOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CreateLayerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,56 +38,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.graalvm.buildtools.gradle.tasks;
 
-import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 /**
- * Defines common logic used by all libraries GraalVM projects in this repository
+ * Layer creation options.
  */
+public interface CreateLayerOptions extends LayerOptions {
+    /**
+     * The list of packages to include in the layer.
+     * @return the package list (can be empty)
+     */
+    @Input
+    @Optional
+    ListProperty<String> getPackages();
 
-plugins {
-    java
-}
+    /**
+     * If set, all classes in the supplied jars will be included
+     * in the generated layer.
+     * @return the classpath to include
+     */
+    @Classpath
+    @Optional
+    ConfigurableFileCollection getJars();
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-    withJavadocJar()
-    withSourcesJar()
-}
-
-repositories {
-    mavenCentral()
-}
-
-group = "org.graalvm.buildtools"
-
-extensions.findByType<VersionCatalogsExtension>()?.also { catalogs ->
-    if (catalogs.find("libs").isPresent) {
-        val versionFromCatalog = catalogs.named("libs")
-            .findVersion("nativeBuildTools")
-        if (versionFromCatalog.isPresent()) {
-            version = versionFromCatalog.get().requiredVersion
-        } else {
-            throw GradleException("Version catalog doesn't define project version 'nativeBuildTools'")
-        }
-    } else {
-        version = "undefined"
-    }
-}
-
-tasks.javadoc {
-    (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
-    (options as StandardJavadocDocletOptions).noTimestamp(true)
-}
-
-tasks.withType<Test>().configureEach {
-    testLogging {
-        events.addAll(listOf(TestLogEvent.STANDARD_OUT, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED))
-    }
-}
-
-val inspections by tasks.registering {
-    dependsOn(tasks.withType<Checkstyle>())
+    /**
+     * Module names to include in the package. For a base layer,
+     * this should typically include "java.base".
+     * @return the list of modules to include in the layer
+     */
+    @Input
+    ListProperty<String> getModules();
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/LayerOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/LayerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,25 +38,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.graalvm.buildtools.gradle.internal;
+package org.graalvm.buildtools.gradle.tasks;
 
-import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
 
-public class NativeConfigurations {
-    private final Configuration imageCompileOnly;
-    private final Configuration imageClasspath;
-
-    public NativeConfigurations(Configuration imageCompileOnly, Configuration imageClasspath) {
-        this.imageCompileOnly = imageCompileOnly;
-        this.imageClasspath = imageClasspath;
-    }
-
-    public Configuration getImageCompileOnlyConfiguration() {
-        return imageCompileOnly;
-    }
-
-    public Configuration getImageClasspathConfiguration() {
-        return imageClasspath;
-    }
-
+/**
+ * Base interface for common options of layer use and layer create.
+ */
+public interface LayerOptions  {
+    /**
+     * The name of the layer.
+     * @return the name property
+     */
+    @Input
+    Property<String> getLayerName();
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/UseLayerOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/UseLayerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,56 +38,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.graalvm.buildtools.gradle.tasks;
 
-import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 
 /**
- * Defines common logic used by all libraries GraalVM projects in this repository
+ * Configures a layer for use.
  */
-
-plugins {
-    java
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-    withJavadocJar()
-    withSourcesJar()
-}
-
-repositories {
-    mavenCentral()
-}
-
-group = "org.graalvm.buildtools"
-
-extensions.findByType<VersionCatalogsExtension>()?.also { catalogs ->
-    if (catalogs.find("libs").isPresent) {
-        val versionFromCatalog = catalogs.named("libs")
-            .findVersion("nativeBuildTools")
-        if (versionFromCatalog.isPresent()) {
-            version = versionFromCatalog.get().requiredVersion
-        } else {
-            throw GradleException("Version catalog doesn't define project version 'nativeBuildTools'")
-        }
-    } else {
-        version = "undefined"
-    }
-}
-
-tasks.javadoc {
-    (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
-    (options as StandardJavadocDocletOptions).noTimestamp(true)
-}
-
-tasks.withType<Test>().configureEach {
-    testLogging {
-        events.addAll(listOf(TestLogEvent.STANDARD_OUT, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED))
-    }
-}
-
-val inspections by tasks.registering {
-    dependsOn(tasks.withType<Checkstyle>())
+public interface UseLayerOptions extends LayerOptions {
+    /**
+     * The path to the layer to use.
+     * @return the path property.
+     */
+    @InputFile
+    @PathSensitive(PathSensitivity.NAME_ONLY)
+    RegularFileProperty getLayerFile();
 }

--- a/samples/layered-java-application/build.gradle
+++ b/samples/layered-java-application/build.gradle
@@ -39,55 +39,47 @@
  * SOFTWARE.
  */
 
-import org.gradle.api.tasks.testing.logging.TestLogEvent
-
-/**
- * Defines common logic used by all libraries GraalVM projects in this repository
- */
-
 plugins {
-    java
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-    withJavadocJar()
-    withSourcesJar()
+    id 'application'
+    id 'org.graalvm.buildtools.native'
 }
 
 repositories {
     mavenCentral()
 }
 
-group = "org.graalvm.buildtools"
+application {
+    mainClass.set('org.graalvm.demo.Application')
+}
 
-extensions.findByType<VersionCatalogsExtension>()?.also { catalogs ->
-    if (catalogs.find("libs").isPresent) {
-        val versionFromCatalog = catalogs.named("libs")
-            .findVersion("nativeBuildTools")
-        if (versionFromCatalog.isPresent()) {
-            version = versionFromCatalog.get().requiredVersion
-        } else {
-            throw GradleException("Version catalog doesn't define project version 'nativeBuildTools'")
+def junitVersion = providers.gradleProperty('junit.jupiter.version')
+        .get()
+
+dependencies {
+    implementation("org.slf4j:slf4j-api:2.0.17")
+    runtimeOnly("ch.qos.logback:logback-classic:1.5.18")
+    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
+    testImplementation('org.junit.jupiter:junit-jupiter')
+}
+
+test {
+    useJUnitPlatform()
+}
+
+tasks.named("nativeRun") {
+    runtimeArgs.add(providers.gradleProperty("message").orElse("default message"))
+}
+
+graalvmNative {
+    binaries {
+        libdependencies {
+            createLayer {
+                modules = ["java.base"]
+                jars.from(externalDependenciesOf(configurations.runtimeClasspath))
+            }
         }
-    } else {
-        version = "undefined"
+        main {
+            useLayer("libdependencies")
+        }
     }
-}
-
-tasks.javadoc {
-    (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
-    (options as StandardJavadocDocletOptions).noTimestamp(true)
-}
-
-tasks.withType<Test>().configureEach {
-    testLogging {
-        events.addAll(listOf(TestLogEvent.STANDARD_OUT, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED))
-    }
-}
-
-val inspections by tasks.registering {
-    dependsOn(tasks.withType<Checkstyle>())
 }

--- a/samples/layered-java-application/gradle.properties
+++ b/samples/layered-java-application/gradle.properties
@@ -1,0 +1,3 @@
+native.gradle.plugin.version = 0.10.7-SNAPSHOT
+junit.jupiter.version = 5.10.0
+junit.platform.version = 1.10.0

--- a/samples/layered-java-application/settings.gradle
+++ b/samples/layered-java-application/settings.gradle
@@ -39,55 +39,10 @@
  * SOFTWARE.
  */
 
-import org.gradle.api.tasks.testing.logging.TestLogEvent
-
-/**
- * Defines common logic used by all libraries GraalVM projects in this repository
- */
-
-plugins {
-    java
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-    withJavadocJar()
-    withSourcesJar()
-}
-
-repositories {
-    mavenCentral()
-}
-
-group = "org.graalvm.buildtools"
-
-extensions.findByType<VersionCatalogsExtension>()?.also { catalogs ->
-    if (catalogs.find("libs").isPresent) {
-        val versionFromCatalog = catalogs.named("libs")
-            .findVersion("nativeBuildTools")
-        if (versionFromCatalog.isPresent()) {
-            version = versionFromCatalog.get().requiredVersion
-        } else {
-            throw GradleException("Version catalog doesn't define project version 'nativeBuildTools'")
-        }
-    } else {
-        version = "undefined"
+pluginManagement {
+    plugins {
+        id 'org.graalvm.buildtools.native' version getProperty('native.gradle.plugin.version')
     }
 }
 
-tasks.javadoc {
-    (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
-    (options as StandardJavadocDocletOptions).noTimestamp(true)
-}
-
-tasks.withType<Test>().configureEach {
-    testLogging {
-        events.addAll(listOf(TestLogEvent.STANDARD_OUT, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED))
-    }
-}
-
-val inspections by tasks.registering {
-    dependsOn(tasks.withType<Checkstyle>())
-}
+rootProject.name = 'layered-java-application'

--- a/samples/layered-java-application/src/main/java/org/graalvm/demo/Application.java
+++ b/samples/layered-java-application/src/main/java/org/graalvm/demo/Application.java
@@ -1,0 +1,14 @@
+package org.graalvm.demo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Arrays;
+
+public class Application {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);
+
+    public static void main(String[] args) {
+        LOGGER.info("App started with args {}", Arrays.asList(args));
+    }
+
+}

--- a/samples/layered-mn-application/build.gradle
+++ b/samples/layered-mn-application/build.gradle
@@ -1,0 +1,72 @@
+plugins {
+    id("io.micronaut.minimal.application")
+    id("org.graalvm.buildtools.native")
+}
+
+version = "0.1"
+group = "layered.mn.app"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    annotationProcessor("io.micronaut:micronaut-http-validation")
+    annotationProcessor("io.micronaut.serde:micronaut-serde-processor")
+    implementation("io.micronaut.serde:micronaut-serde-jackson")
+    compileOnly("io.micronaut:micronaut-http-client")
+    runtimeOnly("ch.qos.logback:logback-classic")
+    testImplementation("io.micronaut:micronaut-http-client")
+}
+
+application {
+    mainClass = "layered.mn.app.Application"
+}
+
+graalvmNative.toolchainDetection = false
+
+micronaut {
+    runtime("netty")
+    testRuntime("junit5")
+    processing {
+        incremental(true)
+        annotations("layered.mn.app.*")
+    }
+}
+
+graalvmNative {
+    binaries {
+        all {
+            verbose = true
+            buildArgs(
+                "--initialize-at-run-time=io.netty.channel.unix.Errors",
+                "--initialize-at-run-time=io.netty.channel.unix.IovArray",
+                "--initialize-at-run-time=io.netty.channel.unix.Limits",
+                "--initialize-at-run-time=io.netty.buffer",
+                "--initialize-at-run-time=io.netty.channel",
+                "--initialize-at-run-time=io.netty.handler",
+                "--initialize-at-run-time=io.netty.resolver",
+                "--initialize-at-run-time=io.netty.util",
+                "--initialize-at-run-time=io.netty.bootstrap",
+                "-H:+UseSharedLayerGraphs",
+                "--initialize-at-build-time=io.micronaut.http.server.netty.discovery.\$NettyServiceDiscovery\$ApplicationEventListener\$onStop2\$Intercepted\$Definition\$Exec",
+                "--initialize-at-build-time=io.micronaut.http.server.netty.discovery.\$NettyServiceDiscovery\$ApplicationEventListener\$onStart1\$Intercepted\$Definition\$Exec"
+            )
+        }
+        create("libdependencies") {
+            var externalJars = externalDependenciesOf(configurations.runtimeClasspath)
+            createLayer {
+                modules = ["java.base"]
+                jars.from(externalJars)
+            }
+            buildArgs(
+                "-H:ApplicationLayerOnlySingletons=io.micronaut.core.io.service.ServiceScanner\$StaticServiceDefinitions",
+                "-H:ApplicationLayerInitializedClasses=io.micronaut.core.io.service.MicronautMetaServiceLoaderUtils",
+                "-H:ApplicationLayerInitializedClasses=io.micronaut.inject.annotation.AnnotationMetadataSupport"
+            )
+        }
+        named("main") {
+            useLayer("libdependencies")
+        }
+    }
+}

--- a/samples/layered-mn-application/gradle.properties
+++ b/samples/layered-mn-application/gradle.properties
@@ -1,0 +1,2 @@
+micronautVersion=4.8.1
+native.gradle.plugin.version = 0.10.7-SNAPSHOT

--- a/samples/layered-mn-application/settings.gradle
+++ b/samples/layered-mn-application/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    plugins {
+        id("io.micronaut.minimal.application")  version "4.5.3"
+        id("io.micronaut.graalvm")  version "4.5.3"
+        id("org.graalvm.buildtools.native") version(getProperty("native.gradle.plugin.version"))
+    }
+}
+
+rootProject.name = "layered-mn-app"

--- a/samples/layered-mn-application/src/main/java/layered/mn/app/Application.java
+++ b/samples/layered-mn-application/src/main/java/layered/mn/app/Application.java
@@ -1,0 +1,10 @@
+package layered.mn.app;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+    }
+}

--- a/samples/layered-mn-application/src/main/java/layered/mn/app/HelloController.java
+++ b/samples/layered-mn-application/src/main/java/layered/mn/app/HelloController.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package layered.mn.app;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+
+@Controller
+public class HelloController {
+    @Get("/")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String sayHello() {
+        return sayHello("layered images");
+    }
+
+    @Get("/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String sayHello(String name) {
+        return "Hello, "+ name + "!";
+    }
+
+    @Get("/bye/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String sayBye(String name) {
+        return "Bye, "+ name + "!";
+    }
+
+}

--- a/samples/layered-mn-application/src/main/resources/application.properties
+++ b/samples/layered-mn-application/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+#Mon Mar 10 16:06:16 CET 2025
+micronaut.application.name=layered-mn-app

--- a/samples/layered-mn-application/src/main/resources/logback.xml
+++ b/samples/layered-mn-application/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/samples/layered-mn-application/src/test/java/layered/mn/app/LayeredMnAppTest.java
+++ b/samples/layered-mn-application/src/test/java/layered/mn/app/LayeredMnAppTest.java
@@ -1,0 +1,21 @@
+package layered.mn.app;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import jakarta.inject.Inject;
+
+@MicronautTest
+class LayeredMnAppTest {
+
+    @Inject
+    EmbeddedApplication<?> application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}


### PR DESCRIPTION
This commit introduces a Gradle DSL to support layered images creation. As of now, this is mainly aimed towards a single use case which is incremental builds. The test project demonstrates how to use the DSL to create a base layer which includes the JDK "java.base" module as well as all external dependencies used by the project.

The DSL builds on top of the binaries concept, by allowing them to declare either that they produce a layer, or that they use one or more layers. The DSL contains methods to make it easier to declare use or creation, as well as supports an easy way to declare that a layer should use only external dependencies. For example, this is how you would create a base layer and consume it from the main binary:

```
graalvmNative {
    binaries {
        libdependencies {
            createLayer {
                modules = ["java.base"]
                jars.from(externalDependenciesOf(configurations.runtimeClasspath))
            }
        }
        main {
            useLayer("libdependencies")
        }
    }
}
```

Note that there is a _binary_ named `libdependencies`, and as soon as the `createLayer` is called, it will offer additional options which are specific to layers (for example declaring the list of packages or modules).

The DSL to create a layer contains the `packages` option, which could be used with automatic extraction of package names, which is why there is code to extract packages from jars, however, this code is currently unused for a reason: these packages can contain dependencies to "optional" modules, which cannot be figured out at build time. Typically, logback will support additional modules and load them dynamically, and if the package is included in the list and that the supporting dependencies are not on classpath, then the layer creation would fail. Therefore, the only reliable option right now is to use the `jars` property to set the list of jars which should belong to the layer.