### PR TITLE
Add missing JUnit 5.13.0 types to initialize-at-build-time classes

### DIFF
--- a/common/junit-platform-native/src/main/resources/initialize-at-buildtime
+++ b/common/junit-platform-native/src/main/resources/initialize-at-buildtime
@@ -99,9 +99,11 @@ org.junit.platform.launcher.listeners.UniqueIdTrackingListener
 org.junit.platform.launcher.TestIdentifier
 org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener
 org.junit.platform.reporting.shadow.org.opentest4j.reporting.events.api.DocumentWriter$1
+org.junit.platform.suite.engine.DiscoverySelectorResolver
 org.junit.platform.suite.engine.SuiteEngineDescriptor
 org.junit.platform.suite.engine.SuiteLauncher
 org.junit.platform.suite.engine.SuiteTestDescriptor
+org.junit.platform.suite.engine.SuiteTestDescriptor$DiscoveryIssueForwardingListener
 org.junit.platform.suite.engine.SuiteTestDescriptor$LifecycleMethods
 org.junit.platform.suite.engine.SuiteTestEngine
 org.junit.runner.Description

--- a/common/junit-platform-native/src/main/resources/initialize-at-buildtime
+++ b/common/junit-platform-native/src/main/resources/initialize-at-buildtime
@@ -89,6 +89,7 @@ org.junit.platform.launcher.core.LauncherConfigurationParameters$ParameterProvid
 org.junit.platform.launcher.core.LauncherDiscoveryResult
 org.junit.platform.launcher.core.LauncherDiscoveryResult$EngineResultInfo
 org.junit.platform.launcher.core.LauncherListenerRegistry
+org.junit.platform.launcher.core.LauncherPhase
 org.junit.platform.launcher.core.ListenerRegistry
 org.junit.platform.launcher.core.SessionPerRequestLauncher
 org.junit.platform.launcher.EngineDiscoveryResult


### PR DESCRIPTION
* Add `LauncherPhase` to JUnit's (introduced in 5.13.0-RC1)
* Add `org.junit.platform.suite.engine.DiscoverySelectorResolver` and `org.junit.platform.suite.engine.SuiteTestDescriptor$DiscoveryIssueForwardingListener` (refactored in 5.13.0-M3)