### PR TITLE
Remove the default Maven phase bound to the `metadata-copy` Maven goal to simplify the use of integration tests

### DIFF
--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/IntegrationTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/IntegrationTest.groovy
@@ -27,4 +27,18 @@ class IntegrationTest extends AbstractGraalVMMavenFunctionalTest {
 [         0 tests failed          ]
 """.trim()
     }
+
+    def "run integration tests with failsafe plugin and agent"() {
+        withSample("integration-test")
+
+        when:
+        mvn '-Pmetadata-copy', 'verify', 'native:metadata-copy'
+
+        then:
+        buildSucceeded
+        file("target/failsafe-reports").exists()
+        file("target/failsafe-reports/org.graalvm.demo.CalculatorTestIT.txt").readLines().any(line -> line.contains("Tests run: 6, Failures: 0, Errors: 0, Skipped: 0"))
+        outputContains "Copying files from: test"
+        outputContains "Metadata copy process finished."
+    }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
@@ -62,7 +62,7 @@ import java.util.ArrayList;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-@Mojo(name = "metadata-copy", defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
+@Mojo(name = "metadata-copy", defaultPhase = LifecyclePhase.NONE)
 public class MetadataCopyMojo extends AbstractMergeAgentFilesMojo {
 
     private static final String DEFAULT_OUTPUT_DIRECTORY = "/META-INF/native-image";

--- a/samples/integration-test/pom.xml
+++ b/samples/integration-test/pom.xml
@@ -101,6 +101,54 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>metadata-copy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.5.3</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>merge-agent-files-in-integration-test</id>
+                                <goals>
+                                    <goal>merge-agent-files</goal>
+                                </goals>
+                                <phase>integration-test</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skipNativeTests>true</skipNativeTests>
+                            <agent>
+                                <enabled>true</enabled>
+                                <defaultMode>Standard</defaultMode>
+                                <metadataCopy>
+                                    <disabledStages>
+                                        <stage>main</stage>
+                                    </disabledStages>
+                                    <merge>false</merge>
+                                </metadataCopy>
+                            </agent>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
- Fixes #112 .
- Remove the default Maven phase bound to the `metadata-copy` Maven goal to simplify the use of integration tests.
- This discovery was first reported in https://github.com/apache/shardingsphere/pull/36050 and https://github.com/graalvm/native-build-tools/issues/727 . 
- In NBT 0.11.0, even if `metadata-copy` is not explicitly used on the command line, the `metadata-copy` goal will be executed in the `prepare-package` phase, which affects the processing of the `integration-test` phase, resulting in the following cumbersome logic to change the `metadata-copy` goal. Since `metadata-copy` is always used manually through the command line like `./mvnw -Pnative test native:metadata-copy`, `metadata-copy` should not be tied to a specific maven phase at all.
```xml
<profile>
            <id>metadata-copy</id>
            <build>
                <plugins>
                    <plugin>
                        <groupId>org.apache.maven.plugins</groupId>
                        <artifactId>maven-failsafe-plugin</artifactId>
                        <version>3.5.3</version>
                        <executions>
                            <execution>
                                <goals>
                                    <goal>integration-test</goal>
                                    <goal>verify</goal>
                                </goals>
                            </execution>
                        </executions>
                    </plugin>
                    <plugin>
                        <groupId>org.graalvm.buildtools</groupId>
                        <artifactId>native-maven-plugin</artifactId>
                        <version>0.11.0</version>
                        <extensions>true</extensions>
                        <executions>
                            <execution>
                                <id>merge-agent-files-in-integration-test</id>
                                <goals>
                                    <goal>merge-agent-files</goal>
                                </goals>
                                <phase>integration-test</phase>
                            </execution>
                             <execution>
                                    <id>metadata-copy-manually</id>
                                    <goals>
                                        <goal>metadata-copy</goal>
                                    </goals>
                                    <phase>deploy</phase>
                                </execution>
                        </executions>
                        <configuration>
                            <skipNativeTests>true</skipNativeTests>
                            <agent>
                                <enabled>true</enabled>
                                <defaultMode>Standard</defaultMode>
                                <metadataCopy>
                                    <disabledStages>
                                        <stage>main</stage>
                                    </disabledStages>
                                    <merge>false</merge>
                                </metadataCopy>
                            </agent>
                        </configuration>
                    </plugin>
                </plugins>
            </build>
        </profile>
```