### PR TITLE
Adds two new switches to the maven test goal

### DIFF
--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -95,6 +95,12 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
     @Parameter(property = "skipNativeTests", defaultValue = "false")
     private boolean skipNativeTests;
 
+    @Parameter(property = "skipTestExecution", defaultValue = "false")
+    private boolean skipTestExecution;
+
+    @Parameter(property = "failNoTests", defaultValue = "true")
+    private boolean failNoTests;
+
     @Override
     protected void populateApplicationClasspath() throws MojoExecutionException {
         super.populateApplicationClasspath();
@@ -147,8 +153,13 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
             return;
         }
         if (!hasTestIds()) {
-            logger.error("Test configuration file wasn't found. Make sure that test execution wasn't skipped.");
-            throw new IllegalStateException("Test configuration file wasn't found.");
+            if (failNoTests) {
+                logger.error("Test configuration file wasn't found. Make sure that test execution wasn't skipped.");
+                throw new IllegalStateException("Test configuration file wasn't found.");
+            } else {
+                logger.info("No tests found, skipping.");
+                return;
+            }
         }
 
         logger.info("====================");
@@ -168,7 +179,10 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
         mainClass = "org.graalvm.junit.platform.NativeImageJUnitLauncher";
 
         buildImage();
-        runNativeTests(outputDirectory.toPath().resolve(NATIVE_TESTS_EXE));
+
+        if (!skipTestExecution) {
+            runNativeTests(outputDirectory.toPath().resolve(NATIVE_TESTS_EXE));
+        }
     }
 
     private void configureEnvironment() {


### PR DESCRIPTION
- skipTestExecution (boolean), default is false

If true, create the native image for the tests but do not execute it. This allows the creation of the native images for testing even if they don't fully execute / tests fail. Otherwise, the build would stop at the first test failure.

- failNoTests (boolean), default is true

If true, fail building if no tests were found. In multi-module builds, there are often modules that have no tests (documentation) or tests are enabled/disabled by profiles (slow tests, e2e tests etc.). This switch allows for a concise configuraiton of the native plugin and then skipping modules where no tests were run without failing the build.
