### PR TITLE
Fix JUnit 6 not working correctly with JDK 21 by expanding the initialize-at-build-time-list

### DIFF
--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/JUnitPlatformFeature.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/JUnitPlatformFeature.java
@@ -224,7 +224,7 @@ public final class JUnitPlatformFeature implements Feature {
                 }
             }
         } catch (IOException e) {
-            throw new RuntimeException("Failed to process build time initializations");
+            throw new RuntimeException("Failed to process build time initializations for JDK 21 or earlier");
         }
     }
 


### PR DESCRIPTION
In this PR we fix the issue of certain JUnit tests that run with JUnit 6 failing due to missing `--initialize-at-build-time` argument, when running the tests with `--strict-image-heap`.

Fixes: https://github.com/graalvm/native-build-tools/issues/831