### PR TITLE
Add `runtimeArgs` support to `native-maven-plugin`

### DIFF
--- a/docs/src/docs/asciidoc/changelog.adoc
+++ b/docs/src/docs/asciidoc/changelog.adoc
@@ -12,6 +12,7 @@ This version introduces a breaking change: the plugin now requires Java 17 to ru
 === Maven plugin
 
 - Added support for running integration tests via maven-failsafe-plugin
+- Add `runtimeArgs` support to `native-maven-plugin`
 
 == Release 0.10.6
 

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -119,6 +119,17 @@ The following configuration options are available:
     <propertyName>value</propertyName>
 </systemPropertyVariables>
 ----
+`<runtimeArgs>`::
+To specify runtime arguments used for a native image run, use:
+[source,xml, role="multi-language-sample"]
+----
+<runtimeArgs>
+    <runtimeArg>-XX:MissingRegistrationReportingMode=Warn</runtimeArg>
+</runtimeArgs>
+----
+
+This parameter is only valid for the Maven Goal of `test`.
+
 `<jvmArgs>`::
    To specify JVM arguments used for a native image build, use:
 [source,xml, role="multi-language-sample"]

--- a/native-maven-plugin/build.gradle.kts
+++ b/native-maven-plugin/build.gradle.kts
@@ -178,3 +178,7 @@ tasks.withType<Checkstyle>().configureEach {
     // generated code
     exclude("**/RuntimeMetadata*")
 }
+
+tasks {
+    withType<Javadoc>().configureEach { options.encoding = "UTF-8" }
+}

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
@@ -41,8 +41,10 @@
 
 package org.graalvm.buildtools.maven
 
+import org.graalvm.buildtools.utils.NativeImageUtils
 import spock.lang.IgnoreIf
 import spock.lang.Issue
+import spock.lang.Requires
 
 class JavaApplicationWithTestsFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
 
@@ -182,4 +184,21 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractGraalVMMavenFunctio
         outputDoesNotContain expectedOutput
     }
 
+    private static int getCurrentJDKVersion() {
+        return NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString())
+    }
+
+    @Requires({ getCurrentJDKVersion() >= 23 })
+    def "can use the Maven plugin with the runtimeArgs config to run tests in a native image"() {
+        withSample("java-application-with-tests")
+
+        when:
+        mvn '-Ptest-runtime-args', '-DquickBuild', 'test'
+
+        def expectedOutput = "Note: this run will print partial stack traces of the locations where a"
+
+        then:
+        buildSucceeded
+        outputContains expectedOutput
+    }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -168,6 +168,9 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     @Parameter(property = "jvmArgs")
     protected List<String> jvmArgs;
 
+    @Parameter(property = "runtimeArgs")
+    protected List<String> runtimeArgs;
+
     @Parameter(property = NATIVE_IMAGE_DRY_RUN, defaultValue = "false")
     protected boolean dryRun;
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -168,6 +168,9 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
         }
         systemProperties.put("junit.platform.listeners.uid.tracking.output.dir",
             NativeExtension.testIdsDirectory(outputDirectory.getAbsolutePath()));
+        if (runtimeArgs == null) {
+            runtimeArgs = new ArrayList<>();
+        }
 
         imageName = NATIVE_TESTS_EXE;
         mainClass = "org.graalvm.junit.platform.NativeImageJUnitLauncher";
@@ -238,6 +241,7 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
             command.add("--xml-output-dir");
             command.add(xmlLocation.toString());
             systemProperties.forEach((key, value) -> command.add("-D" + key + "=" + value));
+            command.addAll(runtimeArgs);
 
             processBuilder.command().addAll(command);
             processBuilder.environment().putAll(environment);

--- a/samples/java-application-with-tests/pom.xml
+++ b/samples/java-application-with-tests/pom.xml
@@ -238,6 +238,41 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>test-runtime-args</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>test-native</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <buildArgs>
+                                <buildArg>--exact-reachability-metadata</buildArg>
+                            </buildArgs>
+                            <runtimeArgs>
+                                <runtimeArg>-XX:MissingRegistrationReportingMode=Warn</runtimeArg>
+                            </runtimeArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
- Fixes #685 .
- Fixes #735 .
- Add `runtimeArgs` support to `native-maven-plugin`.
- Support publishing `native-maven-plugin` to local repository on Windows with Simplified Chinese.
- I have tested this locally with `./gradlew publishToMavenLocal --no-parallel` against https://github.com/linghengqian/jetcd-multi-platform-native-test and `org.graalvm.buildtools:native-maven-plugin:0.11.0-SNAPSHOT`. **This even fixes the bug reported in https://github.com/oracle/graal/issues/11280 where the unit tests never stopped.**
- ![image](https://github.com/user-attachments/assets/0dbc36ed-981e-40b6-9e63-bdec042d5d10)
