### PR TITLE
Add testing of Gradle 9

### DIFF
--- a/build-logic/common-plugins/src/main/groovy/org.graalvm.build.github-actions-helper.gradle
+++ b/build-logic/common-plugins/src/main/groovy/org.graalvm.build.github-actions-helper.gradle
@@ -7,11 +7,11 @@ def matrixDefault = [
 
 // # Following versions are disabled temporarily in order to speed up PR testing  "7.3.3", "7.2", "7.1", "6.8.3",
 def gradleVersions = [
-        "gradle-version": ["current", "8.4", "8.14.2"],
+        "gradle-version": ["current", "8.4", "8.14.2", "9.0.0"],
 ]
 
 def gradleCachedVersions = [
-        "gradle-config-cache-version": ["current", "8.14.2"]
+        "gradle-config-cache-version": ["current", "9.0.0"]
 ]
 
 sourceSets.configureEach { sourceSet ->

--- a/build-logic/gradle-functional-testing/src/main/groovy/org.graalvm.build.functional-testing.gradle
+++ b/build-logic/gradle-functional-testing/src/main/groovy/org.graalvm.build.functional-testing.gradle
@@ -83,8 +83,8 @@ def graalVm = javaToolchains.launcherFor {
 
 def fullFunctionalTest = tasks.register("fullFunctionalTest")
 
-['functionalTest': ["current", "8.4", "8.14.2"],
- 'configCacheFunctionalTest': ['current', "8.14.2"]
+['functionalTest': ["current", "8.4", "8.14.2", "9.0.0"],
+ 'configCacheFunctionalTest': ['current', "9.0.0"]
 ].each { baseName, gradleVersions ->
     gradleVersions.each { gradleVersion ->
         String taskName = gradleVersion == 'current' ? baseName : "gradle${gradleVersion}${baseName.capitalize()}"

--- a/common/junit-platform-native/src/main/resources/initialize-at-buildtime
+++ b/common/junit-platform-native/src/main/resources/initialize-at-buildtime
@@ -123,3 +123,5 @@ org.junit.vintage.engine.JUnit4VersionCheck
 org.junit.vintage.engine.support.UniqueIdReader
 org.junit.vintage.engine.support.UniqueIdStringifier
 org.junit.vintage.engine.VintageTestEngine
+kotlin.annotation.AnnotationTarget
+kotlin.annotation.AnnotationRetention

--- a/samples/kotlin-application-with-tests/build.gradle
+++ b/samples/kotlin-application-with-tests/build.gradle
@@ -40,7 +40,7 @@
  */
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.7.22'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.25'
     id 'application'
     id 'org.graalvm.buildtools.native'
 }


### PR DESCRIPTION
While investigating #760 , I added testing of Gradle 9 to our build. This caused a few cascading issues:

1. we have to upgrade the Kotlin plugin version we use in tests to the latest 1.9.x branch
2. doing so breaks the `KotlinApplicationWithTestsFunctionalTest` with a class initialized at build time error

This error only happens when testing with GraalVM 17, not with 23. The workaround I have found is to add:

```
kotlin.annotation.AnnotationTarget
kotlin.annotation.AnnotationRetention
```

to the list of classes initialized at build time, but I'm not completely sure this is the right thing to do. /cc @sbrannen @marcphilipp 

In any case it seems that the original issue doesn't occur outside of the context of Spring.