### PR TITLE
Run native tests without running tests on JVM first

### DIFF
--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/SharedConstants.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/SharedConstants.java
@@ -78,6 +78,7 @@ public interface SharedConstants {
     String AGENT_OUTPUT_DIRECTORY_MARKER = "{output_dir}";
     String AGENT_OUTPUT_DIRECTORY_OPTION = "config-output-dir=";
     String METADATA_REPO_URL_TEMPLATE = "https://github.com/oracle/graalvm-reachability-metadata/releases/download/%1$s/graalvm-reachability-metadata-%1$s.zip";
+    String SKIP_JVM_TESTS = "skipJVMTests";
     /**
      * The default metadata repository version. Maintained for backwards
      * compatibility.

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JUnitFunctionalTests.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JUnitFunctionalTests.groovy
@@ -73,4 +73,40 @@ class JUnitFunctionalTests extends AbstractFunctionalTest {
 [         0 tests failed          ]
 """.trim()
     }
+
+    def "test if JUnit support works when JVM tests are skipped"() {
+        debug=true
+        given:
+        withSample("junit-tests")
+
+        when:
+        run 'nativeTest', '-DskipJVMTests', '--info'
+
+        then:
+        tasks {
+            succeeded ':testClasses', ':nativeTestCompile', ':nativeTest'
+        }
+        outputContains "VintageTests > testEvery SKIPPED"
+        outputContains "ComplexTest > accessMethodReflectively() SKIPPED"
+        outputContains "ComplexTest > resourceTest() SKIPPED"
+        outputContains "JUnitAnnotationsTests > beforeAndAfterEachTest1() SKIPPED"
+        outputContains "OrderTests > firstTest() SKIPPED"
+        outputDoesNotContain "[junit-platform-native] WARNING: Trying to find test-ids on default locations"
+        outputContains "Running in 'test listener' mode using files matching pattern [junit-platform-unique-ids*] found in folder ["
+        outputContains """
+[        10 containers found      ]
+[         0 containers skipped    ]
+[        10 containers started    ]
+[         0 containers aborted    ]
+[        10 containers successful ]
+[         0 containers failed     ]
+[        24 tests found           ]
+[         1 tests skipped         ]
+[        23 tests started         ]
+[         0 tests aborted         ]
+[        23 tests successful      ]
+[         0 tests failed          ]
+""".trim()
+    }
+
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
@@ -144,6 +144,59 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         junitVersion = System.getProperty('versions.junit')
     }
 
+    def "can execute tests with -DskipJVMTests in a native image directly"() {
+        given:
+        withSample("java-application-with-tests")
+
+        when:
+        run 'nativeTest', '-DskipJVMTests', '--info'
+
+        then:
+        tasks {
+            succeeded ':testClasses',
+                    ':nativeTestCompile',
+                    ':test',
+                    ':nativeTest'
+            doesNotContain ':build'
+        }
+
+        then:
+        outputDoesNotContain "Running in 'test discovery' mode. Note that this is a fallback mode."
+        outputContains "Running in 'test listener' mode using files matching pattern [junit-platform-unique-ids*] found in folder ["
+        outputContains "CalculatorTest > 1 + 1 = 2 SKIPPED"
+        outputContains "CalculatorTest > 1 + 2 = 3 SKIPPED"
+
+        outputContains """
+[         3 containers found      ]
+[         0 containers skipped    ]
+[         3 containers started    ]
+[         0 containers aborted    ]
+[         3 containers successful ]
+[         0 containers failed     ]
+[         6 tests found           ]
+[         0 tests skipped         ]
+[         6 tests started         ]
+[         0 tests aborted         ]
+[         6 tests successful      ]
+[         0 tests failed          ]
+""".trim()
+
+        and:
+        def results = TestResults.from(file("build/test-results/test/TEST-org.graalvm.demo.CalculatorTest.xml"))
+        def nativeResults = TestResults.from(file("build/test-results/test-native/TEST-junit-jupiter.xml"))
+
+        results == nativeResults
+        results.with {
+            tests == 6
+            failures == 0
+            skipped == 0
+            errors == 0
+        }
+
+        where:
+        junitVersion = System.getProperty('versions.junit')
+    }
+
     @Issue("https://github.com/graalvm/native-build-tools/issues/215")
     @Unroll("can pass environment variables to native test execution with JUnit Platform #junitVersion")
     def "can pass environment variables to native test execution"() {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -184,6 +184,7 @@ public class NativeImagePlugin implements Plugin<Project> {
 
     private static final String NATIVE_CONFIGURATION_SERVICE_NAME = "nativeConfigurationService";
     private static final String JUNIT_PLATFORM_LISTENERS_UID_TRACKING_ENABLED = "junit.platform.listeners.uid.tracking.enabled";
+    private static final String JUNIT_PLATFORM_DRY_RUN_ENABLED = "junit.platform.execution.dryRun.enabled";
     private static final String JUNIT_PLATFORM_LISTENERS_UID_TRACKING_OUTPUT_DIR = "junit.platform.listeners.uid.tracking.output.dir";
     private static final String JUNIT_PLATFORM_UNIQUE_IDS_RESOURCE_PATTERN = "junit-platform-unique-ids.*";
     private static final String REPOSITORY_COORDINATES = "org.graalvm.buildtools:graalvm-reachability-metadata:" + VersionInfo.NBT_VERSION + ":repository@zip";
@@ -902,6 +903,16 @@ public class NativeImagePlugin implements Plugin<Project> {
             test.getOutputs().dir(testList);
             // Set system property read by the UniqueIdTrackingListener.
             test.systemProperty(JUNIT_PLATFORM_LISTENERS_UID_TRACKING_ENABLED, true);
+
+            // Set system property to skip execution of JVM tests before native tests
+            if (shouldSkipJVMTests()) {
+                if (graalExtension.getAgent().getEnabled().get()) {
+                    throw new IllegalStateException("Native Image Agent and skipJVMTests cannot be used at the same time.");
+                }
+
+                test.systemProperty(JUNIT_PLATFORM_DRY_RUN_ENABLED, true);
+            }
+
             TrackingDirectorySystemPropertyProvider directoryProvider = project.getObjects().newInstance(TrackingDirectorySystemPropertyProvider.class);
             directoryProvider.getDirectory().set(testListDirectory);
             test.getJvmArgumentProviders().add(directoryProvider);
@@ -936,6 +947,11 @@ public class NativeImagePlugin implements Plugin<Project> {
             task.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
             task.setOnlyIf(t -> graalExtension.getTestSupport().get() && testListDirectory.getAsFile().get().exists());
         });
+    }
+
+    private boolean shouldSkipJVMTests() {
+        String option = System.getProperty(SharedConstants.SKIP_JVM_TESTS);
+        return (option != null && option.isEmpty()) || Boolean.parseBoolean(option);
     }
 
     /**

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JUnitFunctionalTests.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JUnitFunctionalTests.groovy
@@ -67,4 +67,34 @@ class JUnitFunctionalTests extends AbstractGraalVMMavenFunctionalTest {
 [         0 tests failed          ]
 """.trim()
     }
+
+    def "test if JUint support works when JVM tests are skipped"() {
+        withSample("junit-tests")
+
+        when:
+        mvn '-DquickBuild', '-DskipJVMTests', '-Pnative', 'test'
+
+        then:
+        buildSucceeded
+        outputDoesNotContain "[junit-platform-native] WARNING: Trying to find test-ids on default locations"
+        outputContains "[junit-platform-native] Running in 'test listener' mode"
+        outputContainsPattern "Tests run: 4, Failures: 0, Errors: 0, Skipped: 4, .* - in tests.ComplexTest"
+        outputContainsPattern "Tests run: 3, Failures: 0, Errors: 0, Skipped: 3, .* - in tests.OrderTests"
+        outputContainsPattern "Tests run: 14, Failures: 0, Errors: 0, Skipped: 14, .* - in tests.JUnitAnnotationsTests"
+        outputContainsPattern "Tests run: 3, Failures: 0, Errors: 0, Skipped: 3, .* - in tests.VintageTests"
+        outputContains """
+[        10 containers found      ]
+[         0 containers skipped    ]
+[        10 containers started    ]
+[         0 containers aborted    ]
+[        10 containers successful ]
+[         0 containers failed     ]
+[        24 tests found           ]
+[         1 tests skipped         ]
+[        23 tests started         ]
+[         0 tests aborted         ]
+[        23 tests successful      ]
+[         0 tests failed          ]
+""".trim()
+    }
 }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithTestsFunctionalTest.groovy
@@ -75,6 +75,34 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractGraalVMMavenFunctio
 """.trim()
     }
 
+
+    def "can run tests in a native image with the Maven plugin without running JVM tests first"() {
+        withSample("java-application-with-tests")
+
+        when:
+        mvn '-Pnative', '-DskipJVMTests', '-DquickBuild', 'test'
+
+        then:
+        buildSucceeded
+        outputContains "[junit-platform-native] Running in 'test listener' mode"
+        outputContainsPattern "Tests run: 6, Failures: 0, Errors: 0, Skipped: 6, .* - in org.graalvm.demo.CalculatorTest"
+        outputContains """
+[         3 containers found      ]
+[         0 containers skipped    ]
+[         3 containers started    ]
+[         0 containers aborted    ]
+[         3 containers successful ]
+[         0 containers failed     ]
+[         6 tests found           ]
+[         0 tests skipped         ]
+[         6 tests started         ]
+[         0 tests aborted         ]
+[         6 tests successful      ]
+[         0 tests failed          ]
+""".trim()
+    }
+
+
     def "can run tests in a native image with the Maven plugin using shading"() {
         withSample("java-application-with-tests")
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MergeAgentFilesMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MergeAgentFilesMojo.java
@@ -116,7 +116,7 @@ public class MergeAgentFilesMojo extends AbstractMergeAgentFilesMojo {
         File baseDir = new File(agentOutputDirectory);
         if (baseDir.exists()) {
             List<File> sessionDirectories = sessionDirectoriesFrom(baseDir.listFiles()).collect(Collectors.toList());
-            if (sessionDirectories.size() == 0) {
+            if (sessionDirectories.isEmpty()) {
                 sessionDirectories = Collections.singletonList(baseDir);
             }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
@@ -76,6 +76,7 @@ import static org.graalvm.buildtools.utils.NativeImageConfigurationUtils.getNati
 public class NativeExtension extends AbstractMavenLifecycleParticipant implements LogEnabled {
 
     private static final String JUNIT_PLATFORM_LISTENERS_UID_TRACKING_ENABLED = "junit.platform.listeners.uid.tracking.enabled";
+    private static final String JUNIT_PLATFORM_DRY_RUN_ENABLED = "junit.platform.execution.dryRun.enabled";
     private static final String JUNIT_PLATFORM_LISTENERS_UID_TRACKING_OUTPUT_DIR = "junit.platform.listeners.uid.tracking.output.dir";
     private static final String NATIVEIMAGE_IMAGECODE = "org.graalvm.nativeimage.imagecode";
     private static final String SYSTEM_PROPERTY_VARIABLES = "systemPropertyVariables";
@@ -153,11 +154,16 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                 }
                 Set<Context> instrumentedContexts = EnumSet.noneOf(Context.class);
 
+                boolean skipJVMTests = shouldSkipJVMTests(session);
+                if (skipJVMTests && agent.isEnabled()) {
+                    throw new IllegalStateException("Native Image Agent and skipJVMTests cannot be used at the same time.");
+                }
+
                 // Test configuration
                 List<String> plugins = List.of("maven-surefire-plugin", "maven-failsafe-plugin");
                 for (String pluginName : plugins) {
                     withPlugin(build, pluginName, plugin -> {
-                        configureJunitListener(plugin, testIdsDir);
+                        configureJunitListener(plugin, testIdsDir, skipJVMTests);
                         if (agent.isEnabled()) {
                             List<String> agentOptions = agent.getAgentCommandLine();
                             if (configureAgentForPlugin(plugin, buildAgentArgument(target, Context.test, agentOptions))) {
@@ -223,6 +229,11 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
         return DEFAULT_AGENT_EXECUTION_ID;
     }
 
+    private static boolean shouldSkipJVMTests(MavenSession session) {
+        String option = session.getSystemProperties().getProperty(SharedConstants.SKIP_JVM_TESTS);
+        return (option != null && option.isEmpty()) || Boolean.parseBoolean(option);
+    }
+
     private static void setupMergeAgentFiles(PluginExecution exec, Xpp3Dom configuration, Context context) {
         List<String> goals = new ArrayList<>();
         goals.add("merge-agent-files");
@@ -265,12 +276,17 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
         logger.info("Instrumenting Maven " + execution + " execution with the native-image-agent. Agent output: " + outputDirectory);
     }
 
-    private static void configureJunitListener(Plugin surefirePlugin, String testIdsDir) {
+    private static void configureJunitListener(Plugin surefirePlugin, String testIdsDir, boolean skipJVMTests) {
         updatePluginConfiguration(surefirePlugin, (exec, configuration) -> {
             Xpp3Dom systemPropertyVariables = findOrAppend(configuration, SYSTEM_PROPERTY_VARIABLES);
             Xpp3Dom junitTracking = findOrAppend(systemPropertyVariables, JUNIT_PLATFORM_LISTENERS_UID_TRACKING_ENABLED);
             Xpp3Dom testIdsProperty = findOrAppend(systemPropertyVariables, JUNIT_PLATFORM_LISTENERS_UID_TRACKING_OUTPUT_DIR);
             junitTracking.setValue("true");
+
+            if (skipJVMTests) {
+                Xpp3Dom junitDryRun = findOrAppend(systemPropertyVariables, JUNIT_PLATFORM_DRY_RUN_ENABLED);
+                junitDryRun.setValue("true");
+            }
             testIdsProperty.setValue(testIdsDir);
         });
     }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/Utils.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/Utils.java
@@ -40,17 +40,22 @@
  */
 package org.graalvm.buildtools.utils;
 
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
 public abstract class Utils {
-    public static boolean parseBoolean(String description, String value) {
-        value = assertNotEmptyAndTrim(value, description + " must have a value").toLowerCase();
-        switch (value) {
-            case "true":
-                return true;
-            case "false":
-                return false;
-            default:
-                throw new IllegalStateException(description + " must have a value of 'true' or 'false'");
+
+    public static Boolean parseBooleanNode(Xpp3Dom root, String name) {
+        if (root == null) {
+            return null;
         }
+
+        Xpp3Dom node = Xpp3DomParser.getTagByName(root, name);
+        if (node == null) {
+            // if node is not provided, default value is false
+            return null;
+        }
+
+        return Boolean.parseBoolean(node.getValue());
     }
 
     public static String assertNotEmptyAndTrim(String input, String message) {


### PR DESCRIPTION
Problem: At the moment, every time we run native tests (with both Maven or Gradle), we must run tests on JVM first, in order to collect `test-ids` required for native run. With more complex tests, this additional step increases time required for tests execution.

Idea: We should use JUnit's [dry-run mode](https://docs.junit.org/current/user-guide/#launcher-api-dry-run-mode) to just collect `test-ids` without executing tests on JVM.

Solution: we can set `junit.platform.execution.dryRun.enabled` system property to true when executing tests on JVM ([maven change](https://github.com/graalvm/native-build-tools/pull/765/files#diff-1eff98b60d5a4c9aad6024aa570fc33d1241d14f9d01bac8c26c052ea38512f5R228), [gradle change](https://github.com/graalvm/native-build-tools/pull/765/files#diff-3ca19e7e49fe64feca3a1e88279c961b56e03450666583025c711da44cfb73bbR683)).

NOTE: Since this approach changes the default behavior, we should bump major version for the next release.