### PR TITLE
Prefer GraalVM's Java when running with agent

### DIFF
--- a/native-gradle-plugin/docs/functional/tracing-agent.md
+++ b/native-gradle-plugin/docs/functional/tracing-agent.md
@@ -16,6 +16,14 @@ Every task that implements `JavaForkOptions` is eligible for instrumentation. Th
 `tasksToInstrumentPredicate` setting may narrow that set. Non-matching tasks must be skipped
 without failing the build.
 
+### 2.1 Agent Java runtime
+
+When agent instrumentation is enabled, the task must prefer the Java executable from a valid
+`GRAALVM_HOME`. If that is unavailable, the task may use `JAVA_HOME` only when the installation
+identifies itself as GraalVM. A regular JDK in `JAVA_HOME` must not replace the task's configured
+launcher or executable. When instrumentation is disabled, the plugin must leave the task's Java
+runtime selection unchanged.
+
 ## 3. Agent modes
 
 The Gradle DSL must expose standard, conditional, direct, and disabled agent modes using the

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -212,8 +212,9 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         withSample("java-application-with-reflection")
         buildFile << """
             tasks.named('run') {
+                def javaExecutableName = System.getProperty('os.name').contains('Windows') ? 'java.exe' : 'java'
+                executable = new File(new File(System.getProperty('java.home'), 'bin'), javaExecutableName).absolutePath
                 doLast {
-                    def javaExecutableName = System.getProperty('os.name').contains('Windows') ? 'java.exe' : 'java'
                     def expectedExecutable = new File(new File(System.getenv('GRAALVM_HOME'), 'bin'), javaExecutableName).absolutePath
                     def actualExecutable = executable ?: javaLauncher.get().executablePath.asFile.absolutePath
                     assert actualExecutable == expectedExecutable
@@ -228,6 +229,38 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         tasks {
             succeeded ':run'
             doesNotContain ':jar'
+        }
+
+        where:
+        junitVersion = System.getProperty('versions.junit')
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/581")
+    @Requires({
+        System.getenv("GRAALVM_HOME") != null
+    })
+    @Unroll("agent keeps explicit test executable in sync with GraalVM java executable for JUnit Platform #junitVersion")
+    def "agent keeps explicit test executable in sync with GraalVM java executable"() {
+        given:
+        withSample("java-application-with-reflection")
+        buildFile << """
+            tasks.named('test') {
+                def javaExecutableName = System.getProperty('os.name').contains('Windows') ? 'java.exe' : 'java'
+                executable = new File(new File(System.getProperty('java.home'), 'bin'), javaExecutableName).absolutePath
+                doLast {
+                    def expectedExecutable = new File(new File(System.getenv('GRAALVM_HOME'), 'bin'), javaExecutableName).absolutePath
+                    assert executable == expectedExecutable
+                    assert javaLauncher.get().executablePath.asFile.absolutePath == expectedExecutable
+                }
+            }
+        """.stripIndent()
+
+        when:
+        run 'test', '-Pagent=standard'
+
+        then:
+        tasks {
+            succeeded ':test'
         }
 
         where:

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -44,6 +44,8 @@ package org.graalvm.buildtools.gradle
 import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 import org.graalvm.buildtools.gradle.fixtures.GraalVMSupport
 import org.graalvm.buildtools.utils.NativeImageUtils
+import spock.lang.Issue
+import spock.lang.Requires
 import spock.lang.Unroll
 
 class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
@@ -195,6 +197,38 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
 
         then:
         outputContains "Application message: Hello, native!"
+
+        where:
+        junitVersion = System.getProperty('versions.junit')
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/581")
+    @Requires({
+        System.getenv("GRAALVM_HOME") != null
+    })
+    @Unroll("agent uses GraalVM's Java executable for run task with JUnit Platform #junitVersion")
+    def "agent uses GraalVM java executable"() {
+        given:
+        withSample("java-application-with-reflection")
+        buildFile << """
+            tasks.named('run') {
+                doLast {
+                    def javaExecutableName = System.getProperty('os.name').contains('Windows') ? 'java.exe' : 'java'
+                    def expectedExecutable = new File(new File(System.getenv('GRAALVM_HOME'), 'bin'), javaExecutableName).absolutePath
+                    def actualExecutable = executable ?: javaLauncher.get().executablePath.asFile.absolutePath
+                    assert actualExecutable == expectedExecutable
+                }
+            }
+        """.stripIndent()
+
+        when:
+        run 'run', '-Pagent=standard'
+
+        then:
+        tasks {
+            succeeded ':run'
+            doesNotContain ':jar'
+        }
 
         where:
         junitVersion = System.getProperty('versions.junit')

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -234,6 +234,66 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         junitVersion = System.getProperty('versions.junit')
     }
 
+    @Issue("https://github.com/graalvm/native-build-tools/issues/581")
+    @Requires({
+        System.getenv("GRAALVM_HOME") != null && !System.getProperty("os.name", "unknown").contains("Windows")
+    })
+    @Unroll("agent does not replace configured launcher with regular JAVA_HOME for JUnit Platform #junitVersion")
+    def "agent does not replace configured launcher with regular JAVA_HOME"() {
+        given:
+        withSample("java-application-with-reflection")
+        def graalvmHome = System.getenv("GRAALVM_HOME")
+        def fakeJavaHome = file("fake-java-home")
+        def fakeJava = new File(fakeJavaHome, "bin/java")
+        fakeJava.parentFile.mkdirs()
+        fakeJava.text = """#!/bin/sh
+exec "${System.getProperty('java.home')}/bin/java" "\$@"
+"""
+        fakeJava.setExecutable(true)
+        new File(fakeJavaHome, "release").text = """JAVA_VERSION="${System.getProperty('java.version')}"
+IMPLEMENTOR="Regular JDK"
+"""
+        withEnvironmentOverrides([
+                "GRAALVM_HOME": null,
+                "JAVA_HOME": fakeJavaHome.absolutePath,
+                "GRADLE_OPTS": null
+        ])
+        file("gradle.properties") << """
+org.gradle.java.installations.paths=${graalvmHome}
+org.gradle.java.installations.auto-detect=false
+org.gradle.java.installations.auto-download=false
+""".stripIndent()
+        buildFile << """
+            tasks.named('run') {
+                javaLauncher.set(javaToolchains.launcherFor {
+                    languageVersion.set(JavaLanguageVersion.of(${getCurrentJDKVersion()}))
+                })
+            }
+
+            tasks.register('verifyRunLauncher') {
+                doLast {
+                    def actualExecutable = tasks.named('run').get().javaLauncher.get().executablePath.asFile.canonicalFile
+                    def expectedExecutable = new File('${graalvmHome}', 'bin/java').canonicalFile
+                    def javaHomeExecutable = new File(new File(System.getenv('JAVA_HOME')), 'bin/java').canonicalFile
+                    assert actualExecutable == expectedExecutable
+                    assert actualExecutable != javaHomeExecutable
+                }
+            }
+        """.stripIndent()
+
+        when:
+        run 'verifyRunLauncher', '-Pagent=standard'
+
+        then:
+        tasks {
+            succeeded ':verifyRunLauncher'
+            doesNotContain ':run'
+        }
+
+        where:
+        junitVersion = System.getProperty('versions.junit')
+    }
+
     @Unroll("plugin supports configuration cache (JUnit Platform #junitVersion)")
     def "supports configuration cache"() {
         given:

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -239,8 +239,8 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
     @Requires({
         System.getenv("GRAALVM_HOME") != null
     })
-    @Unroll("agent keeps explicit test executable in sync with GraalVM java executable for JUnit Platform #junitVersion")
-    def "agent keeps explicit test executable in sync with GraalVM java executable"() {
+    @Unroll("agent replaces explicit test executable with GraalVM java launcher for JUnit Platform #junitVersion")
+    def "agent replaces explicit test executable with GraalVM java launcher"() {
         given:
         withSample("java-application-with-reflection")
         buildFile << """
