### PR TITLE
Add fallback for jarless artifacts in the native-maven-plugin

### DIFF
--- a/native-maven-plugin/reproducers/issue-727/main-module/pom.xml
+++ b/native-maven-plugin/reproducers/issue-727/main-module/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    The Universal Permissive License (UPL), Version 1.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.graalvm.buildtools.examples</groupId>
+        <artifactId>issue-727</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>main-module</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.buildtools.examples</groupId>
+            <artifactId>module-without-source</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>test-native</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>compile-no-fork</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skip>false</skip>
+                            <fallback>false</fallback>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/native-maven-plugin/reproducers/issue-727/main-module/src/test/java/org/graalvm/buildtools/examples/SimpleTest.java
+++ b/native-maven-plugin/reproducers/issue-727/main-module/src/test/java/org/graalvm/buildtools/examples/SimpleTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ */
+package org.graalvm.buildtools.examples;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SimpleTest {
+    @Test
+    void succeeds() {
+        assertTrue(true);
+    }
+}

--- a/native-maven-plugin/reproducers/issue-727/module-without-source/pom.xml
+++ b/native-maven-plugin/reproducers/issue-727/module-without-source/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    The Universal Permissive License (UPL), Version 1.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.graalvm.buildtools.examples</groupId>
+        <artifactId>issue-727</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-without-source</artifactId>
+    <packaging>jar</packaging>
+</project>

--- a/native-maven-plugin/reproducers/issue-727/pom.xml
+++ b/native-maven-plugin/reproducers/issue-727/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    The Universal Permissive License (UPL), Version 1.0
+
+    Subject to the condition set forth below, permission is hereby granted to any
+    person obtaining a copy of this software, associated documentation and/or
+    data (collectively the "Software"), free of charge and under any and all
+    copyright rights in the Software, and any and all patent rights owned or
+    freely licensable by each licensor hereunder covering either (i) the
+    unmodified Software as contributed to or provided by such licensor, or (ii)
+    the Larger Works (as defined below), to deal in both
+
+    (a) the Software, and
+
+    (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+    one is included with the Software each a "Larger Work" to which the Software
+    is contributed by such licensors),
+
+    without restriction, including without limitation the rights to copy, create
+    derivative works of, display, perform, and distribute the Software and make,
+    use, sell, offer for sale, import, export, have made, and have sold the
+    Software and the Larger Work(s), and to sublicense the foregoing rights on
+    either these or other terms.
+
+    This license is subject to the following condition:
+
+    The above copyright notice and either this complete permission notice or at a
+    minimum a reference to the UPL must be included in all copies or substantial
+    portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.graalvm.buildtools.examples</groupId>
+    <artifactId>issue-727</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>module-without-source</module>
+        <module>main-module</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+        <junit.jupiter.version>5.13.0</junit.jupiter.version>
+        <native.maven.plugin.version>0.11.4-SNAPSHOT</native.maven.plugin.version>
+        <junit.platform.native.version>0.11.4-SNAPSHOT</junit.platform.native.version>
+    </properties>
+</project>

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/issues/ModuleWithoutSourcesFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/issues/ModuleWithoutSourcesFunctionalTest.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.maven.issues
+
+import org.graalvm.buildtools.maven.AbstractGraalVMMavenFunctionalTest
+import spock.lang.Issue
+
+class ModuleWithoutSourcesFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
+    @Issue("https://github.com/graalvm/native-build-tools/issues/727")
+    def "native tests handle reactor modules without sources or packaged jars"() {
+        withReproducer("issue-727")
+
+        when:
+        mvn '-DquickBuild', '-Pnative', 'test'
+
+        then:
+        buildSucceeded
+        outputContains """
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         1 tests successful      ]
+[         0 tests failed          ]
+""".trim()
+    }
+}

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -376,10 +376,12 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
             }
         });
         var currentClasspath = current.getArtifactResults().stream()
-            .map(result -> new JUnitPlatformNativeDependenciesHelper.DependencyNotation(
-                result.getArtifact().getGroupId(),
-                result.getArtifact().getArtifactId(),
-                result.getArtifact().getVersion()
+            .map(ArtifactResult::getArtifact)
+            .filter(Objects::nonNull)
+            .map(artifact -> new JUnitPlatformNativeDependenciesHelper.DependencyNotation(
+                artifact.getGroupId(),
+                artifact.getArtifactId(),
+                artifact.getVersion()
             )).toList();
         var deps = JUnitPlatformNativeDependenciesHelper.inferMissingDependenciesForTestRuntime(currentClasspath);
         for (var missing : deps) {


### PR DESCRIPTION
In this PR, we introduce a fallback for artifacts that only have a `pom.xml` file, without a `jar` file present. Multi-module projects often include "hollow" or "aggregator" modules. If these lack a physical JAR, `AbstractNativeImageMojo.processArtifact()` would throw an exception if the chosen maven phase was before the `package` phase. To mitigate this, we add a fallback that resolves the module's `target/classes` directory directly from the Maven Reactor.

This PR is based on a copilot-generated PR authored by @linghengqian (https://github.com/linghengqian/native-build-tools/pull/1), with minor cleanup and test changes.

Fixes: https://github.com/graalvm/native-build-tools/issues/727