### PR TITLE
Make environment variables set in the pom.xml of the native-maven-plugin be visible in the image builder

### DIFF
--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -156,10 +156,10 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     @Parameter(property = "excludeConfig")
     protected List<ExcludeConfigConfiguration> excludeConfig;
 
-    @Parameter(property = "environmentVariables")
+    @Parameter(alias = "environmentVariables", property = "environmentVariables")
     protected Map<String, String> environment;
 
-    @Parameter(property = "systemPropertyVariables")
+    @Parameter(alias = "systemPropertyVariables", property = "systemPropertyVariables")
     protected Map<String, String> systemProperties;
 
     @Parameter(property = "configurationFileDirectories")
@@ -240,6 +240,12 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
         if (systemProperties != null) {
             for (Map.Entry<String, String> entry : systemProperties.entrySet()) {
                 cliArgs.add("-D" + entry.getKey() + "=" + entry.getValue());
+            }
+        }
+
+        if (environment != null) {
+            for (Map.Entry<String, String> entry : environment.entrySet()) {
+                cliArgs.add("-E" + entry.getKey() + "=" + entry.getValue());
             }
         }
 


### PR DESCRIPTION
In this PR, we make environment variables set in the `pom.xml` `<environmentVariables>` tag visible to the native image static analysis by providing them to the `native-image` builder using the `-E<variable>=<value>` flag (consistent with how `systemProperties` are currently handled).

Also in this PR, to avoid documentation mismatches and breaking older builds, we add aliases for both `environmentVariables` and `systemPropertyVariables` properties. 

Current documentation and samples frequently use these names even though the plugin only recognized the field names `environment` and `systemProperties`. By using aliases, we ensure:

* **Consistency**: The naming now matches the `maven-surefire-plugin` and `maven-failsafe-plugin` conventions.
* **Backwards Compatibility**: Existing builds using the `<environment>` and `<systemProperties>` tags will continue to work without modification.

Alternatively we could just rename the fields to `environmentVariables` and `systemPropertyVariables` (and avoid aliases), but that could potentially break older builds that used the old tag names.

Fixes: https://github.com/graalvm/native-build-tools/issues/818