### PR TITLE
Make end-to-end maven guide disable tests instructions as in the main docs

### DIFF
--- a/docs/src/docs/asciidoc/end-to-end-maven-guide.adoc
+++ b/docs/src/docs/asciidoc/end-to-end-maven-guide.adoc
@@ -205,7 +205,7 @@ First, Maven runs the tests on the JVM, then compiles them ahead of time and exe
 
 ==== Disable tests
 
-If you wish to disable tests on the JVM as well as running native code tests, invoke Maven with the `-DskipTests` flag. 
+If you wish to disable running tests on the JVM as well as tests as native code, you can invoke Maven with the -DskipTests flag.
 This flag is supported by the Maven Surefire plugin and Native Build Tools. 
 
 [source,bash, role="multi-language-sample"]


### PR DESCRIPTION
Current explanation for disabling tests is not accurate in end-to-end maven guide. It should be the same as we describe it in the main docs: https://github.com/graalvm/native-build-tools/blob/master/docs/src/docs/asciidoc/maven-plugin.adoc?plain=1#L677 