### PR TITLE
Add class introduced in 5.14.1/6.0.1

### DIFF
--- a/common/junit-platform-native/src/main/resources/initialize-at-buildtime
+++ b/common/junit-platform-native/src/main/resources/initialize-at-buildtime
@@ -41,6 +41,7 @@ org.junit.jupiter.engine.discovery.ClassSelectorResolver
 org.junit.jupiter.engine.discovery.ClassSelectorResolver$DummyClassTemplateInvocationContext
 org.junit.jupiter.engine.discovery.DiscoverySelectorResolver
 org.junit.jupiter.engine.discovery.MethodFinder
+org.junit.jupiter.engine.discovery.MethodSegmentResolver
 org.junit.jupiter.engine.discovery.MethodSelectorResolver
 org.junit.jupiter.engine.discovery.MethodSelectorResolver$MethodType
 org.junit.jupiter.engine.discovery.MethodSelectorResolver$MethodType$1


### PR DESCRIPTION
`MethodSegmentResolver` is used during discovery and therefore also needs to be initialized at build time on JDK <= 21.