### PR TITLE
Fix relativlization bug

### DIFF
--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
@@ -101,7 +101,11 @@ public class NativeImageUtils {
 
             Path resultingPath = tmpFile.toPath().toAbsolutePath();
             if (projectDir != null) { // We know where the project dir is, so want to use relative paths
-                resultingPath = projectDir.toAbsolutePath().relativize(resultingPath);
+                Path absProjectDir = projectDir.toAbsolutePath();
+                // Only relativize if both paths are on the same file system (same drive on Windows)
+                if (resultingPath.getRoot() != null && resultingPath.getRoot().equals(absProjectDir.getRoot())) {
+                    resultingPath = absProjectDir.relativize(resultingPath);
+                }
             }
             return Collections.singletonList("@" + resultingPath);
         } catch (IOException e) {

--- a/docs/src/docs/asciidoc/changelog.adoc
+++ b/docs/src/docs/asciidoc/changelog.adoc
@@ -1,6 +1,14 @@
 [[changelog]]
 == Changelog
 
+== Release 0.11.3
+
+- Fixed use of argument file when the temporary directory is not on the same drive as the project
+
+== Release 0.11.2
+
+- Fixed missing JUnit types in build time initialization
+
 == Release 0.11.1
 
 - Fix `NoClassDefFoundError` when JUnit feature is missing some dependency


### PR DESCRIPTION
If the temporary directory and the working directory are not on the same drive, relativization will fail. This commit uses an absolute path in case relativization is not possible.

Fixes #777