@@ -249,7 +249,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
                 executable = new File(new File(System.getProperty('java.home'), 'bin'), javaExecutableName).absolutePath
                 doLast {
                     def expectedExecutable = new File(new File(System.getenv('GRAALVM_HOME'), 'bin'), javaExecutableName).absolutePath
-                    assert executable == expectedExecutable
+                    assert executable == null
                     assert javaLauncher.get().executablePath.asFile.absolutePath == expectedExecutable
                 }
             }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -303,9 +303,13 @@ org.gradle.java.installations.auto-download=false
                 })
             }
 
+            def runJavaExecutable = tasks.named('run').flatMap {
+                it.javaLauncher.map { launcher -> launcher.executablePath.asFile.canonicalFile }
+            }
+
             tasks.register('verifyRunLauncher') {
                 doLast {
-                    def actualExecutable = tasks.named('run').get().javaLauncher.get().executablePath.asFile.canonicalFile
+                    def actualExecutable = runJavaExecutable.get()
                     def expectedExecutable = new File('${graalvmHome}', 'bin/java').canonicalFile
                     def javaHomeExecutable = new File(new File(System.getenv('JAVA_HOME')), 'bin/java').canonicalFile
                     assert actualExecutable == expectedExecutable

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -209,6 +209,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
     @Unroll("agent uses GraalVM's Java executable for run task with JUnit Platform #junitVersion")
     def "agent uses GraalVM java executable"() {
         given:
+        // Enabled agent tasks prefer GRAALVM_HOME. §FS-tracing-agent.2.1
         withSample("java-application-with-reflection")
         buildFile << """
             tasks.named('run') {
@@ -242,6 +243,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
     @Unroll("agent replaces explicit test executable with GraalVM java launcher for JUnit Platform #junitVersion")
     def "agent replaces explicit test executable with GraalVM java launcher"() {
         given:
+        // Test tasks keep their launcher and executable aligned while preferring GRAALVM_HOME. §FS-tracing-agent.2.1
         withSample("java-application-with-reflection")
         buildFile << """
             tasks.named('test') {
@@ -274,8 +276,12 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
     @Unroll("agent does not replace configured launcher with regular JAVA_HOME for JUnit Platform #junitVersion")
     def "agent does not replace configured launcher with regular JAVA_HOME"() {
         given:
+        // A regular JAVA_HOME must not replace an explicitly configured launcher. §FS-tracing-agent.2.1
         withSample("java-application-with-reflection")
         def graalvmHome = System.getenv("GRAALVM_HOME")
+        def graalvmRelease = new Properties()
+        new File(graalvmHome, "release").withInputStream { graalvmRelease.load(it) }
+        def graalvmJavaVersion = graalvmRelease.getProperty("JAVA_VERSION").replace('"', '').tokenize('.')[0].toInteger()
         def fakeJavaHome = file("fake-java-home")
         def fakeJava = new File(fakeJavaHome, "bin/java")
         fakeJava.parentFile.mkdirs()
@@ -299,7 +305,7 @@ org.gradle.java.installations.auto-download=false
         buildFile << """
             tasks.named('run') {
                 javaLauncher.set(javaToolchains.launcherFor {
-                    languageVersion.set(JavaLanguageVersion.of(${getCurrentJDKVersion()}))
+                    languageVersion.set(JavaLanguageVersion.of(${graalvmJavaVersion}))
                 })
             }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -109,6 +109,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -1068,8 +1069,8 @@ public class NativeImagePlugin implements Plugin<Project> {
             JavaLauncher javaLauncher = javaLauncherForAgent.getOrNull();
             if (javaLauncher != null) {
                 if (taskToInstrument instanceof Test test) {
+                    javaForkOptions.setExecutable(null);
                     test.getJavaLauncher().set(javaLauncher);
-                    javaForkOptions.setExecutable(javaLauncher.getExecutablePath().getAsFile().getAbsolutePath());
                 } else if (taskToInstrument instanceof JavaExec javaExec) {
                     javaExec.getJavaLauncher().set(javaLauncher);
                     javaForkOptions.setExecutable(javaLauncher.getExecutablePath().getAsFile().getAbsolutePath());
@@ -1291,6 +1292,7 @@ public class NativeImagePlugin implements Plugin<Project> {
         }
 
         @Override
+        @Internal
         public boolean isCurrentJvm() {
             return false;
         }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -1065,6 +1065,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                                 JavaForkOptions javaForkOptions) {
         Provider<AgentConfiguration> agentConfiguration = AgentConfigurationFactory.getAgentConfiguration(agentMode, graalExtension.getAgent());
         Provider<JavaLauncher> javaLauncherForAgent = javaLauncherForAgent(project.getProviders());
+        // Agent runs prefer an available GraalVM Java without replacing task configuration with a regular JAVA_HOME. §FS-tracing-agent.2.1
         if (agentConfiguration.get().isEnabled()) {
             JavaLauncher javaLauncher = javaLauncherForAgent.getOrNull();
             if (javaLauncher != null) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -1063,12 +1063,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                                 Task taskToInstrument,
                                 JavaForkOptions javaForkOptions) {
         Provider<AgentConfiguration> agentConfiguration = AgentConfigurationFactory.getAgentConfiguration(agentMode, graalExtension.getAgent());
-        Provider<JavaLauncher> javaLauncherForAgent = graalvmHomeProvider(project.getProviders())
-                .map(serializableTransformerOf(graalHomePath -> {
-                    String javaExecutable = graalHomePath + (IS_WINDOWS ? "\\bin\\java.exe" : "/bin/java");
-                    File javaExecutableFile = new File(javaExecutable);
-                    return javaExecutableFile.exists() ? new FixedJavaLauncher(new File(graalHomePath), javaExecutableFile) : null;
-                }));
+        Provider<JavaLauncher> javaLauncherForAgent = javaLauncherForAgent(project.getProviders());
         if (agentConfiguration.get().isEnabled()) {
             JavaLauncher javaLauncher = javaLauncherForAgent.getOrNull();
             if (javaLauncher != null) {
@@ -1119,6 +1114,38 @@ public class NativeImagePlugin implements Plugin<Project> {
             execOperations));
 
         taskToInstrument.doLast(new CleanupAgentFilesAction(mergeInputDirs, fileOperations));
+    }
+
+    private static Provider<JavaLauncher> javaLauncherForAgent(ProviderFactory providers) {
+        return providers.environmentVariable("GRAALVM_HOME")
+                .map(serializableTransformerOf(graalHomePath -> javaLauncherForAgentHome(graalHomePath, false)))
+                .orElse(providers.environmentVariable("JAVA_HOME")
+                        .map(serializableTransformerOf(javaHomePath -> javaLauncherForAgentHome(javaHomePath, true))));
+    }
+
+    private static JavaLauncher javaLauncherForAgentHome(String javaHomePath, boolean requireGraalVM) {
+        File javaHome = new File(javaHomePath);
+        if (requireGraalVM && !isGraalVMHome(javaHome)) {
+            return null;
+        }
+        File javaExecutableFile = new File(javaHome, IS_WINDOWS ? "bin\\java.exe" : "bin/java");
+        return javaExecutableFile.exists() ? new FixedJavaLauncher(javaHome, javaExecutableFile) : null;
+    }
+
+    private static boolean isGraalVMHome(File javaHome) {
+        File release = new File(javaHome, "release");
+        if (!release.isFile()) {
+            return false;
+        }
+        Properties properties = new Properties();
+        try (var inputStream = java.nio.file.Files.newInputStream(release.toPath())) {
+            properties.load(inputStream);
+        } catch (Exception ignored) {
+            return false;
+        }
+        return properties.stringPropertyNames().stream()
+                .anyMatch(propertyName -> propertyName.toUpperCase(Locale.ROOT).contains("GRAALVM")
+                        || String.valueOf(properties.getProperty(propertyName)).toLowerCase(Locale.ROOT).contains("graalvm"));
     }
 
     private static void injectTestPluginDependencies(Project project, String binaryName, Property<Boolean> testSupportEnabled) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -94,6 +94,7 @@ import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFile;
@@ -113,10 +114,14 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.jvm.toolchain.JavaInstallationMetadata;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.process.CommandLineArgumentProvider;
@@ -126,6 +131,7 @@ import org.gradle.process.JavaForkOptions;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.io.File;
+import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -139,6 +145,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -1056,12 +1063,32 @@ public class NativeImagePlugin implements Plugin<Project> {
                                 Task taskToInstrument,
                                 JavaForkOptions javaForkOptions) {
         Provider<AgentConfiguration> agentConfiguration = AgentConfigurationFactory.getAgentConfiguration(agentMode, graalExtension.getAgent());
+        Provider<JavaLauncher> javaLauncherForAgent = graalvmHomeProvider(project.getProviders())
+                .map(serializableTransformerOf(graalHomePath -> {
+                    String javaExecutable = graalHomePath + (IS_WINDOWS ? "\\bin\\java.exe" : "/bin/java");
+                    File javaExecutableFile = new File(javaExecutable);
+                    return javaExecutableFile.exists() ? new FixedJavaLauncher(new File(graalHomePath), javaExecutableFile) : null;
+                }));
+        if (agentConfiguration.get().isEnabled()) {
+            JavaLauncher javaLauncher = javaLauncherForAgent.getOrNull();
+            if (javaLauncher != null) {
+                if (taskToInstrument instanceof Test test) {
+                    test.getJavaLauncher().set(javaLauncher);
+                } else if (taskToInstrument instanceof JavaExec javaExec) {
+                    javaExec.getJavaLauncher().set(javaLauncher);
+                }
+            }
+        }
         //noinspection Convert2Lambda
         taskToInstrument.doFirst(new Action<Task>() {
             @Override
             public void execute(@Nonnull Task task) {
                 if (agentConfiguration.get().isEnabled()) {
                     logger.logOnce("Instrumenting task with the native-image-agent: " + task.getName());
+                    JavaLauncher javaLauncher = javaLauncherForAgent.getOrNull();
+                    if (javaLauncher != null && !(task instanceof Test) && !(task instanceof JavaExec)) {
+                        javaForkOptions.setExecutable(javaLauncher.getExecutablePath().getAsFile().getAbsolutePath());
+                    }
                 }
             }
         });
@@ -1177,6 +1204,149 @@ public class NativeImagePlugin implements Plugin<Project> {
         @Override
         public Iterable<String> asArguments() {
             return Collections.singleton("-D" + JUNIT_PLATFORM_LISTENERS_UID_TRACKING_OUTPUT_DIR + "=" + getDirectory().getAsFile().get().getAbsolutePath());
+        }
+    }
+
+    private static final class FixedJavaLauncher implements JavaLauncher, Serializable {
+        private final File javaExecutable;
+        private final FixedJavaInstallationMetadata metadata;
+
+        private FixedJavaLauncher(File javaHome, File javaExecutable) {
+            this.javaExecutable = javaExecutable;
+            this.metadata = new FixedJavaInstallationMetadata(javaHome);
+        }
+
+        @Override
+        public JavaInstallationMetadata getMetadata() {
+            return metadata;
+        }
+
+        @Override
+        public RegularFile getExecutablePath() {
+            return new FixedRegularFile(javaExecutable);
+        }
+    }
+
+    private static final class FixedJavaInstallationMetadata implements JavaInstallationMetadata, Serializable {
+        private final File javaHome;
+        private final String javaVersion;
+
+        private FixedJavaInstallationMetadata(File javaHome) {
+            this.javaHome = javaHome;
+            this.javaVersion = javaVersion(javaHome);
+        }
+
+        @Override
+        public JavaLanguageVersion getLanguageVersion() {
+            return JavaLanguageVersion.of(javaVersion.replaceFirst("^1\\.", "").replaceFirst("[^0-9].*", ""));
+        }
+
+        @Override
+        public String getJavaRuntimeVersion() {
+            return javaVersion;
+        }
+
+        @Override
+        public String getJvmVersion() {
+            return javaVersion;
+        }
+
+        @Override
+        public String getVendor() {
+            return "GraalVM";
+        }
+
+        @Override
+        public Directory getInstallationPath() {
+            return new FixedDirectory(javaHome);
+        }
+
+        @Override
+        public boolean isCurrentJvm() {
+            return false;
+        }
+
+        private static String javaVersion(File javaHome) {
+            File release = new File(javaHome, "release");
+            if (release.isFile()) {
+                Properties properties = new Properties();
+                try (var inputStream = java.nio.file.Files.newInputStream(release.toPath())) {
+                    properties.load(inputStream);
+                    String version = properties.getProperty("JAVA_VERSION");
+                    if (version != null) {
+                        return version.replace("\"", "");
+                    }
+                } catch (Exception ignored) {
+                    // Fall through to the JVM running Gradle.
+                }
+            }
+            return System.getProperty("java.version");
+        }
+    }
+
+    private static final class FixedRegularFile implements RegularFile, Serializable {
+        private final File file;
+
+        private FixedRegularFile(File file) {
+            this.file = file;
+        }
+
+        @Override
+        public File getAsFile() {
+            return file;
+        }
+
+        @Override
+        public String toString() {
+            return file.getAbsolutePath();
+        }
+    }
+
+    private static final class FixedDirectory implements Directory, Serializable {
+        private final File directory;
+
+        private FixedDirectory(File directory) {
+            this.directory = directory;
+        }
+
+        @Override
+        public File getAsFile() {
+            return directory;
+        }
+
+        @Override
+        public FileTree getAsFileTree() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Directory dir(String path) {
+            return new FixedDirectory(new File(directory, path));
+        }
+
+        @Override
+        public Provider<Directory> dir(Provider<? extends CharSequence> path) {
+            return path.map(serializableTransformerOf(value -> dir(value.toString())));
+        }
+
+        @Override
+        public RegularFile file(String path) {
+            return new FixedRegularFile(new File(directory, path));
+        }
+
+        @Override
+        public Provider<RegularFile> file(Provider<? extends CharSequence> path) {
+            return path.map(serializableTransformerOf(value -> file(value.toString())));
+        }
+
+        @Override
+        public FileCollection files(Object... paths) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String toString() {
+            return directory.getAbsolutePath();
         }
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -1069,8 +1069,10 @@ public class NativeImagePlugin implements Plugin<Project> {
             if (javaLauncher != null) {
                 if (taskToInstrument instanceof Test test) {
                     test.getJavaLauncher().set(javaLauncher);
+                    javaForkOptions.setExecutable(javaLauncher.getExecutablePath().getAsFile().getAbsolutePath());
                 } else if (taskToInstrument instanceof JavaExec javaExec) {
                     javaExec.getJavaLauncher().set(javaLauncher);
+                    javaForkOptions.setExecutable(javaLauncher.getExecutablePath().getAsFile().getAbsolutePath());
                 }
             }
         }

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -68,6 +68,7 @@ abstract class AbstractFunctionalTest extends Specification {
     private String output
     private String errorOutput
     private File initScript
+    private Map<String, String> environment
 
     BuildResult result
 
@@ -135,6 +136,18 @@ abstract class AbstractFunctionalTest extends Specification {
     protected void withSpacesInProjectDir() {
         testDirectory = testDirectory.resolve("with spaces")
         Files.createDirectory(testDirectory)
+    }
+
+    protected void withEnvironmentOverrides(Map<String, String> overrides) {
+        def updatedEnvironment = new LinkedHashMap<>(System.getenv())
+        overrides.each { key, value ->
+            if (value == null) {
+                updatedEnvironment.remove(key)
+            } else {
+                updatedEnvironment.put(key, value)
+            }
+        }
+        environment = updatedEnvironment
     }
 
     protected void withSample(String name, boolean quickBuildMode = true) {
@@ -219,6 +232,9 @@ abstract class AbstractFunctionalTest extends Specification {
         }
         if (debug) {
             runner.withDebug(true)
+        }
+        if (environment != null) {
+            runner.withEnvironment(environment)
         }
         runner
     }

--- a/samples/java-application-with-extra-sourceset/build.gradle
+++ b/samples/java-application-with-extra-sourceset/build.gradle
@@ -66,6 +66,13 @@ dependencies {
 configurations {
     nativeImageClasspath.extendsFrom(graalImplementation)
 }
+
+graalvmNative {
+    binaries.main {
+        buildArgs.add('-H:+UnlockExperimentalVMOptions')
+        buildArgs.add('-H:Features=org.graalvm.demo.ApplicationFeature')
+    }
+}
 // end::extra-sourceset[]
 
 graalvmNative {

--- a/samples/java-application-with-extra-sourceset/build.gradle
+++ b/samples/java-application-with-extra-sourceset/build.gradle
@@ -74,9 +74,3 @@ graalvmNative {
     }
 }
 // end::extra-sourceset[]
-
-graalvmNative {
-    binaries.all {
-        buildArgs.add("--features=org.graalvm.demo.ApplicationFeature")
-    }
-}

--- a/samples/java-application-with-extra-sourceset/build.gradle.kts
+++ b/samples/java-application-with-extra-sourceset/build.gradle.kts
@@ -64,4 +64,11 @@ dependencies {
 configurations {
     nativeImageClasspath.extendsFrom(getByName("graalImplementation"))
 }
+
+graalvmNative {
+    binaries.named("main") {
+        buildArgs.add("-H:+UnlockExperimentalVMOptions")
+        buildArgs.add("-H:Features=org.graalvm.demo.ApplicationFeature")
+    }
+}
 // end::extra-sourceset[]


### PR DESCRIPTION
Fixes #581.

## Summary

- Prefer the GraalVM Java executable from `GRAALVM_HOME` or `JAVA_HOME` when running tasks instrumented with the native-image-agent.
- Set a matching `javaLauncher` for `Test` and `JavaExec` tasks so Gradle 9 does not reject a mismatch between `executable` and `javaLauncher`.
- Keep the executable override as a fallback for other `JavaForkOptions` implementations.
- Add functional coverage for the agent-instrumented `run` task using GraalVM Java.

## Validation

- `./gradlew :native-gradle-plugin:functionalTest -DgradleVersion=9.0.0 --tests org.graalvm.buildtools.gradle.JavaApplicationWithAgentFunctionalTest --fail-fast`
- `./gradlew :native-gradle-plugin:configCacheFunctionalTest -DgradleVersion=9.0.0 --tests org.graalvm.buildtools.gradle.JavaApplicationWithAgentFunctionalTest --fail-fast`
- `./gradlew :native-gradle-plugin:test :native-gradle-plugin:inspections`
- `git diff --check`