### PR TITLE
Group annotations by dependency and print a warning if the dependency is missing

### DIFF
--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java
@@ -87,7 +87,9 @@ public class JupiterConfigProvider extends PluginConfigProvider {
             AnnotationUtils.registerClassesFromAnnotationForReflection(testClass, registry, EnabledIf.class, JupiterConfigProvider::handleEnabledIf);
             AnnotationUtils.registerClassesFromAnnotationForReflection(testClass, registry, DisabledIf.class, JupiterConfigProvider::handleDisabledIf);
         } catch (NoClassDefFoundError e) {
-            AnnotationUtils.printMissingAnnotationsWarning("org.junit.jupiter.api", List.of("TestMethodOrder", "ExtendWith", "DisplayNameGeneration", "IndicativeSentencesGeneration", "EnabledIf", "DisabledIf"));
+            debug("Cannot register annotations %s from 'org.junit.jupiter.api'. " +
+                        "Please verify that you have dependency that includes 'org.junit.jupiter.api' if you want to use these annotations.",
+                        List.of("TestMethodOrder", "ExtendWith", "DisplayNameGeneration", "IndicativeSentencesGeneration", "EnabledIf", "DisabledIf"));
         }
 
         /* Annotations from org.junit.jupiter.params */
@@ -102,11 +104,13 @@ public class JupiterConfigProvider extends PluginConfigProvider {
             try {
                 AnnotationUtils.registerClassesFromAnnotationForReflection(testClass, registry, FieldSource.class, JupiterConfigProvider::handleFieldSource);
             } catch (NoClassDefFoundError e) {
-                System.out.println("[junit-platform-native] Cannot register @FieldSource annotation from org.junit.jupiter.params." +
-                        " Please verify that you have this dependency (with version greater than JUnit 5.13) if you want to use this annotation.");
+                debug("Cannot register @FieldSource annotation from org.junit.jupiter.params. " +
+                        "Please verify that you have this dependency (with version greater than JUnit 5.13) if you want to use this annotation.");
             }
         } catch (NoClassDefFoundError e) {
-            AnnotationUtils.printMissingAnnotationsWarning("org.junit.jupiter.params", List.of("ArgumentsSource", "ConvertWith", "AggregateWith", "EnumSource", "MethodSource", "FieldSource"));
+            debug("Cannot register annotations %s from 'org.junit.jupiter.params'. " +
+                        "Please verify that you have dependency that includes 'org.junit.jupiter.params' if you want to use these annotations.",
+                        List.of("ArgumentsSource", "ConvertWith", "AggregateWith", "EnumSource", "MethodSource", "FieldSource"));
         }
 
     }

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/util/AnnotationUtils.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/util/AnnotationUtils.java
@@ -125,12 +125,4 @@ public class AnnotationUtils {
             config.registerAllClassMembersForReflection(reflectivelyAccessedClass);
         });
     }
-
-    public static void printMissingAnnotationsWarning(String packageName, List<String> annotations) {
-        System.out.printf("[junit-platform-native] Cannot register annotations %s from %s. " +
-                "Please verify that you have dependency that includes %s if you want to use these annotations.",
-                annotations,
-                packageName,
-                packageName);
-    }
 }

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/vintage/VintageConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/vintage/VintageConfigProvider.java
@@ -46,6 +46,8 @@ import org.graalvm.junit.platform.config.core.PluginConfigProvider;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 import org.graalvm.nativeimage.hosted.RuntimeSerialization;
 
+import static org.graalvm.junit.platform.JUnitPlatformFeature.debug;
+
 public class VintageConfigProvider extends PluginConfigProvider {
 
     @Override
@@ -54,7 +56,7 @@ public class VintageConfigProvider extends PluginConfigProvider {
             RuntimeSerialization.register(Class.forName("org.junit.runner.Result").getDeclaredClasses());
             RuntimeReflection.register(Class.forName("org.junit.runner.Description").getDeclaredFields());
         } catch (ClassNotFoundException e) {
-            System.out.println("Cannot register declared classes of org.junit.runner.Result for serialization or fields of org.junit.runner.Description for reflection. Vintage JUnit not available.");
+            debug("Cannot register declared classes of org.junit.runner.Result for serialization or fields of org.junit.runner.Description for reflection. Vintage JUnit not available.");
         }
     }
 


### PR DESCRIPTION
Now that [we are not duplicating JUnit dependencies](https://github.com/graalvm/native-build-tools/pull/712), we could end up in a situation where:

- user didn't provide some dependency (for example `org.junit.jupiter:junit-jupiter-params`)
- [JupiterConfigProvider](https://github.com/graalvm/native-build-tools/blob/master/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java#L80) wants to register annotations (and their parameters) for reflection from that dependency
- we will get `NoClassDefFoundError`

Solution: group annotations by the dependency that introduces them, and print a warning if the dependency is not available. 

Fixes: https://github.com/graalvm/native-build-tools/issues/747