### PR TITLE
Disable CI startup on fork branches

### DIFF
--- a/.github/workflows/test-graalvm-metadata.yml
+++ b/.github/workflows/test-graalvm-metadata.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   test-graalvm-reachability-metadata:
     name: "Test GraalVM Reachability Metadata"
+    if: ${{ github.repository == 'graalvm/native-build-tools' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test-junit-platform-native.yml
+++ b/.github/workflows/test-junit-platform-native.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   test-junit-platform-native:
     name: "Test junit-platform-native"
+    if: ${{ github.repository == 'graalvm/native-build-tools' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test-native-gradle-plugin.yml
+++ b/.github/workflows/test-native-gradle-plugin.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   populate-matrix:
     name: "Set matrix"
+    if: ${{ github.repository == 'graalvm/native-build-tools' }}
     runs-on: "ubuntu-22.04"
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/test-native-maven-plugin.yml
+++ b/.github/workflows/test-native-maven-plugin.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   populate-matrix:
     name: "Set matrix"
+    if: ${{ github.repository == 'graalvm/native-build-tools' }}
     runs-on: "ubuntu-22.04"
     timeout-minutes: 5
     outputs:


### PR DESCRIPTION
- For https://github.com/graalvm/native-build-tools/issues/731 and https://github.com/graalvm/native-build-tools/issues/685 .
- Disable CI startup on fork branches.
- This is the source of the most annoying email reminders I encountered at https://github.com/graalvm/native-build-tools/issues/731. We have discussed something similar at https://github.com/oracle/graalvm-reachability-metadata/pull/229.
- ![image](https://github.com/user-attachments/assets/a28f6fdb-28bd-47ff-bc4d-f8e4b7dc8daa)
