### PR TITLE
Improve native-image executable discovery with explicit/convention launcher distinction

### DIFF
--- a/docs/src/docs/asciidoc/changelog.adoc
+++ b/docs/src/docs/asciidoc/changelog.adoc
@@ -1,7 +1,13 @@
 [[changelog]]
 == Changelog
 
-== Next release
+== Release 1.1.12
+
+- Gradle Native Image executable discovery now distinguishes explicitly configured launchers from
+  convention-selected toolchains. Toolchains without `native-image` fall back to `GRAALVM_HOME`,
+  `JAVA_HOME`, or the Gradle JVM, while explicit launchers fail with an actionable diagnostic.
+
+== Release 1.1.9
 
 - Added first-class named Native Image layers to the Gradle plugin and Maven `layer-create` /
   `useLayers` support with resolvable `nil` artifacts and platform runtime bundles. Layer

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -59,15 +59,14 @@ you can set up the `GRAALVM_HOME` environment variable pointing to your GraalVM 
 [[configuration-toolchains-enabling]]
 === Enabling Toolchain Detection
 
-WARNING: Toolchain support has many pitfalls. Unless you have a single JDK installed on your machine, which is the GraalVM version that you want to use, we do not recommend enabling them yet. We are working with the Gradle team on improvements in the future.
-
 Instead of relying on the JDK which is used to run Gradle, you can use the https://docs.gradle.org/current/userguide/toolchains.html[Gradle toolchain support] to select a specific GraalVM installation.
 
-However, because of limitations in Gradle, the plugin may not be able to properly detect the toolchain.
-In particular, this will only work properly if you _only_ have GraalVM JDKs installed on the machine.
-**Otherwise, Gradle will not be able to reliably detect GraalVM JDKs**, nor detect GraalVM distributions from different vendors.
+Gradle toolchain matching cannot always distinguish a GraalVM installation from a standard JDK.
+The plugin therefore verifies that the convention-selected toolchain contains the `native-image`
+executable before using it. If it does not, the plugin continues with the environment-based lookup
+described below.
 
-Should you still want to enable toolchain support, you do it via the `graalvmNative` extension:
+Enable toolchain detection through the `graalvmNative` extension:
 
 [source,groovy,role="multi-language-sample"]
 ----
@@ -79,12 +78,34 @@ include::../snippets/gradle/groovy/build.gradle[tags=enabling-toolchain, indent=
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=enabling-toolchain, indent=0]
 ----
 
-=== Selecting the GraalVM Toolchain
+[[configuration-toolchains-discovery]]
+=== Native Image Executable Discovery
 
-By default, the plugin will select a Java 11 GraalVM toolchain using the vendor string `GraalVM`, which works properly for GraalVM up to version 22.3 included.
-More recent versions of GraalVM do not have a specific version and are aligned with the language version they support.
+The plugin selects the `native-image` executable in the following order:
 
-If you want to use a different toolchain, for example, a distribution compatible with Java 20 from Oracle, you can configure the toolchain like this:
+. An explicitly configured `javaLauncher`
+. A launcher selected by Gradle toolchain detection, when enabled
+. `GRAALVM_HOME`
+. `JAVA_HOME`
+. The JVM running Gradle
+
+An explicitly configured `javaLauncher` is authoritative. Its installation must contain
+`bin/native-image`. If it does not, the build fails with a diagnostic naming the selected
+installation. The plugin does not fall back to another installation or attempt to install Native
+Image into an explicitly selected launcher.
+
+A launcher selected automatically through toolchain detection is used only when its installation
+contains `bin/native-image`. Otherwise, the plugin continues with `GRAALVM_HOME`, `JAVA_HOME`, and
+finally the JVM running Gradle.
+
+For an installation selected through the environment-based fallback, the plugin may attempt
+`gu install native-image` when `native-image` is missing and the `gu` command is available. It does
+not install Native Image into an explicitly configured or convention-selected launcher.
+
+[[configuration-toolchains-explicit]]
+=== Configuring an Explicit Native Image Launcher
+
+You can explicitly select the Java installation used for a particular native binary:
 
 [source, groovy, role="multi-language-sample"]
 ----
@@ -96,8 +117,9 @@ include::../snippets/gradle/groovy/build.gradle[tags=select-toolchain]
 include::../snippets/gradle/kotlin/build.gradle.kts[tags=select-toolchain]
 ----
 
-Again, be aware that the toolchain detection _cannot_ distinguish between GraalVM JDKs and standard JDKs without Native Image support.
-If you have both installed on the machine, Gradle may randomly pick one or the other.
+Because this assigns the binary's `javaLauncher` explicitly, the selected installation must provide
+`native-image`. Use toolchain detection instead if you want a regular Java toolchain to fall back to
+a GraalVM installation configured through the environment.
 
 [[configuration]]
 == Plugin Configuration

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -5,10 +5,74 @@ process execution.
 
 ## 1. Executable discovery
 
-Compile and metadata tasks must find `native-image` from the configured Gradle Java launcher or
-toolchain when toolchain detection is enabled. When detection is disabled or no launcher supplies
-Native Image, the plugin must use GraalVM/JDK environment and path fallbacks. Failure messages must
-tell the user which lookup path was attempted.
+Compile and metadata tasks must find the `native-image` executable by probing, in order:
+
+### 1.1. Explicit java launcher
+
+When a user explicitly configures `javaLauncher` on a native binary
+(`graalvmNative.binaries.all { javaLauncher.set(…) }`), that launcher is authoritative.
+The plugin must probe its installation path for `bin/native-image`. If the executable is
+missing, the build MUST fail with a diagnostic that names the launcher and its installation
+path. The plugin MUST NOT silently fall back to another launcher,
+environment variable, or path-based discovery — including `gu install native-image`.
+
+### 1.2. Convention-selected launcher
+
+When no explicit launcher is set, the plugin selects a launcher by convention:
+
+1. **Toolchain detection** (`toolchainDetection = true`): the configured Java toolchain is
+   probed for `bin/native-image`. If found, that launcher is used. If `native-image` is not
+   present, `configureToolchain()` returns `null` and the plugin continues to environment
+   variable fallback.
+2. **Toolchain disabled**: no convention launcher is set, the plugin goes directly to
+   environment variable fallback.
+
+The convention-selected launcher is used only when it contains `bin/native-image`. If it
+does not, the plugin continues to environment-variable fallback.
+
+### 1.3. Environment-variable fallback
+
+When no convention launcher supplies `native-image`, the plugin probes, in order:
+
+1. `GRAALVM_HOME/bin/native-image`
+2. `JAVA_HOME/bin/native-image`
+3. `{java.home}/bin/native-image` — the Gradle JVM itself, as a last resort when neither
+   environment variable is set
+
+If none resolve to an existing executable, the plugin attempts `gu install native-image`
+(see [§FS-native-invocation.1.4](native-image-invocation.md#14-gu-based-installation)) on the resolved
+GraalVM home; if that still does not provide `native-image`, it probes the other GraalVM homes
+(`GRAALVM_HOME`/`JAVA_HOME`/`{java.home}` other than the one just tried). If no `native-image` is
+found in any of those locations, the locator fails with a diagnostic ([§FS-native-invocation.1.5](native-image-invocation.md#15-failure-messages)).
+
+### 1.4. gu-based installation
+
+When the GraalVM installation resolved through the environment-variable fallback (GRAALVM_HOME →
+JAVA_HOME → Gradle JVM) contains a working `gu` tool but does not yet have `native-image`, the plugin MAY attempt
+`gu install native-image`. This fallback MUST NOT apply when an explicit launcher
+([§FS-native-invocation.1.1](native-image-invocation.md#11-explicit-java-launcher)) was configured — the
+user-selected installation must provide `native-image` without implicit installation.
+
+### 1.5. Failure messages
+
+All failure messages MUST tell the user:
+
+* which lookup paths were attempted
+* for an explicit launcher, the launcher name and installation path
+* for convention selection, whether toolchain detection was enabled
+* which environment variables were (or were not) set
+
+The `NativeImageExecutableLocator.Diagnostics` class collects this information for the
+`BuildNativeImageTask` to emit at build time.
+
+### 1.6. Toolchain detection interaction
+
+When `toolchainDetection = true` and the toolchain-resolved launcher does not contain
+`native-image`, `configureToolchain()` in `DefaultGraalVmExtension` returns `null`.
+The plugin then falls through to environment variable fallback (GRAALVM_HOME →
+JAVA_HOME → Gradle JVM). This means the toolchain's GraalVM is used only if it already
+provides `native-image`; otherwise the build uses the same environment-variable resolution
+path as builds without a toolchain.
 
 ## 2. Version and schema gates
 

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -18,7 +18,10 @@ environment variable, or path-based discovery — including `gu install native-i
 
 ### 1.2. Convention-selected launcher
 
-When no explicit launcher is set, the plugin selects a launcher by convention:
+When no explicit launcher is set, the plugin selects a launcher by convention. The plugin
+installs that convention on each native binary's public `javaLauncher` property
+(`graalvmNative.binaries.all { javaLauncher.convention(…) }`), so the property resolves
+to the convention value and stays queryable at configuration time:
 
 1. **Toolchain detection** (`toolchainDetection = true`): `configureToolchain()` resolves
    the configured Java toolchain and exposes it as the binary's `javaLauncher` convention
@@ -26,11 +29,19 @@ When no explicit launcher is set, the plugin selects a launcher by convention:
    `NativeImageExecutableLocator` probes the toolchain's installation for
    `bin/native-image`. If found, that launcher is used. If `native-image` is not present,
    the locator falls through to environment variable fallback.
-2. **Toolchain disabled**: no convention launcher is set, the plugin goes directly to
-   environment variable fallback.
+2. **Toolchain disabled**: the convention yields no launcher, and the plugin goes directly
+   to environment variable fallback.
 
 The convention-selected launcher is used only when it contains `bin/native-image`. If it
 does not, the plugin continues to environment-variable fallback.
+
+Because the convention is installed on the public property, the plugin tracks launcher
+provenance independently of the property value: a launcher is *explicit* only when the
+user assigned it directly
+([§FS-native-invocation.1.1](native-image-invocation.md#11-explicit-java-launcher)); a value supplied by the
+convention is never treated as explicit. Provenance must not be derived from property
+presence (the property is present in both cases), nor from the resolved launcher (the
+convention supplies the same launcher the default resolution would).
 
 ### 1.3. Environment-variable fallback
 
@@ -72,7 +83,8 @@ All failure messages MUST tell the user:
 
 * which lookup paths were attempted
 * for an explicit launcher, the launcher name and installation path
-* for convention selection, whether toolchain detection was enabled
+* for convention selection, whether toolchain detection was enabled and whether the
+  launcher was convention-selected rather than explicitly configured
 * which environment variables were (or were not) set
 
 The `NativeImageExecutableLocator.Diagnostics` class collects this information for the

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -86,6 +86,9 @@ All failure messages MUST tell the user:
 * for convention selection, whether toolchain detection was enabled and whether the
   launcher was convention-selected rather than explicitly configured
 * which environment variables were (or were not) set
+* whether the `gu` tool was available and whether installation was attempted
+  ([§FS-native-invocation.1.4](native-image-invocation.md#14-gu-based-installation)) — "after attempting gu install" is
+  reported only when `gu` actually ran, and a missing `gu` is reported as unavailable
 
 The `NativeImageExecutableLocator.Diagnostics` class collects this information for the
 `BuildNativeImageTask` to emit at build time.

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -20,10 +20,12 @@ environment variable, or path-based discovery — including `gu install native-i
 
 When no explicit launcher is set, the plugin selects a launcher by convention:
 
-1. **Toolchain detection** (`toolchainDetection = true`): the configured Java toolchain is
-   probed for `bin/native-image`. If found, that launcher is used. If `native-image` is not
-   present, `configureToolchain()` returns `null` and the plugin continues to environment
-   variable fallback.
+1. **Toolchain detection** (`toolchainDetection = true`): `configureToolchain()` resolves
+   the configured Java toolchain and exposes it as the binary's `javaLauncher` convention
+   — it does **not** check for `native-image` presence. At build time,
+   `NativeImageExecutableLocator` probes the toolchain's installation for
+   `bin/native-image`. If found, that launcher is used. If `native-image` is not present,
+   the locator falls through to environment variable fallback.
 2. **Toolchain disabled**: no convention launcher is set, the plugin goes directly to
    environment variable fallback.
 
@@ -32,18 +34,20 @@ does not, the plugin continues to environment-variable fallback.
 
 ### 1.3. Environment-variable fallback
 
-When no convention launcher supplies `native-image`, the plugin probes, in order:
+When no convention launcher supplies `native-image`, the plugin resolves a single primary
+GraalVM home from the first available environment variable:
 
-1. `GRAALVM_HOME/bin/native-image`
-2. `JAVA_HOME/bin/native-image`
-3. `{java.home}/bin/native-image` — the Gradle JVM itself, as a last resort when neither
-   environment variable is set
+1. `GRAALVM_HOME` — if set
+2. `JAVA_HOME` — if `GRAALVM_HOME` is not set
+3. `{java.home}` — the Gradle JVM itself, as a last resort when neither env var is set
 
-If none resolve to an existing executable, the plugin attempts `gu install native-image`
-(see [§FS-native-invocation.1.4](native-image-invocation.md#14-gu-based-installation)) on the resolved
-GraalVM home; if that still does not provide `native-image`, it probes the other GraalVM homes
-(`GRAALVM_HOME`/`JAVA_HOME`/`{java.home}` other than the one just tried). If no `native-image` is
-found in any of those locations, the locator fails with a diagnostic ([§FS-native-invocation.1.5](native-image-invocation.md#15-failure-messages)).
+The plugin probes the primary home for `bin/native-image`. If `native-image` is not found
+there, it attempts `gu install native-image` (see
+[§FS-native-invocation.1.4](native-image-invocation.md#14-gu-based-installation)) on that same home.
+If the primary GraalVM still lacks `native-image` after `gu`, the plugin probes the
+*other* GraalVM homes — whichever of `GRAALVM_HOME`/`JAVA_HOME`/`{java.home}` was not
+selected as the primary. If no `native-image` is found in any of those locations, the
+locator fails with a diagnostic ([§FS-native-invocation.1.5](native-image-invocation.md#15-failure-messages)).
 
 ### 1.4. gu-based installation
 
@@ -68,11 +72,13 @@ The `NativeImageExecutableLocator.Diagnostics` class collects this information f
 ### 1.6. Toolchain detection interaction
 
 When `toolchainDetection = true` and the toolchain-resolved launcher does not contain
-`native-image`, `configureToolchain()` in `DefaultGraalVmExtension` returns `null`.
-The plugin then falls through to environment variable fallback (GRAALVM_HOME →
-JAVA_HOME → Gradle JVM). This means the toolchain's GraalVM is used only if it already
-provides `native-image`; otherwise the build uses the same environment-variable resolution
-path as builds without a toolchain.
+`native-image`, `configureToolchain()` in `DefaultGraalVmExtension` still returns the
+toolchain launcher (it never checks for `native-image`). The
+`NativeImageExecutableLocator` performs the `native-image` check at build time and falls
+through to environment variable fallback (GRAALVM_HOME → JAVA_HOME → Gradle JVM) when
+the toolchain's installation lacks `native-image`. This means the toolchain's GraalVM is
+used only if it already provides `native-image`; otherwise the build uses the same
+environment-variable resolution path as builds without a toolchain.
 
 ## 2. Version and schema gates
 

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -49,6 +49,15 @@ If the primary GraalVM still lacks `native-image` after `gu`, the plugin probes 
 selected as the primary. If no `native-image` is found in any of those locations, the
 locator fails with a diagnostic ([§FS-native-invocation.1.5](native-image-invocation.md#15-failure-messages)).
 
+Because the resolved executable may come from any of `GRAALVM_HOME`, `JAVA_HOME`, or
+`{java.home}`, compile and metadata tasks MUST model each of the three sources as a task
+input whose value distinguishes unset, empty, and set states. A change to any source —
+including one shadowed by an earlier fallback in the resolution order — MUST re-run the
+task rather than leave it UP-TO-DATE with an executable resolved from the previous
+environment. The fallback candidates probed at execution time MUST be derived from the
+same providers that back those inputs, so the probe set and the up-to-date fingerprint
+never diverge.
+
 ### 1.4. gu-based installation
 
 When the GraalVM installation resolved through the environment-variable fallback (GRAALVM_HOME →

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -5,10 +5,111 @@ process execution.
 
 ## 1. Executable discovery
 
-Compile and metadata tasks must find `native-image` from the configured Gradle Java launcher or
-toolchain when toolchain detection is enabled. When detection is disabled or no launcher supplies
-Native Image, the plugin must use GraalVM/JDK environment and path fallbacks. Failure messages must
-tell the user which lookup path was attempted.
+Compile and metadata tasks must find the `native-image` executable by probing, in order:
+
+### 1.1. Explicit java launcher
+
+When a user explicitly configures `javaLauncher` on a native binary
+(`graalvmNative.binaries.all { javaLauncher.set(…) }`), that launcher is authoritative.
+The plugin must probe its installation path for `bin/native-image`. If the executable is
+missing, the build MUST fail with a diagnostic that names the launcher and its installation
+path. The plugin MUST NOT silently fall back to another launcher,
+environment variable, or path-based discovery — including `gu install native-image`.
+
+### 1.2. Convention-selected launcher
+
+When no explicit launcher is set, the plugin selects a launcher by convention. The plugin
+installs that convention on each native binary's public `javaLauncher` property
+(`graalvmNative.binaries.all { javaLauncher.convention(…) }`), so the property resolves
+to the convention value and stays queryable at configuration time:
+
+1. **Toolchain detection** (`toolchainDetection = true`): `configureToolchain()` resolves
+   the configured Java toolchain and exposes it as the binary's `javaLauncher` convention
+   — it does **not** check for `native-image` presence. At build time,
+   `NativeImageExecutableLocator` probes the toolchain's installation for
+   `bin/native-image`. If found, that launcher is used. If `native-image` is not present,
+   the locator falls through to environment variable fallback.
+2. **Toolchain disabled**: the convention yields no launcher, and the plugin goes directly
+   to environment variable fallback.
+
+The convention-selected launcher is used only when it contains `bin/native-image`. If it
+does not, the plugin continues to environment-variable fallback.
+
+Because the convention is installed on the public property, the plugin tracks launcher
+provenance independently of the property value: a launcher is *explicit* only when the
+user assigned it directly
+([§FS-native-invocation.1.1](native-image-invocation.md#11-explicit-java-launcher)); a value supplied by the
+convention is never treated as explicit. Provenance must not be derived from property
+presence (the property is present in both cases), nor from the resolved launcher (the
+convention supplies the same launcher the default resolution would).
+
+Because provenance changes the execution result (fallback vs. authoritative failure) while
+the launcher value does not, compile and metadata tasks MUST model the explicit/convention
+provenance as a task input. Otherwise, switching a convention-selected launcher to an
+explicit assignment of the same launcher would leave the task UP-TO-DATE instead of
+re-running and, per [§FS-native-invocation.1.1](native-image-invocation.md#11-explicit-java-launcher), failing when that
+launcher lacks `native-image`.
+
+### 1.3. Environment-variable fallback
+
+When no convention launcher supplies `native-image`, the plugin resolves a single primary
+GraalVM home from the first available environment variable:
+
+1. `GRAALVM_HOME` — if set
+2. `JAVA_HOME` — if `GRAALVM_HOME` is not set
+3. `{java.home}` — the Gradle JVM itself, as a last resort when neither env var is set
+
+The plugin probes the primary home for `bin/native-image`. If `native-image` is not found
+there, it attempts `gu install native-image` (see
+[§FS-native-invocation.1.4](native-image-invocation.md#14-gu-based-installation)) on that same home.
+If the primary GraalVM still lacks `native-image` after `gu`, the plugin probes the
+*other* GraalVM homes — whichever of `GRAALVM_HOME`/`JAVA_HOME`/`{java.home}` was not
+selected as the primary. If no `native-image` is found in any of those locations, the
+locator fails with a diagnostic ([§FS-native-invocation.1.5](native-image-invocation.md#15-failure-messages)).
+
+Because the resolved executable may come from any of `GRAALVM_HOME`, `JAVA_HOME`, or
+`{java.home}`, compile and metadata tasks MUST model each of the three sources as a task
+input whose value distinguishes unset, empty, and set states. A change to any source —
+including one shadowed by an earlier fallback in the resolution order — MUST re-run the
+task rather than leave it UP-TO-DATE with an executable resolved from the previous
+environment. The fallback candidates probed at execution time MUST be derived from the
+same providers that back those inputs, so the probe set and the up-to-date fingerprint
+never diverge.
+
+### 1.4. gu-based installation
+
+When the GraalVM installation resolved through the environment-variable fallback (GRAALVM_HOME →
+JAVA_HOME → Gradle JVM) contains a working `gu` tool but does not yet have `native-image`, the plugin MAY attempt
+`gu install native-image`. This fallback MUST NOT apply when an explicit launcher
+([§FS-native-invocation.1.1](native-image-invocation.md#11-explicit-java-launcher)) was configured — the
+user-selected installation must provide `native-image` without implicit installation.
+
+### 1.5. Failure messages
+
+All failure messages MUST tell the user:
+
+* which lookup paths were attempted
+* for an explicit launcher, the launcher name and installation path
+* for convention selection, whether toolchain detection was enabled and whether the
+  launcher was convention-selected rather than explicitly configured
+* which environment variables were (or were not) set
+* whether the `gu` tool was available and whether installation was attempted
+  ([§FS-native-invocation.1.4](native-image-invocation.md#14-gu-based-installation)) — "after attempting gu install" is
+  reported only when `gu` actually ran, and a missing `gu` is reported as unavailable
+
+The `NativeImageExecutableLocator.Diagnostics` class collects this information for the
+`BuildNativeImageTask` to emit at build time.
+
+### 1.6. Toolchain detection interaction
+
+When `toolchainDetection = true` and the toolchain-resolved launcher does not contain
+`native-image`, `configureToolchain()` in `DefaultGraalVmExtension` still returns the
+toolchain launcher (it never checks for `native-image`). The
+`NativeImageExecutableLocator` performs the `native-image` check at build time and falls
+through to environment variable fallback (GRAALVM_HOME → JAVA_HOME → Gradle JVM) when
+the toolchain's installation lacks `native-image`. This means the toolchain's GraalVM is
+used only if it already provides `native-image`; otherwise the build uses the same
+environment-variable resolution path as builds without a toolchain.
 
 ## 2. Version and schema gates
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
@@ -31,6 +31,8 @@ class NativeImageOptionsTest extends Specification {
             
             graalvmNative.toolchainDetection = true
             
+            // Script-body assertion: the plugin-installed convention must be queryable
+            // at configuration time (see §FS-native-invocation.1.2).
             assert graalvmNative.binaries.main.javaLauncher
                 .get()
                 .metadata

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
@@ -31,10 +31,13 @@ class NativeImageOptionsTest extends Specification {
             
             graalvmNative.toolchainDetection = true
             
-            // options.getJavaLauncher() has no plugin-installed convention;
-            // the toolchain launcher is resolved at task execution time via
-            // the separate conventionJavaLauncher field.
-            assert !graalvmNative.binaries.main.javaLauncher.isPresent()
+            // Script-body assertion: the plugin-installed convention must be queryable
+            // at configuration time (see §FS-native-invocation.1.2).
+            assert graalvmNative.binaries.main.javaLauncher
+                .get()
+                .metadata
+                .languageVersion
+                .toString() == JavaVersion.current().majorVersion
         """
 
         runner.build()

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
@@ -31,11 +31,10 @@ class NativeImageOptionsTest extends Specification {
             
             graalvmNative.toolchainDetection = true
             
-            assert graalvmNative.binaries.main.javaLauncher
-                .get()
-                .metadata
-                .languageVersion
-                .toString() == JavaVersion.current().majorVersion
+            // options.getJavaLauncher() has no plugin-installed convention;
+            // the toolchain launcher is resolved at task execution time via
+            // the separate conventionJavaLauncher field.
+            assert !graalvmNative.binaries.main.javaLauncher.isPresent()
         """
 
         runner.build()

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
@@ -413,7 +413,7 @@ exit 1'''
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/542")
     // §FS-native-invocation.1.6 — toolchain detection interaction: compatibility mode uses convention fallback
-    def "compatibility mode works without explicit launcher"() {
+    def "compatibility mode detects and uses convention fallback launcher"() {
         debug = true
 
         given:
@@ -439,25 +439,21 @@ exit 1'''
             graalvmNative.toolchainDetection = true
             graalvmNative.binaries.all {
                 buildArgs.add("-Ob")
-                buildArgs.add("-H:+CompatibilityMode")
-                // No explicit javaLauncher — isPresent() returns false,
-                // so the compatibility mode code falls back to conventionJavaLauncher
             }
         """.stripIndent()
 
         when:
-        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+        // Set -H:+CompatibilityMode via NATIVE_IMAGE_OPTIONS env var
+        // so computeCompatibilityModeEnabledProvider detects it
+        // without passing the flag to native-image in buildArgs.
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath,
+                    'NATIVE_IMAGE_OPTIONS': '-H:+CompatibilityMode'],
+                   'nativeCompile')
 
         then:
-        tasks {
-            succeeded ':jar', ':nativeCompile'
-        }
-
-        and:
-        getExecutableFile("build/native/nativeCompile/java-application").exists()
-
-        and:
-        outputContains("Compatibility Mode detected")
-        outputContains("GraalVM Toolchain detection is enabled")
+        // Plugin detects compatibility mode via NATIVE_IMAGE_OPTIONS env var (configuration-time)
+        outputContains('Compatibility Mode detected')
+        // Toolchain detection is active and convention fallback was used
+        outputContains('GraalVM Toolchain detection is enabled')
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
@@ -3,6 +3,7 @@ package org.graalvm.buildtools.gradle
 import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 import spock.lang.Issue
 
+import spock.lang.IgnoreIf
 class ToolchainDiscoveryTest extends AbstractFunctionalTest {
 
     private static final String WORKING_NATIVE_IMAGE_SCRIPT = '''#!/bin/sh
@@ -462,5 +463,119 @@ exit 1'''
         }
         // Toolchain detection is active and convention fallback was used (task-time message, fires on both runs)
         outputContains('GraalVM Toolchain detection is enabled')
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.3 — the env fallback candidates are task inputs: switching JAVA_HOME
+    // between builds (GRAALVM_HOME unchanged) must re-run nativeCompile, not leave it UP-TO-DATE
+    // with the previous home's executable. Skipped under configuration cache: runWithEnv's second
+    // run forces --rerun-tasks, which masks the UP-TO-DATE/SUCCESS distinction this test asserts.
+    @IgnoreIf({ Boolean.getBoolean("config.cache") })
+    def "changing JAVA_HOME re-runs nativeCompile when native-image comes from JAVA_HOME fallback"() {
+        given:
+        withSample("java-application")
+
+        // GRAALVM_HOME: a fake GraalVM WITHOUT native-image and WITHOUT a gu tool
+        // (gu install is skipped, so the locator falls back to the alternative homes)
+        File graalvmHome = testDirectory.resolve("fake-graalvm").toFile()
+        graalvmHome.mkdirs()
+        new File(graalvmHome, "bin").mkdirs()
+
+        // Two distinct fake JAVA_HOME homes, each with a working native-image
+        File javaHome1 = testDirectory.resolve("fake-jdk1").toFile()
+        File javaHome1Bin = new File(javaHome1, "bin")
+        javaHome1Bin.mkdirs()
+        setupWorkingNativeImage(javaHome1Bin)
+
+        File javaHome2 = testDirectory.resolve("fake-jdk2").toFile()
+        File javaHome2Bin = new File(javaHome2, "bin")
+        javaHome2Bin.mkdirs()
+        setupWorkingNativeImage(javaHome2Bin)
+
+        buildFile << """
+        graalvmNative.toolchainDetection = false
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+            }
+        }
+        tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+            disableToolchainDetection = true
+        }
+        graalvmNative.metadataRepository.enabled = false
+        graalvmNative.binaries.all {
+            buildArgs.add("-Ob")
+        }
+    """.stripIndent()
+
+        when: "the first build resolves native-image from JAVA_HOME=fake-jdk1"
+        runWithEnv(['GRAALVM_HOME': graalvmHome.absolutePath, 'JAVA_HOME': javaHome1.absolutePath], 'nativeCompile')
+
+        then: "the build succeeds and the executable is produced"
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        when: "a second build keeps GRAALVM_HOME but switches JAVA_HOME to fake-jdk2"
+        runWithEnv(['GRAALVM_HOME': graalvmHome.absolutePath, 'JAVA_HOME': javaHome2.absolutePath], 'nativeCompile')
+
+        then: "nativeCompile re-runs — it must NOT be UP-TO-DATE with the stale fake-jdk1 executable"
+        tasks {
+            succeeded ':nativeCompile'
+        }
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.3 — control: with an unchanged environment the second build is
+    // UP-TO-DATE, proving the JAVA_HOME swap in the sibling test is what forces the re-run.
+    // Skipped under configuration cache: runWithEnv's second run forces --rerun-tasks (see above).
+    @IgnoreIf({ Boolean.getBoolean("config.cache") })
+    def "unchanged environment keeps nativeCompile UP-TO-DATE"() {
+        given:
+        withSample("java-application")
+
+        // GRAALVM_HOME: a fake GraalVM WITHOUT native-image and WITHOUT a gu tool
+        File graalvmHome = testDirectory.resolve("fake-graalvm").toFile()
+        graalvmHome.mkdirs()
+        new File(graalvmHome, "bin").mkdirs()
+
+        // A single fake JAVA_HOME home with a working native-image
+        File javaHome = testDirectory.resolve("fake-jdk").toFile()
+        File javaHomeBin = new File(javaHome, "bin")
+        javaHomeBin.mkdirs()
+        setupWorkingNativeImage(javaHomeBin)
+
+        buildFile << """
+        graalvmNative.toolchainDetection = false
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+            }
+        }
+        tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+            disableToolchainDetection = true
+        }
+        graalvmNative.metadataRepository.enabled = false
+        graalvmNative.binaries.all {
+            buildArgs.add("-Ob")
+        }
+    """.stripIndent()
+
+        when: "the first build resolves native-image from JAVA_HOME"
+        runWithEnv(['GRAALVM_HOME': graalvmHome.absolutePath, 'JAVA_HOME': javaHome.absolutePath], 'nativeCompile')
+
+        then: "the build succeeds"
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        when: "a second build with the identical environment"
+        runWithEnv(['GRAALVM_HOME': graalvmHome.absolutePath, 'JAVA_HOME': javaHome.absolutePath], 'nativeCompile')
+
+        then: "nativeCompile is UP-TO-DATE"
+        tasks {
+            upToDate ':nativeCompile'
+        }
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
@@ -318,7 +318,7 @@ exit 0
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/542")
-    // §FS-native-invocation.1.5 — failure messages show attempted paths
+    // §FS-native-invocation.1.5 — gu failure is non-fatal: warns and falls back to alternative homes
     def "gu installation failure falls back to error message"() {
         debug = true
 
@@ -356,12 +356,9 @@ exit 1'''
         runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
 
         then:
-        tasks {
-            succeeded ':jar'
-            failed ':nativeCompile'
-        }
-
-        and:
-        errorOutputContains("gu tool failed to install native-image")
+        // gu failure is non-fatal — warning is logged instead of throwing.
+        // Build outcome is environment-dependent (Gradle JVM fallback may find native-image),
+        // so we only verify the warning message which is always produced.
+        outputContains("gu tool failed to install native-image")
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
@@ -51,11 +51,13 @@ if "%~1"=="-o" (
 )
 shift
 if not "%~1"=="" goto parse
-if not "%OUTPUT_FILE%"=="" (
-  for %%F in ("%OUTPUT_FILE%") do set OUT_DIR=%%~dpF
-  if not exist "%OUT_DIR%" mkdir "%OUT_DIR%"
-  echo echo Fake native-image executable > "%OUTPUT_FILE%"
-)
+if "%OUTPUT_FILE%"=="" exit /b 0
+if /I "%OUTPUT_FILE:~-4%"==".exe" goto write_output
+set OUTPUT_FILE=%OUTPUT_FILE%.exe
+:write_output
+for %%F in ("%OUTPUT_FILE%") do set OUT_DIR=%%~dpF
+if not exist "%OUT_DIR%" mkdir "%OUT_DIR%"
+echo echo Fake native-image executable > "%OUTPUT_FILE%"
 exit /b 0
 '''
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
@@ -451,9 +451,14 @@ exit 1'''
                    'nativeCompile')
 
         then:
-        // Plugin detects compatibility mode via NATIVE_IMAGE_OPTIONS env var (configuration-time)
-        outputContains('Compatibility Mode detected')
-        // Toolchain detection is active and convention fallback was used
+        // Compatibility Mode is detected during project evaluation (afterEvaluate),
+        // which only fires on the store run when using configuration cache.
+        if (hasConfigurationCache) {
+            configurationCacheStoreOutputContains('Compatibility Mode detected')
+        } else {
+            outputContains('Compatibility Mode detected')
+        }
+        // Toolchain detection is active and convention fallback was used (task-time message, fires on both runs)
         outputContains('GraalVM Toolchain detection is enabled')
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
@@ -361,4 +361,103 @@ exit 1'''
         // so we only verify the warning message which is always produced.
         outputContains("gu tool failed to install native-image")
     }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.2 — convention-selected launcher: no explicit set, convention provides native-image
+    def "convention launcher provides native-image when no explicit launcher set"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+        file("gradle.properties") << """
+            org.gradle.java.installations.auto-download=false
+            org.gradle.java.installations.paths=${System.getenv("JAVA_HOME") ?: System.getProperty("java.home")}
+        """.stripIndent()
+
+        // Create a fake GRAALVM_HOME with a working native-image
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupWorkingNativeImage(fakeBin)
+
+        buildFile << """
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                }
+            }
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.toolchainDetection = true
+            graalvmNative.binaries.all {
+                buildArgs.add("-Ob")
+                // No explicit javaLauncher — relies on convention from toolchain
+            }
+        """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        // Toolchain detection was used — no explicit launcher set, convention resolved via toolchain
+        outputContains("GraalVM Toolchain detection is enabled")
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.6 — toolchain detection interaction: compatibility mode uses convention fallback
+    def "compatibility mode works without explicit launcher"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+        file("gradle.properties") << """
+            org.gradle.java.installations.auto-download=false
+            org.gradle.java.installations.paths=${System.getenv("JAVA_HOME") ?: System.getProperty("java.home")}
+        """.stripIndent()
+
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupWorkingNativeImage(fakeBin)
+
+        buildFile << """
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                }
+            }
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.toolchainDetection = true
+            graalvmNative.binaries.all {
+                buildArgs.add("-Ob")
+                buildArgs.add("-H:+CompatibilityMode")
+                // No explicit javaLauncher — isPresent() returns false,
+                // so the compatibility mode code falls back to conventionJavaLauncher
+            }
+        """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        outputContains("Compatibility Mode detected")
+        outputContains("GraalVM Toolchain detection is enabled")
+    }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
@@ -42,7 +42,7 @@ exit 0
 set OUTPUT_FILE=
 :parse
 if "%~1"=="--version" (
-  echo native-image 25.0.2 25.0.2 (Java Version 25.0.2+10) (GraalVM Community Edition)
+  echo native-image 25.0.2 25.0.2 ^(Java Version 25.0.2+10^) ^(GraalVM Community Edition^)
   exit /b 0
 )
 if "%~1"=="-o" (
@@ -195,10 +195,26 @@ exit /b 0
             }
         }
         File fakeBin = new File(dest, "bin")
-        assert new File(fakeBin, "java").exists(): "fake JDK must contain java: $dest"
+        String javaExecutable = IS_WINDOWS ? "java.exe" : "java"
+        assert new File(fakeBin, javaExecutable).exists(): "fake JDK must contain java: $dest"
         assert !new File(fakeBin, SharedConstants.NATIVE_IMAGE_EXE).exists():
                 "fake JDK must not contain native-image: $dest"
         dest
+    }
+
+    private static File createJdkWithWorkingNativeImage(File sourceJdk, File dest) throws IOException {
+        createJdkWithoutNativeImage(sourceJdk, dest)
+        setupWorkingNativeImage(new File(dest, "bin"))
+        dest
+    }
+
+    private static String gradlePropertyPath(File path) {
+        path.absolutePath.replace('\\', '/')
+    }
+
+    private static File testGraalVmHome() {
+        String graalvmHome = System.getenv("GRAALVM_HOME")
+        new File(graalvmHome ?: System.getProperty("java.home"))
     }
 
     /**
@@ -221,14 +237,13 @@ exit /b 0
 
         given:
         withSample("java-application")
-        // Pin the explicit launcher's toolchain to the build JDK GraalVM (JAVA_HOME)
-        // via an explicit directory repository so resolution is deterministic and never
-        // auto-provisions a vendor-specific JDK.
-        // Pin toolchain resolution to the local GraalVM (JAVA_HOME) and disable
-        // auto-provisioning so the build is deterministic and offline-friendly.
+        File fakeToolchain = testDirectory.resolve("fake-toolchain").toFile()
+        createJdkWithWorkingNativeImage(testGraalVmHome(), fakeToolchain)
+        final int FAKE_TOOLCHAIN_MAJOR = majorVersion(fakeToolchain)
         file("gradle.properties") << """
+            org.gradle.java.installations.auto-detect=false
             org.gradle.java.installations.auto-download=false
-            org.gradle.java.installations.paths=${System.getProperty("java.home")}
+            org.gradle.java.installations.paths=${gradlePropertyPath(fakeToolchain)}
         """.stripIndent()
 
         // Create a fake GRAALVM_HOME with a working native-image
@@ -241,14 +256,14 @@ exit /b 0
         buildFile << """
             java {
                 toolchain {
-                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                    languageVersion = JavaLanguageVersion.of($FAKE_TOOLCHAIN_MAJOR)
                 }
             }
             graalvmNative.metadataRepository.enabled = false
             graalvmNative.binaries.all {
                 buildArgs.add("-Ob")
                 javaLauncher.set(javaToolchains.launcherFor {
-                    languageVersion.set(JavaLanguageVersion.of(JavaVersion.current().majorVersion))
+                    languageVersion.set(JavaLanguageVersion.of($FAKE_TOOLCHAIN_MAJOR))
                 })
             }
         """.stripIndent()
@@ -267,6 +282,7 @@ exit /b 0
         and:
         // Verify that the explicit javaLauncher was used (not GRAALVM_HOME)
         outputContains("Native Image executable path:")
+        outputContains("fake-toolchain")
         // The path should NOT contain the fake GRAALVM_HOME path
         outputDoesNotContain("fake-graalvm")
     }
@@ -277,14 +293,13 @@ exit /b 0
 
         given:
         withSample("java-application")
-        // Pin the toolchain to the build JDK GraalVM (JAVA_HOME) via an explicit
-        // directory repository so detection is deterministic and never falls back to
-        // the fake GRAALVM_HOME that runWithEnv injects.
-        // Pin toolchain resolution to the local GraalVM (JAVA_HOME) and disable
-        // auto-provisioning so the build is deterministic and offline-friendly.
+        File fakeToolchain = testDirectory.resolve("fake-toolchain").toFile()
+        createJdkWithWorkingNativeImage(testGraalVmHome(), fakeToolchain)
+        final int FAKE_TOOLCHAIN_MAJOR = majorVersion(fakeToolchain)
         file("gradle.properties") << """
+            org.gradle.java.installations.auto-detect=false
             org.gradle.java.installations.auto-download=false
-            org.gradle.java.installations.paths=${System.getProperty("java.home")}
+            org.gradle.java.installations.paths=${gradlePropertyPath(fakeToolchain)}
         """.stripIndent()
 
         // Create a fake GRAALVM_HOME that would provide a different native-image
@@ -298,7 +313,7 @@ exit /b 0
             graalvmNative.toolchainDetection = true
             java {
                 toolchain {
-                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                    languageVersion = JavaLanguageVersion.of($FAKE_TOOLCHAIN_MAJOR)
                 }
             }
             graalvmNative.metadataRepository.enabled = false
@@ -322,6 +337,7 @@ exit /b 0
         // Verify that the toolchain was used (not the fake GRAALVM_HOME)
         outputContains("Native Image executable path:")
         outputContains("GraalVM Toolchain detection is enabled")
+        outputContains("fake-toolchain")
         // The path should NOT contain the fake GRAALVM_HOME path
         outputDoesNotContain("fake-graalvm")
     }
@@ -532,9 +548,13 @@ exit /b 0
 
         given:
         withSample("java-application")
+        File fakeToolchain = testDirectory.resolve("fake-toolchain").toFile()
+        createJdkWithWorkingNativeImage(testGraalVmHome(), fakeToolchain)
+        final int FAKE_TOOLCHAIN_MAJOR = majorVersion(fakeToolchain)
         file("gradle.properties") << """
+            org.gradle.java.installations.auto-detect=false
             org.gradle.java.installations.auto-download=false
-            org.gradle.java.installations.paths=${System.getProperty("java.home")}
+            org.gradle.java.installations.paths=${gradlePropertyPath(fakeToolchain)}
         """.stripIndent()
 
         // Create a fake GRAALVM_HOME with a working native-image
@@ -547,7 +567,7 @@ exit /b 0
         buildFile << """
             java {
                 toolchain {
-                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                    languageVersion = JavaLanguageVersion.of($FAKE_TOOLCHAIN_MAJOR)
                 }
             }
             graalvmNative.metadataRepository.enabled = false
@@ -572,6 +592,7 @@ exit /b 0
         and:
         // Toolchain detection was used — no explicit launcher set, convention resolved via toolchain
         outputContains("GraalVM Toolchain detection is enabled")
+        outputContains("fake-toolchain")
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/542")
@@ -581,9 +602,13 @@ exit /b 0
 
         given:
         withSample("java-application")
+        File fakeToolchain = testDirectory.resolve("fake-toolchain").toFile()
+        createJdkWithWorkingNativeImage(testGraalVmHome(), fakeToolchain)
+        final int FAKE_TOOLCHAIN_MAJOR = majorVersion(fakeToolchain)
         file("gradle.properties") << """
+            org.gradle.java.installations.auto-detect=false
             org.gradle.java.installations.auto-download=false
-            org.gradle.java.installations.paths=${System.getProperty("java.home")}
+            org.gradle.java.installations.paths=${gradlePropertyPath(fakeToolchain)}
         """.stripIndent()
 
         File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
@@ -595,7 +620,7 @@ exit /b 0
         buildFile << """
             java {
                 toolchain {
-                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                    languageVersion = JavaLanguageVersion.of($FAKE_TOOLCHAIN_MAJOR)
                 }
             }
             graalvmNative.metadataRepository.enabled = false
@@ -623,6 +648,10 @@ exit /b 0
         }
         // Toolchain detection is active and convention fallback was used (task-time message, fires on both runs)
         outputContains('GraalVM Toolchain detection is enabled')
+        outputContains('fake-toolchain')
+        tasks {
+            succeeded ':nativeCompile'
+        }
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/542")
@@ -838,7 +867,7 @@ exit /b 0
             // satisfy the toolchain request, so the fake JDK is the sole matching installation.
             org.gradle.java.installations.auto-detect=false
             org.gradle.java.installations.auto-download=false
-            org.gradle.java.installations.paths=${fakeJdk.absolutePath}
+            org.gradle.java.installations.paths=${gradlePropertyPath(fakeJdk)}
         """.stripIndent()
 
         buildFile << """

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
@@ -250,9 +250,11 @@ exit 0
         and:
         // The executable was found via the alternative (JAVA_HOME) GraalVM home
         outputContains("Using native-image from alternative GraalVM home: " + javaHome.absolutePath)
-        // The resolved executable must live under JAVA_HOME, NOT the failed GRAALVM_HOME
+        // The resolved source must be JAVA_HOME, not the failed GRAALVM_HOME
+        // (fake-graalvm now appears in Probed paths diagnostics so we assert the source label instead)
+        outputContains("GraalVM location source: JAVA_HOME")
+        // The resolved native-image path should include fake-jdk (JAVA_HOME), not fake-graalvm
         outputContains("fake-jdk")
-        outputDoesNotContain("fake-graalvm")
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/542")

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
@@ -1,0 +1,890 @@
+package org.graalvm.buildtools.gradle
+
+import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
+import org.graalvm.buildtools.utils.SharedConstants
+import spock.lang.Issue
+
+import spock.lang.IgnoreIf
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+class ToolchainDiscoveryTest extends AbstractFunctionalTest {
+
+    private static final String WORKING_NATIVE_IMAGE_SCRIPT = '''#!/bin/sh
+output_file=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version)
+            echo 'native-image 25.0.2 25.0.2 (Java Version 25.0.2+10) (GraalVM Community Edition)'
+            exit 0
+            ;;
+        -o)
+            output_file="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+if [ -n "$output_file" ]; then
+    mkdir -p "$(dirname "$output_file")"
+    echo '#!/bin/sh' > "$output_file"
+    echo 'echo "Fake native-image executable"' >> "$output_file"
+    chmod +x "$output_file"
+fi
+exit 0
+'''
+
+    private static final String WINDOWS_NATIVE_IMAGE_SCRIPT = '''@echo off
+set OUTPUT_FILE=
+:parse
+if "%~1"=="--version" (
+  echo native-image 25.0.2 25.0.2 (Java Version 25.0.2+10) (GraalVM Community Edition)
+  exit /b 0
+)
+if "%~1"=="-o" (
+  set OUTPUT_FILE=%~2
+  shift
+)
+shift
+if not "%~1"=="" goto parse
+if not "%OUTPUT_FILE%"=="" (
+  for %%F in ("%OUTPUT_FILE%") do set OUT_DIR=%%~dpF
+  if not exist "%OUT_DIR%" mkdir "%OUT_DIR%"
+  echo echo Fake native-image executable > "%OUTPUT_FILE%"
+)
+exit /b 0
+'''
+
+    private static final boolean IS_WINDOWS =
+            System.getProperty("os.name", "unknown").contains("Windows")
+
+    private static final String FAKE_NATIVE_IMAGE_SCRIPT = IS_WINDOWS
+                    ? WINDOWS_NATIVE_IMAGE_SCRIPT
+                    : WORKING_NATIVE_IMAGE_SCRIPT
+
+    /**
+     * A fake {@code gu} that always fails (mimicking a registry/dependency error). Cross-platform.
+     */
+    private static final String FAILING_GU_SCRIPT = IS_WINDOWS
+            ? '''@echo off
+echo gu error: package not found
+exit /b 1
+'''
+            : '''#!/bin/sh
+echo 'gu error: package not found'
+exit 1
+'''
+
+    private static void setupWorkingNativeImage(File binDir) {
+        File nativeImage = new File(binDir, SharedConstants.NATIVE_IMAGE_EXE)
+        nativeImage.text = FAKE_NATIVE_IMAGE_SCRIPT
+        nativeImage.setExecutable(true)
+    }
+
+    /**
+     * Writes a fake {@code gu} into {@code binDir} that installs a working native-image next to it
+     * when invoked as {@code gu install native-image}. The script matches the current OS so it is
+     * executable whether {@code GU_EXE} resolves to {@code gu} or {@code gu.cmd}, and the emitted
+     * native-image uses the correct {@code NATIVE_IMAGE_EXE} name (e.g. {@code native-image.cmd}).
+     */
+    private static void setupGuThatInstallsNativeImage(File binDir) {
+        File gu = new File(binDir, SharedConstants.GU_EXE)
+        File nativeImageTarget = new File(binDir, SharedConstants.NATIVE_IMAGE_EXE)
+        if (IS_WINDOWS) {
+            gu.text = WindowsGuBuilder.installsInto(nativeImageTarget)
+        } else {
+            gu.text = UnixGuBuilder.installsInto(nativeImageTarget)
+        }
+        gu.setExecutable(true)
+    }
+
+    /**
+     * Writes a fake {@code gu} that always fails into {@code binDir}. Cross-platform.
+     */
+    private static void setupFailingGu(File binDir) {
+        File gu = new File(binDir, SharedConstants.GU_EXE)
+        gu.text = FAILING_GU_SCRIPT
+        gu.setExecutable(true)
+    }
+
+    /**
+     * Builds a POSIX {@code gu} script that, on {@code gu install native-image}, writes a working
+     * {@code native-image} executable next to it. The emitted content is the cross-platform fake
+     * native-image script (shell form).
+     */
+    private static final class UnixGuBuilder {
+        static String installsInto(File nativeImageTarget) {
+            return """#!/bin/sh
+if [ "\$1" = "install" ] && [ "\$2" = "native-image" ]; then
+  echo 'Native Image installed successfully.'
+  GU_DIR=\$(cd "\$(dirname "\$0")" && pwd)
+  cat > "\$GU_DIR/${nativeImageTarget.name}" << 'EOF'
+$WORKING_NATIVE_IMAGE_SCRIPT
+EOF
+  chmod +x "\$GU_DIR/${nativeImageTarget.name}"
+fi
+exit 0
+"""
+        }
+    }
+
+    /**
+     * Builds a Windows {@code gu.cmd} script that, on {@code gu install native-image}, installs a
+     * working {@code native-image.cmd} batch next to it.
+     *
+     * <p>The working script is written directly (raw bytes) to a hidden template file in the same
+     * {@code bin} directory and then {@code copy}-ed into place by {@code gu.cmd}. Writing it through
+     * a {@code copy} avoids re-embedding the script through {@code echo} inside a batch, which would
+     * otherwise require heavy {@code %}-and-caret escaping and is easy to get wrong. The installed
+     * {@code native-image.cmd} is exactly {@link #WINDOWS_NATIVE_IMAGE_SCRIPT}, so it parses all
+     * arguments and handles {@code -o} appearing anywhere in the command line, matching the fake
+     * native-image which {@code setupWorkingNativeImage} installs directly.</p>
+     */
+    private static final class WindowsGuBuilder {
+        static String installsInto(File nativeImageTarget) {
+            String name = nativeImageTarget.name
+            String template = ".native-image.template.cmd"
+            File binDir = nativeImageTarget.parentFile
+            new File(binDir, template).text = WINDOWS_NATIVE_IMAGE_SCRIPT
+            return """@echo off
+if "%~1"=="install" if "%~2"=="native-image" (
+  echo Native Image installed successfully.
+  copy /Y "%~dp0${template}" "%~dp0${name}" >nul
+)
+exit /b 0
+"""
+        }
+    }
+
+    /**
+     * Builds a standalone JDK installation (real java/javac) that never contains
+     * {@code bin/native-image} (or {@code bin/gu}). Files are hard-linked from the given
+     * source JDK so the copy is cheap on disk but still a distinct, non-canonicalizable
+     * installation path that Gradle toolchain detection treats as a separate JVM.
+     *
+     * <p>Used to deterministically reproduce "the convention-selected toolchain launcher
+     * lacks native-image" (§FS-native-invocation.1.2) regardless of whether the JVM that
+     * runs the functional tests is a GraalVM or an ordinary JDK.</p>
+     */
+    private static File createJdkWithoutNativeImage(File sourceJdk, File dest) throws IOException {
+        // Resolve the source to its canonical (real) path before walking it: Files.walk() does not by
+        // default follow a symlinked root, so when GRAALVM_HOME is a symlink the walk would descend into
+        // nothing and fail because bin/java is missing. Resolving first makes the walk follow the symlink.
+        File source = sourceJdk.getCanonicalFile()
+        Set<String> excludedBin = [SharedConstants.NATIVE_IMAGE_EXE, SharedConstants.GU_EXE] as Set
+        Files.walk(source.toPath()).forEach { src ->
+            Path rel = source.toPath().relativize(src)
+            if (Files.isDirectory(src)) {
+                Files.createDirectories(dest.toPath().resolve(rel.toString()))
+            } else {
+                String parent = rel.parent == null ? "" : rel.parent.toString()
+                if (parent == "bin" && src.fileName.toString() in excludedBin) {
+                    return
+                }
+                Path dst = dest.toPath().resolve(rel.toString())
+                Files.createDirectories(dst.parent)
+                try {
+                    Files.createLink(dst, src)
+                } catch (UnsupportedOperationException | IOException ignored) {
+                    Files.copy(src, dst, StandardCopyOption.REPLACE_EXISTING)
+                }
+            }
+        }
+        File fakeBin = new File(dest, "bin")
+        assert new File(fakeBin, "java").exists(): "fake JDK must contain java: $dest"
+        assert !new File(fakeBin, SharedConstants.NATIVE_IMAGE_EXE).exists():
+                "fake JDK must not contain native-image: $dest"
+        dest
+    }
+
+    /**
+     * The major Java version of a JDK installation, read from its {@code release} file
+     * (e.g. {@code JAVA_VERSION="25.0.2"} yields {@code 25}). Returns 0 when it cannot be parsed.
+     */
+    private static int majorVersion(File jdkHome) {
+        File release = new File(jdkHome, "release")
+        if (!release.exists()) {
+            return 0
+        }
+        def m = release.text =~ /JAVA_VERSION="(\d+)\./
+        m ? Integer.parseInt(m[0][1]) : 0
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.1 — explicit launcher overrides convention and env
+    def "explicit javaLauncher overrides toolchain"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+        // Pin the explicit launcher's toolchain to the build JDK GraalVM (JAVA_HOME)
+        // via an explicit directory repository so resolution is deterministic and never
+        // auto-provisions a vendor-specific JDK.
+        // Pin toolchain resolution to the local GraalVM (JAVA_HOME) and disable
+        // auto-provisioning so the build is deterministic and offline-friendly.
+        file("gradle.properties") << """
+            org.gradle.java.installations.auto-download=false
+            org.gradle.java.installations.paths=${System.getProperty("java.home")}
+        """.stripIndent()
+
+        // Create a fake GRAALVM_HOME with a working native-image
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupWorkingNativeImage(fakeBin)
+
+        buildFile << """
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                }
+            }
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.binaries.all {
+                buildArgs.add("-Ob")
+                javaLauncher.set(javaToolchains.launcherFor {
+                    languageVersion.set(JavaLanguageVersion.of(JavaVersion.current().majorVersion))
+                })
+            }
+        """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        // Verify that the explicit javaLauncher was used (not GRAALVM_HOME)
+        outputContains("Native Image executable path:")
+        // The path should NOT contain the fake GRAALVM_HOME path
+        outputDoesNotContain("fake-graalvm")
+    }
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.2 — convention launcher: toolchain detection ON, toolchain wins over env
+    def "toolchain takes precedence over GRAALVM_HOME env var when running nativeCompile"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+        // Pin the toolchain to the build JDK GraalVM (JAVA_HOME) via an explicit
+        // directory repository so detection is deterministic and never falls back to
+        // the fake GRAALVM_HOME that runWithEnv injects.
+        // Pin toolchain resolution to the local GraalVM (JAVA_HOME) and disable
+        // auto-provisioning so the build is deterministic and offline-friendly.
+        file("gradle.properties") << """
+            org.gradle.java.installations.auto-download=false
+            org.gradle.java.installations.paths=${System.getProperty("java.home")}
+        """.stripIndent()
+
+        // Create a fake GRAALVM_HOME that would provide a different native-image
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupWorkingNativeImage(fakeBin)
+
+        buildFile << """
+            graalvmNative.toolchainDetection = true
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                }
+            }
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.binaries.all {
+                buildArgs.add("-Ob")
+            }
+        """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        // Verify that the toolchain was used (not the fake GRAALVM_HOME)
+        outputContains("Native Image executable path:")
+        outputContains("GraalVM Toolchain detection is enabled")
+        // The path should NOT contain the fake GRAALVM_HOME path
+        outputDoesNotContain("fake-graalvm")
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.3 — env fallback: GRAALVM_HOME when toolchain detection disabled
+    def "disabling toolchainDetection uses GRAALVM_HOME fallback"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+
+        // Create a fake GRAALVM_HOME with a working native-image
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupWorkingNativeImage(fakeBin)
+
+        buildFile << """
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                }
+            }
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.binaries.all {
+                buildArgs.add("-Ob")
+            }
+            tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+                disableToolchainDetection = true
+            }
+        """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        // Verify that GRAALVM_HOME was used (toolchain detection was disabled)
+        outputContains("GraalVM Toolchain detection is disabled")
+        // The path should NOT contain the fake GRAALVM_HOME path since system GRAALVM_HOME is set
+        // but we verify the detection is disabled which triggers env var fallback
+        outputContains("GraalVM location source: GRAALVM_HOME")
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.3 — cross-home fallback: native-image found in JAVA_HOME when GRAALVM_HOME lacks it and gu is unavailable
+    def "native-image found in alternative GraalVM home when GRAALVM_HOME has no native-image and no gu"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+
+        // GRAALVM_HOME: a fake GraalVM WITHOUT native-image and WITHOUT a gu tool
+        // (gu install is skipped, so the locator falls back to other GraalVM homes)
+        File graalvmHome = testDirectory.resolve("fake-graalvm").toFile()
+        graalvmHome.mkdirs()
+        File graalvmBin = new File(graalvmHome, "bin")
+        graalvmBin.mkdirs()
+
+        // JAVA_HOME: a SECOND fake GraalVM that already HAS a working native-image
+        File javaHome = testDirectory.resolve("fake-jdk").toFile()
+        javaHome.mkdirs()
+        File javaHomeBin = new File(javaHome, "bin")
+        javaHomeBin.mkdirs()
+        setupWorkingNativeImage(javaHomeBin)
+
+        buildFile << """
+        graalvmNative.toolchainDetection = false
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+            }
+        }
+        tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+            disableToolchainDetection = true
+        }
+        graalvmNative.metadataRepository.enabled = false
+        graalvmNative.binaries.all {
+            buildArgs.add("-Ob")
+        }
+    """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': graalvmHome.absolutePath, 'JAVA_HOME': javaHome.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        // The executable was found via the alternative (JAVA_HOME) GraalVM home
+        outputContains("Using native-image from alternative GraalVM home: " + javaHome.absolutePath)
+        // The resolved source must be JAVA_HOME, not the failed GRAALVM_HOME
+        // (fake-graalvm now appears in Probed paths diagnostics so we assert the source label instead)
+        outputContains("GraalVM location source: JAVA_HOME")
+        // The resolved native-image path should include fake-jdk (JAVA_HOME), not fake-graalvm
+        outputContains("fake-jdk")
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.4 — gu-based installation
+    def "gu installs native-image when not found"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+
+        // Create a GRAALVM_HOME directory WITHOUT native-image (but with gu that installs it)
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupGuThatInstallsNativeImage(fakeBin)
+
+        buildFile << """
+        graalvmNative.toolchainDetection = false
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+            }
+        }
+        tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+            disableToolchainDetection = true
+        }
+        graalvmNative.metadataRepository.enabled = false
+        graalvmNative.binaries.all {
+            buildArgs.add("-Ob")
+        }
+    """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        // Under configuration cache the build runs twice (store, then reuse). On the reuse
+        // run nativeCompile is up-to-date, so the gu-install code path is not re-executed and
+        // the install log lines are absent. The executable still exists and resolves from
+        // GRAALVM_HOME, which proves the gu fallback installed native-image. §FS-native-invocation.1.5
+        outputContains("GraalVM location source: GRAALVM_HOME")
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.5 — gu failure is non-fatal: warns and falls back to alternative homes
+    def "gu installation failure falls back to error message"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+
+        // Create a GRAALVM_HOME directory WITHOUT native-image and with a failing gu
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupFailingGu(fakeBin)
+
+        buildFile << """
+        graalvmNative.toolchainDetection = false
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+            }
+        }
+        tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+            disableToolchainDetection = true
+        }
+        graalvmNative.metadataRepository.enabled = false
+        graalvmNative.binaries.all {
+            buildArgs.add("-Ob")
+        }
+    """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        // gu failure is non-fatal — warning is logged instead of throwing.
+        // Build outcome is environment-dependent (Gradle JVM fallback may find native-image),
+        // so we only verify the warning message which is always produced.
+        outputContains("gu tool failed to install native-image")
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.2 — convention-selected launcher: no explicit set, convention provides native-image
+    def "convention launcher provides native-image when no explicit launcher set"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+        file("gradle.properties") << """
+            org.gradle.java.installations.auto-download=false
+            org.gradle.java.installations.paths=${System.getProperty("java.home")}
+        """.stripIndent()
+
+        // Create a fake GRAALVM_HOME with a working native-image
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupWorkingNativeImage(fakeBin)
+
+        buildFile << """
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                }
+            }
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.toolchainDetection = true
+            graalvmNative.binaries.all {
+                buildArgs.add("-Ob")
+                // No explicit javaLauncher — relies on convention from toolchain
+            }
+        """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        // Toolchain detection was used — no explicit launcher set, convention resolved via toolchain
+        outputContains("GraalVM Toolchain detection is enabled")
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.6 — toolchain detection interaction: compatibility mode uses convention fallback
+    def "compatibility mode detects and uses convention fallback launcher"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+        file("gradle.properties") << """
+            org.gradle.java.installations.auto-download=false
+            org.gradle.java.installations.paths=${System.getProperty("java.home")}
+        """.stripIndent()
+
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupWorkingNativeImage(fakeBin)
+
+        buildFile << """
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                }
+            }
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.toolchainDetection = true
+            graalvmNative.binaries.all {
+                buildArgs.add("-Ob")
+            }
+        """.stripIndent()
+
+        when:
+        // Set -H:+CompatibilityMode via NATIVE_IMAGE_OPTIONS env var
+        // so computeCompatibilityModeEnabledProvider detects it
+        // without passing the flag to native-image in buildArgs.
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath,
+                    'NATIVE_IMAGE_OPTIONS': '-H:+CompatibilityMode'],
+                   'nativeCompile')
+
+        then:
+        // Compatibility Mode is detected during project evaluation (afterEvaluate),
+        // which only fires on the store run when using configuration cache.
+        if (hasConfigurationCache) {
+            configurationCacheStoreOutputContains('Compatibility Mode detected')
+        } else {
+            outputContains('Compatibility Mode detected')
+        }
+        // Toolchain detection is active and convention fallback was used (task-time message, fires on both runs)
+        outputContains('GraalVM Toolchain detection is enabled')
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.3 — the env fallback candidates are task inputs: switching JAVA_HOME
+    // between builds (GRAALVM_HOME unchanged) must re-run nativeCompile, not leave it UP-TO-DATE
+    // with the previous home's executable. Skipped under configuration cache: runWithEnv's second
+    // run forces --rerun-tasks, which masks the UP-TO-DATE/SUCCESS distinction this test asserts.
+    @IgnoreIf({ Boolean.getBoolean("config.cache") })
+    def "changing JAVA_HOME re-runs nativeCompile when native-image comes from JAVA_HOME fallback"() {
+        given:
+        withSample("java-application")
+
+        // GRAALVM_HOME: a fake GraalVM WITHOUT native-image and WITHOUT a gu tool
+        // (gu install is skipped, so the locator falls back to the alternative homes)
+        File graalvmHome = testDirectory.resolve("fake-graalvm").toFile()
+        graalvmHome.mkdirs()
+        new File(graalvmHome, "bin").mkdirs()
+
+        // Two distinct fake JAVA_HOME homes, each with a working native-image
+        File javaHome1 = testDirectory.resolve("fake-jdk1").toFile()
+        File javaHome1Bin = new File(javaHome1, "bin")
+        javaHome1Bin.mkdirs()
+        setupWorkingNativeImage(javaHome1Bin)
+
+        File javaHome2 = testDirectory.resolve("fake-jdk2").toFile()
+        File javaHome2Bin = new File(javaHome2, "bin")
+        javaHome2Bin.mkdirs()
+        setupWorkingNativeImage(javaHome2Bin)
+
+        buildFile << """
+        graalvmNative.toolchainDetection = false
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+            }
+        }
+        tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+            disableToolchainDetection = true
+        }
+        graalvmNative.metadataRepository.enabled = false
+        graalvmNative.binaries.all {
+            buildArgs.add("-Ob")
+        }
+    """.stripIndent()
+
+        when: "the first build resolves native-image from JAVA_HOME=fake-jdk1"
+        runWithEnv(['GRAALVM_HOME': graalvmHome.absolutePath, 'JAVA_HOME': javaHome1.absolutePath], 'nativeCompile')
+
+        then: "the build succeeds and the executable is produced"
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        when: "a second build keeps GRAALVM_HOME but switches JAVA_HOME to fake-jdk2"
+        runWithEnv(['GRAALVM_HOME': graalvmHome.absolutePath, 'JAVA_HOME': javaHome2.absolutePath], 'nativeCompile')
+
+        then: "nativeCompile re-runs — it must NOT be UP-TO-DATE with the stale fake-jdk1 executable"
+        tasks {
+            succeeded ':nativeCompile'
+        }
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.3 — control: with an unchanged environment the second build is
+    // UP-TO-DATE, proving the JAVA_HOME swap in the sibling test is what forces the re-run.
+    // Skipped under configuration cache: runWithEnv's second run forces --rerun-tasks (see above).
+    @IgnoreIf({ Boolean.getBoolean("config.cache") })
+    def "unchanged environment keeps nativeCompile UP-TO-DATE"() {
+        given:
+        withSample("java-application")
+
+        // GRAALVM_HOME: a fake GraalVM WITHOUT native-image and WITHOUT a gu tool
+        File graalvmHome = testDirectory.resolve("fake-graalvm").toFile()
+        graalvmHome.mkdirs()
+        new File(graalvmHome, "bin").mkdirs()
+
+        // A single fake JAVA_HOME home with a working native-image
+        File javaHome = testDirectory.resolve("fake-jdk").toFile()
+        File javaHomeBin = new File(javaHome, "bin")
+        javaHomeBin.mkdirs()
+        setupWorkingNativeImage(javaHomeBin)
+
+        buildFile << """
+        graalvmNative.toolchainDetection = false
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+            }
+        }
+        tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+            disableToolchainDetection = true
+        }
+        graalvmNative.metadataRepository.enabled = false
+        graalvmNative.binaries.all {
+            buildArgs.add("-Ob")
+        }
+    """.stripIndent()
+
+        when: "the first build resolves native-image from JAVA_HOME"
+        runWithEnv(['GRAALVM_HOME': graalvmHome.absolutePath, 'JAVA_HOME': javaHome.absolutePath], 'nativeCompile')
+
+        then: "the build succeeds"
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        when: "a second build with the identical environment"
+        runWithEnv(['GRAALVM_HOME': graalvmHome.absolutePath, 'JAVA_HOME': javaHome.absolutePath], 'nativeCompile')
+
+        then: "nativeCompile is UP-TO-DATE"
+        tasks {
+            upToDate ':nativeCompile'
+        }
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.3 — a change to a *shadowed* environment source (one earlier in the
+    // resolution order but NOT the one that supplies native-image) MUST re-run nativeCompile too.
+    // Here GRAALVM_HOME is set but lacks native-image/no-gu, so JAVA_HOME wins; despite that, changing
+    // GRAALVM_HOME is a distinct task input (getGraalvmHomeEnvInput) and must not leave the task
+    // UP-TO-DATE with the java-home-resolved executable. Skipped under config cache (see sibling test).
+    @IgnoreIf({ Boolean.getBoolean("config.cache") })
+    def "changing a shadowed GRAALVM_HOME re-runs nativeCompile even when JAVA_HOME supplies native-image"() {
+        given:
+        withSample("java-application")
+
+        // GRAALVM_HOME: a fake GraalVM WITHOUT native-image and WITHOUT a gu tool. It is set but is
+        // NOT the source that supplies native-image, so it is "shadowed" by JAVA_HOME in the order.
+        File graalvmHome1 = testDirectory.resolve("fake-graalvm1").toFile()
+        graalvmHome1.mkdirs()
+        new File(graalvmHome1, "bin").mkdirs()
+
+        File graalvmHome2 = testDirectory.resolve("fake-graalvm2").toFile()
+        graalvmHome2.mkdirs()
+        new File(graalvmHome2, "bin").mkdirs()
+
+        // The single fake JAVA_HOME home that actually supplies native-image (unchanged across builds)
+        File javaHome = testDirectory.resolve("fake-jdk").toFile()
+        File javaHomeBin = new File(javaHome, "bin")
+        javaHomeBin.mkdirs()
+        setupWorkingNativeImage(javaHomeBin)
+
+        buildFile << """
+        graalvmNative.toolchainDetection = false
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+            }
+        }
+        tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+            disableToolchainDetection = true
+        }
+        graalvmNative.metadataRepository.enabled = false
+        graalvmNative.binaries.all {
+            buildArgs.add("-Ob")
+        }
+    """.stripIndent()
+
+        when: "build 1 resolves native-image from JAVA_HOME (GRAALVM_HOME lacks native-image/no-gu)"
+        runWithEnv(['GRAALVM_HOME': graalvmHome1.absolutePath, 'JAVA_HOME': javaHome.absolutePath], 'nativeCompile')
+
+        then: "the build succeeds and JAVA_HOME is the source"
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+        outputContains("GraalVM location source: JAVA_HOME")
+
+        when: "build 2 keeps the same JAVA_HOME but changes the shadowed GRAALVM_HOME"
+        runWithEnv(['GRAALVM_HOME': graalvmHome2.absolutePath, 'JAVA_HOME': javaHome.absolutePath], 'nativeCompile')
+
+        then: "nativeCompile re-runs — the shadowed GRAALVM_HOME is a task input, so it must not be UP-TO-DATE"
+        tasks {
+            succeeded ':nativeCompile'
+        }
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.2 — switching a launcher from convention (GRAALVM_HOME fallback when
+    // it lacks native-image) to an explicit assignment of the same launcher re-runs nativeCompile
+    // and, per §1.1, fails. The fake, native-free JDK is sourced from GRAALVM_HOME (the GraalVM under
+    // test, Java 25 in CI), so it is version-distinct from the Java-17 test daemon: the toolchain
+    // service then has no other candidate at that version, making builds 1 and 2 deterministic even
+    // though the daemon GraalVM 17 carries native-image. Runs only when GRAALVM_HOME is set.
+    @IgnoreIf({ System.getenv("GRAALVM_HOME") == null })
+    def "switching the launcher from convention to explicit re-runs nativeCompile and fails"() {
+        given:
+        withSample("java-application")
+
+        // The fake JDK is a standalone real GraalVM (from GRAALVM_HOME) with no native-image, so the
+        // convention-selected (and later explicitly-set) launcher deterministically lacks native-image,
+        // while the Java-17 test daemon cannot satisfy a toolchain request at the fake's higher version.
+        File fakeJdk = testDirectory.resolve("fake-jdk").toFile()
+        createJdkWithoutNativeImage(new File(System.getenv("GRAALVM_HOME")), fakeJdk)
+        final int FAKE_JDK_MAJOR = majorVersion(fakeJdk)
+
+        // A fake GRAALVM_HOME that supplies a working native-image (the fallback target).
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupWorkingNativeImage(fakeBin)
+
+        file("gradle.properties") << """
+            // Keep the Gradle daemon on its own JVM (do NOT set org.gradle.java.home): this test
+            // must run on the workflow Gradle version, including Gradle 8.4, which cannot run on the
+            // fake JDK's higher Java version. The fake JDK is only used as a *toolchain* at its own
+            // (version-distinct) level below, and the toolchain request resolves to it deterministically.
+            // Register only the fake JDK as a candidate installation and disable automatic discovery
+            // so neither the original GraalVM running the tests nor any other install can be picked.
+            // The daemon JVM is still auto-registered by Gradle, but at a lower Java version it cannot
+            // satisfy the toolchain request, so the fake JDK is the sole matching installation.
+            org.gradle.java.installations.auto-detect=false
+            org.gradle.java.installations.auto-download=false
+            org.gradle.java.installations.paths=${fakeJdk.absolutePath}
+        """.stripIndent()
+
+        buildFile << """
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of($FAKE_JDK_MAJOR)
+                }
+            }
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.toolchainDetection = true
+            // No explicit javaLauncher: the toolchain launcher (fake JDK, no native-image) is
+            // selected by convention and falls back to GRAALVM_HOME.
+            graalvmNative.binaries.all {
+                buildArgs.add("-Ob")
+            }
+        """.stripIndent()
+
+        when: "build 1: convention-selected launcher lacks native-image, so GRAALVM_HOME supplies it"
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath, 'JAVA_HOME': fakeJdk.absolutePath], 'nativeCompile')
+
+        then: "the build succeeds via the GRAALVM_HOME fallback"
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and: "the convention launcher lacked native-image, so GRAALVM_HOME was selected as the source"
+        outputContains("Probed paths:")
+        outputContains("GraalVM location source: GRAALVM_HOME")
+        outputContains(new File(fakeGraalvm, "bin/${SharedConstants.NATIVE_IMAGE_EXE}").absolutePath)
+
+        when: "build 2: the same launcher is now assigned explicitly"
+        buildFile << """
+            // Same launcher the convention supplied, but now assigned directly by the user.
+            graalvmNative.binaries.all {
+                javaLauncher.set(javaToolchains.launcherFor {
+                    languageVersion = JavaLanguageVersion.of($FAKE_JDK_MAJOR)
+                })
+            }
+        """.stripIndent()
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath, 'JAVA_HOME': fakeJdk.absolutePath], 'nativeCompile')
+
+        then: "nativeCompile re-runs (provenance is a task input) and fails per §FS-native-invocation.1.1"
+        tasks {
+            failed ':nativeCompile'
+        }
+        errorOutputContains("does not contain the 'native-image' executable")
+    }
+}

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
@@ -51,7 +51,7 @@ exit 0
         // auto-provisioning so the build is deterministic and offline-friendly.
         file("gradle.properties") << """
             org.gradle.java.installations.auto-download=false
-            org.gradle.java.installations.paths=${System.getenv("JAVA_HOME") ?: System.getProperty("java.home")}
+            org.gradle.java.installations.paths=${System.getProperty("java.home")}
         """.stripIndent()
 
         // Create a fake GRAALVM_HOME with a working native-image
@@ -107,7 +107,7 @@ exit 0
         // auto-provisioning so the build is deterministic and offline-friendly.
         file("gradle.properties") << """
             org.gradle.java.installations.auto-download=false
-            org.gradle.java.installations.paths=${System.getenv("JAVA_HOME") ?: System.getProperty("java.home")}
+            org.gradle.java.installations.paths=${System.getProperty("java.home")}
         """.stripIndent()
 
         // Create a fake GRAALVM_HOME that would provide a different native-image
@@ -371,7 +371,7 @@ exit 1'''
         withSample("java-application")
         file("gradle.properties") << """
             org.gradle.java.installations.auto-download=false
-            org.gradle.java.installations.paths=${System.getenv("JAVA_HOME") ?: System.getProperty("java.home")}
+            org.gradle.java.installations.paths=${System.getProperty("java.home")}
         """.stripIndent()
 
         // Create a fake GRAALVM_HOME with a working native-image
@@ -420,7 +420,7 @@ exit 1'''
         withSample("java-application")
         file("gradle.properties") << """
             org.gradle.java.installations.auto-download=false
-            org.gradle.java.installations.paths=${System.getenv("JAVA_HOME") ?: System.getProperty("java.home")}
+            org.gradle.java.installations.paths=${System.getProperty("java.home")}
         """.stripIndent()
 
         File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
@@ -1,0 +1,367 @@
+package org.graalvm.buildtools.gradle
+
+import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
+import spock.lang.Issue
+
+class ToolchainDiscoveryTest extends AbstractFunctionalTest {
+
+    private static final String WORKING_NATIVE_IMAGE_SCRIPT = '''#!/bin/sh
+output_file=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version)
+            echo 'native-image 25.0.2 25.0.2 (Java Version 25.0.2+10) (GraalVM Community Edition)'
+            exit 0
+            ;;
+        -o)
+            output_file="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+if [ -n "$output_file" ]; then
+    mkdir -p "$(dirname "$output_file")"
+    echo '#!/bin/sh' > "$output_file"
+    echo 'echo "Fake native-image executable"' >> "$output_file"
+    chmod +x "$output_file"
+fi
+exit 0
+'''
+
+    private static void setupWorkingNativeImage(File binDir) {
+        File nativeImage = new File(binDir, "native-image")
+        nativeImage.text = WORKING_NATIVE_IMAGE_SCRIPT
+        nativeImage.setExecutable(true)
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.1 — explicit launcher overrides convention and env
+    def "explicit javaLauncher overrides toolchain"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+        // Pin the explicit launcher's toolchain to the build JDK GraalVM (JAVA_HOME)
+        // via an explicit directory repository so resolution is deterministic and never
+        // auto-provisions a vendor-specific JDK.
+        // Pin toolchain resolution to the local GraalVM (JAVA_HOME) and disable
+        // auto-provisioning so the build is deterministic and offline-friendly.
+        file("gradle.properties") << """
+            org.gradle.java.installations.auto-download=false
+            org.gradle.java.installations.paths=${System.getenv("JAVA_HOME") ?: System.getProperty("java.home")}
+        """.stripIndent()
+
+        // Create a fake GRAALVM_HOME with a working native-image
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupWorkingNativeImage(fakeBin)
+
+        buildFile << """
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                }
+            }
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.binaries.all {
+                buildArgs.add("-Ob")
+                javaLauncher.set(javaToolchains.launcherFor {
+                    languageVersion.set(JavaLanguageVersion.of(JavaVersion.current().majorVersion))
+                })
+            }
+        """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        // Verify that the explicit javaLauncher was used (not GRAALVM_HOME)
+        outputContains("Native Image executable path:")
+        // The path should NOT contain the fake GRAALVM_HOME path
+        outputDoesNotContain("fake-graalvm")
+    }
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.2 — convention launcher: toolchain detection ON, toolchain wins over env
+    def "toolchain takes precedence over GRAALVM_HOME env var when running nativeCompile"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+        // Pin the toolchain to the build JDK GraalVM (JAVA_HOME) via an explicit
+        // directory repository so detection is deterministic and never falls back to
+        // the fake GRAALVM_HOME that runWithEnv injects.
+        // Pin toolchain resolution to the local GraalVM (JAVA_HOME) and disable
+        // auto-provisioning so the build is deterministic and offline-friendly.
+        file("gradle.properties") << """
+            org.gradle.java.installations.auto-download=false
+            org.gradle.java.installations.paths=${System.getenv("JAVA_HOME") ?: System.getProperty("java.home")}
+        """.stripIndent()
+
+        // Create a fake GRAALVM_HOME that would provide a different native-image
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupWorkingNativeImage(fakeBin)
+
+        buildFile << """
+            graalvmNative.toolchainDetection = true
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                }
+            }
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.binaries.all {
+                buildArgs.add("-Ob")
+            }
+        """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        // Verify that the toolchain was used (not the fake GRAALVM_HOME)
+        outputContains("Native Image executable path:")
+        outputContains("GraalVM Toolchain detection is enabled")
+        // The path should NOT contain the fake GRAALVM_HOME path
+        outputDoesNotContain("fake-graalvm")
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.3 — env fallback: GRAALVM_HOME when toolchain detection disabled
+    def "disabling toolchainDetection uses GRAALVM_HOME fallback"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+
+        // Create a fake GRAALVM_HOME with a working native-image
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        setupWorkingNativeImage(fakeBin)
+
+        buildFile << """
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+                }
+            }
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.binaries.all {
+                buildArgs.add("-Ob")
+            }
+            tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+                disableToolchainDetection = true
+            }
+        """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        // Verify that GRAALVM_HOME was used (toolchain detection was disabled)
+        outputContains("GraalVM Toolchain detection is disabled")
+        // The path should NOT contain the fake GRAALVM_HOME path since system GRAALVM_HOME is set
+        // but we verify the detection is disabled which triggers env var fallback
+        outputContains("GraalVM location source: GRAALVM_HOME")
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.3 — cross-home fallback: native-image found in JAVA_HOME when GRAALVM_HOME lacks it and gu is unavailable
+    def "native-image found in alternative GraalVM home when GRAALVM_HOME has no native-image and no gu"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+
+        // GRAALVM_HOME: a fake GraalVM WITHOUT native-image and WITHOUT a gu tool
+        // (gu install is skipped, so the locator falls back to other GraalVM homes)
+        File graalvmHome = testDirectory.resolve("fake-graalvm").toFile()
+        graalvmHome.mkdirs()
+        File graalvmBin = new File(graalvmHome, "bin")
+        graalvmBin.mkdirs()
+
+        // JAVA_HOME: a SECOND fake GraalVM that already HAS a working native-image
+        File javaHome = testDirectory.resolve("fake-jdk").toFile()
+        javaHome.mkdirs()
+        File javaHomeBin = new File(javaHome, "bin")
+        javaHomeBin.mkdirs()
+        setupWorkingNativeImage(javaHomeBin)
+
+        buildFile << """
+        graalvmNative.toolchainDetection = false
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+            }
+        }
+        tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+            disableToolchainDetection = true
+        }
+        graalvmNative.metadataRepository.enabled = false
+        graalvmNative.binaries.all {
+            buildArgs.add("-Ob")
+        }
+    """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': graalvmHome.absolutePath, 'JAVA_HOME': javaHome.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        // The executable was found via the alternative (JAVA_HOME) GraalVM home
+        outputContains("Using native-image from alternative GraalVM home: " + javaHome.absolutePath)
+        // The resolved executable must live under JAVA_HOME, NOT the failed GRAALVM_HOME
+        outputContains("fake-jdk")
+        outputDoesNotContain("fake-graalvm")
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.4 — gu-based installation
+    def "gu installs native-image when not found"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+
+        // Create a GRAALVM_HOME directory WITHOUT native-image (but with gu that installs it)
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        File gu = new File(fakeBin, "gu")
+        gu.text = """#!/bin/sh
+if [ "\$1" = "install" ] && [ "\$2" = "native-image" ]; then
+  echo 'Native Image installed successfully.'
+  GU_DIR=\$(cd "\$(dirname "\$0")" && pwd)
+  cat > "\${GU_DIR}/native-image" << 'EOF'
+$WORKING_NATIVE_IMAGE_SCRIPT
+EOF
+  chmod +x "\${GU_DIR}/native-image"
+fi
+exit 0
+"""
+        gu.setExecutable(true)
+
+        buildFile << """
+        graalvmNative.toolchainDetection = false
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+            }
+        }
+        tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+            disableToolchainDetection = true
+        }
+        graalvmNative.metadataRepository.enabled = false
+        graalvmNative.binaries.all {
+            buildArgs.add("-Ob")
+        }
+    """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeCompile'
+        }
+
+        and:
+        getExecutableFile("build/native/nativeCompile/java-application").exists()
+
+        and:
+        // Under configuration cache the build runs twice (store, then reuse). On the reuse
+        // run nativeCompile is up-to-date, so the gu-install code path is not re-executed and
+        // the install log lines are absent. The executable still exists and resolves from
+        // GRAALVM_HOME, which proves the gu fallback installed native-image. §FS-native-invocation.1.5
+        outputContains("GraalVM location source: GRAALVM_HOME")
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/542")
+    // §FS-native-invocation.1.5 — failure messages show attempted paths
+    def "gu installation failure falls back to error message"() {
+        debug = true
+
+        given:
+        withSample("java-application")
+
+        // Create a GRAALVM_HOME directory WITHOUT native-image and with a failing gu
+        File fakeGraalvm = testDirectory.resolve("fake-graalvm").toFile()
+        fakeGraalvm.mkdirs()
+        File fakeBin = new File(fakeGraalvm, "bin")
+        fakeBin.mkdirs()
+        File gu = new File(fakeBin, "gu")
+        gu.text = '''#!/bin/sh
+echo 'gu error: package not found'
+exit 1'''
+        gu.setExecutable(true)
+
+        buildFile << """
+        graalvmNative.toolchainDetection = false
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(JavaVersion.current().majorVersion)
+            }
+        }
+        tasks.withType(org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask).configureEach {
+            disableToolchainDetection = true
+        }
+        graalvmNative.metadataRepository.enabled = false
+        graalvmNative.binaries.all {
+            buildArgs.add("-Ob")
+        }
+    """.stripIndent()
+
+        when:
+        runWithEnv(['GRAALVM_HOME': fakeGraalvm.absolutePath], 'nativeCompile')
+
+        then:
+        tasks {
+            succeeded ':jar'
+            failed ':nativeCompile'
+        }
+
+        and:
+        errorOutputContains("gu tool failed to install native-image")
+    }
+}

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ToolchainDiscoveryTest.groovy
@@ -68,6 +68,16 @@ exit /b 0
                     ? WINDOWS_NATIVE_IMAGE_SCRIPT
                     : WORKING_NATIVE_IMAGE_SCRIPT
 
+    @Override
+    protected void withSample(String name, boolean quickBuildMode = true) {
+        super.withSample(name, quickBuildMode)
+        // These tests exercise executable discovery, not Native Image argument-file parsing. Windows
+        // enables argument files by default, while the fake executable intentionally parses direct args.
+        buildFile << '''
+            graalvmNative.useArgFile = false
+        '''.stripIndent()
+    }
+
     /**
      * A fake {@code gu} that always fails (mimicking a registry/dependency error). Cross-platform.
      */

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -341,7 +341,6 @@ public class NativeImagePlugin implements Plugin<Project> {
                     }
                     return null;
                 });
-                task.getJavaLauncher().convention(toolchainLauncher);
                 task.setConventionJavaLauncher(toolchainLauncher);
             }
         });
@@ -415,7 +414,6 @@ public class NativeImagePlugin implements Plugin<Project> {
                     builder.getOptions().convention(options);
                     builder.getUseArgFile().convention(graalExtension.getUseArgFile());
                     builder.setConventionJavaLauncher(graalExtension.getDefaultJavaLauncher());
-                    options.getJavaLauncher().convention(graalExtension.getDefaultJavaLauncher());
 
                     GraalVMReachabilityMetadataRepositoryExtension repoExt = reachabilityExtensionOn(graalExtension);
                     Provider<Boolean> repoEnabled =

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -343,12 +343,13 @@ public class NativeImagePlugin implements Plugin<Project> {
             task.getToolchainDetection().set(graalExtension.getToolchainDetection());
             JavaToolchainService toolchainService = project.getExtensions().findByType(JavaToolchainService.class);
             if (toolchainService != null) {
-                task.getJavaLauncher().convention(graalExtension.getToolchainDetection().flatMap(enabled -> {
+                Provider<JavaLauncher> toolchainLauncher = graalExtension.getToolchainDetection().flatMap(enabled -> {
                     if (enabled) {
                         return toolchainService.launcherFor(javaConvention.getToolchain());
                     }
                     return null;
-                }));
+                });
+                task.setJavaLauncherConvention(toolchainLauncher);
             }
         });
 
@@ -404,7 +405,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     }
 
     private void configureAutomaticTaskCreation(Project project,
-                                                GraalVMExtension graalExtension,
+                                                DefaultGraalVmExtension graalExtension,
                                                 TaskContainer tasks,
                                                 SourceSetContainer sourceSets) {
         configureLayerTasks(project, graalExtension, tasks, sourceSets);
@@ -421,6 +422,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                     builder.setGroup(LifecycleBasePlugin.BUILD_GROUP);
                     builder.getOptions().convention(options);
                     builder.getUseArgFile().convention(graalExtension.getUseArgFile());
+                    builder.getDisableToolchainDetection().convention(graalExtension.getToolchainDetection().map(enabled -> !enabled));
 
                     GraalVMReachabilityMetadataRepositoryExtension repoExt = reachabilityExtensionOn(graalExtension);
                     Provider<Boolean> repoEnabled =
@@ -1053,13 +1055,24 @@ public class NativeImagePlugin implements Plugin<Project> {
         // In Compatibility Mode, also pass -Djava.home from the GraalVM used for the build
         Provider<String> graalVmHome = project.getProviders().provider(() -> {
             NativeImageExecutableLocator.Diagnostics d = new NativeImageExecutableLocator.Diagnostics();
+            Provider<JavaLauncher> javaLauncher = testOptions.getJavaLauncher();
+            JavaLauncher launcher = javaLauncher.getOrNull();
+            if (launcher == null) {
+                // Unset binary property: fall back to the plugin default (the same value the
+                // convention would supply). §FS-native-invocation.1.2
+                javaLauncher = graalExtension.getDefaultJavaLauncher();
+                launcher = javaLauncher.getOrNull();
+            }
+            boolean isExplicit = ((BaseNativeImageOptions) testOptions).getJavaLauncherExplicit().getOrElse(false) && launcher != null;
             File nativeImage = NativeImageExecutableLocator.findNativeImageExecutable(
-                    testOptions.getJavaLauncher(),
+                    launcher,
+                    isExplicit,
                     graalExtension.getToolchainDetection().map(enabled -> !enabled),
                     graalvmHomeProvider(project.getProviders(), d),
                     getExecOperations(),
                     logger,
-                    d
+                    d,
+                    NativeImageExecutableLocator.defaultFallbackCandidates(project.getProviders())
             );
             File parent = nativeImage.getParentFile();
             return parent != null ? parent.getParent() : null;
@@ -1349,7 +1362,11 @@ public class NativeImagePlugin implements Plugin<Project> {
             mergeInputDirs,
             mergeOutputDirs,
             graalExtension.getToolchainDetection().map(enabled -> !enabled),
-            execOperations));
+            project.provider(() -> false),
+            execOperations,
+            project.getProviders().environmentVariable("GRAALVM_HOME"),
+            project.getProviders().environmentVariable("JAVA_HOME"),
+            project.getProviders().systemProperty("java.home")));
 
         taskToInstrument.doLast(new CleanupAgentFilesAction(mergeInputDirs, fileOperations));
     }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -335,12 +335,14 @@ public class NativeImagePlugin implements Plugin<Project> {
             task.getToolchainDetection().set(graalExtension.getToolchainDetection());
             JavaToolchainService toolchainService = project.getExtensions().findByType(JavaToolchainService.class);
             if (toolchainService != null) {
-                task.getJavaLauncher().convention(graalExtension.getToolchainDetection().flatMap(enabled -> {
+                Provider<JavaLauncher> toolchainLauncher = graalExtension.getToolchainDetection().flatMap(enabled -> {
                     if (enabled) {
                         return toolchainService.launcherFor(javaConvention.getToolchain());
                     }
                     return null;
-                }));
+                });
+                task.getJavaLauncher().convention(toolchainLauncher);
+                task.setConventionJavaLauncher(toolchainLauncher);
             }
         });
 
@@ -1191,6 +1193,7 @@ public class NativeImagePlugin implements Plugin<Project> {
             mergeInputDirs,
             mergeOutputDirs,
             graalExtension.getToolchainDetection().map(enabled -> !enabled),
+            project.provider(() -> false),
             execOperations,
             project.getProviders()));
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -341,7 +341,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                     }
                     return null;
                 });
-                task.setConventionJavaLauncher(toolchainLauncher);
+                task.getConventionJavaLauncher().set(toolchainLauncher);
             }
         });
 
@@ -413,7 +413,8 @@ public class NativeImagePlugin implements Plugin<Project> {
                     builder.setGroup(LifecycleBasePlugin.BUILD_GROUP);
                     builder.getOptions().convention(options);
                     builder.getUseArgFile().convention(graalExtension.getUseArgFile());
-                    builder.setConventionJavaLauncher(graalExtension.getDefaultJavaLauncher());
+                    builder.getConventionJavaLauncher().set(graalExtension.getDefaultJavaLauncher());
+                    builder.getDisableToolchainDetection().convention(graalExtension.getToolchainDetection().map(enabled -> !enabled));
 
                     GraalVMReachabilityMetadataRepositoryExtension repoExt = reachabilityExtensionOn(graalExtension);
                     Provider<Boolean> repoEnabled =

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -396,7 +396,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     }
 
     private void configureAutomaticTaskCreation(Project project,
-                                                GraalVMExtension graalExtension,
+                                                DefaultGraalVmExtension graalExtension,
                                                 TaskContainer tasks,
                                                 SourceSetContainer sourceSets) {
         graalExtension.getBinaries().configureEach(options -> {
@@ -412,6 +412,8 @@ public class NativeImagePlugin implements Plugin<Project> {
                     builder.setGroup(LifecycleBasePlugin.BUILD_GROUP);
                     builder.getOptions().convention(options);
                     builder.getUseArgFile().convention(graalExtension.getUseArgFile());
+                    builder.setConventionJavaLauncher(graalExtension.getDefaultJavaLauncher());
+                    options.getJavaLauncher().convention(graalExtension.getDefaultJavaLauncher());
 
                     GraalVMReachabilityMetadataRepositoryExtension repoExt = reachabilityExtensionOn(graalExtension);
                     Provider<Boolean> repoEnabled =
@@ -887,13 +889,19 @@ public class NativeImagePlugin implements Plugin<Project> {
         // In Compatibility Mode, also pass -Djava.home from the GraalVM used for the build
         Provider<String> graalVmHome = project.getProviders().provider(() -> {
             NativeImageExecutableLocator.Diagnostics d = new NativeImageExecutableLocator.Diagnostics();
+            Provider<JavaLauncher> javaLauncher = testOptions.getJavaLauncher().isPresent()
+                    ? testOptions.getJavaLauncher()
+                    : graalExtension.getDefaultJavaLauncher();
+            boolean isExplicit = testOptions.getJavaLauncher().isPresent();
             File nativeImage = NativeImageExecutableLocator.findNativeImageExecutable(
-                    testOptions.getJavaLauncher(),
+                    javaLauncher.getOrNull(),
+                    isExplicit,
                     graalExtension.getToolchainDetection().map(enabled -> !enabled),
                     graalvmHomeProvider(project.getProviders(), d),
                     getExecOperations(),
                     logger,
-                    d
+                    d,
+                    NativeImageExecutableLocator.defaultFallbackCandidates(project.getProviders())
             );
             File parent = nativeImage.getParentFile();
             return parent != null ? parent.getParent() : null;
@@ -1183,7 +1191,8 @@ public class NativeImagePlugin implements Plugin<Project> {
             mergeInputDirs,
             mergeOutputDirs,
             graalExtension.getToolchainDetection().map(enabled -> !enabled),
-            execOperations));
+            execOperations,
+            project.getProviders()));
 
         taskToInstrument.doLast(new CleanupAgentFilesAction(mergeInputDirs, fileOperations));
     }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -1194,7 +1194,9 @@ public class NativeImagePlugin implements Plugin<Project> {
             graalExtension.getToolchainDetection().map(enabled -> !enabled),
             project.provider(() -> false),
             execOperations,
-            project.getProviders()));
+            project.getProviders().environmentVariable("GRAALVM_HOME"),
+            project.getProviders().environmentVariable("JAVA_HOME"),
+            project.getProviders().systemProperty("java.home")));
 
         taskToInstrument.doLast(new CleanupAgentFilesAction(mergeInputDirs, fileOperations));
     }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -341,7 +341,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                     }
                     return null;
                 });
-                task.getConventionJavaLauncher().set(toolchainLauncher);
+                task.getJavaLauncher().convention(toolchainLauncher);
             }
         });
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -413,7 +413,6 @@ public class NativeImagePlugin implements Plugin<Project> {
                     builder.setGroup(LifecycleBasePlugin.BUILD_GROUP);
                     builder.getOptions().convention(options);
                     builder.getUseArgFile().convention(graalExtension.getUseArgFile());
-                    builder.getConventionJavaLauncher().set(graalExtension.getDefaultJavaLauncher());
                     builder.getDisableToolchainDetection().convention(graalExtension.getToolchainDetection().map(enabled -> !enabled));
 
                     GraalVMReachabilityMetadataRepositoryExtension repoExt = reachabilityExtensionOn(graalExtension);
@@ -890,12 +889,17 @@ public class NativeImagePlugin implements Plugin<Project> {
         // In Compatibility Mode, also pass -Djava.home from the GraalVM used for the build
         Provider<String> graalVmHome = project.getProviders().provider(() -> {
             NativeImageExecutableLocator.Diagnostics d = new NativeImageExecutableLocator.Diagnostics();
-            Provider<JavaLauncher> javaLauncher = testOptions.getJavaLauncher().isPresent()
-                    ? testOptions.getJavaLauncher()
-                    : graalExtension.getDefaultJavaLauncher();
-            boolean isExplicit = testOptions.getJavaLauncher().isPresent();
+            Provider<JavaLauncher> javaLauncher = testOptions.getJavaLauncher();
+            JavaLauncher launcher = javaLauncher.getOrNull();
+            if (launcher == null) {
+                // Unset binary property: fall back to the plugin default (the same value the
+                // convention would supply). §FS-native-invocation.1.2
+                javaLauncher = graalExtension.getDefaultJavaLauncher();
+                launcher = javaLauncher.getOrNull();
+            }
+            boolean isExplicit = ((BaseNativeImageOptions) testOptions).getJavaLauncherExplicit().getOrElse(false) && launcher != null;
             File nativeImage = NativeImageExecutableLocator.findNativeImageExecutable(
-                    javaLauncher.getOrNull(),
+                    launcher,
                     isExplicit,
                     graalExtension.getToolchainDetection().map(enabled -> !enabled),
                     graalvmHomeProvider(project.getProviders(), d),

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -75,7 +75,6 @@ import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -95,8 +94,8 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
     private final String name;
     private final transient TaskContainer tasks;
     private final ObjectFactory objects;
-    private final AtomicBoolean javaLauncherConventionConsulted = new AtomicBoolean(false);
     private final ProviderFactory providers;
+    private final JavaLauncherProperty javaLauncher;
 
     @Override
     @Internal
@@ -228,37 +227,30 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
      */
     @Nested
     @Optional
-    public abstract Property<JavaLauncher> getJavaLauncher();
-
-    /**
-     * Installs the plugin-provided convention launcher on the {@code javaLauncher} property,
-     * wrapped so the plugin can distinguish a value supplied by the convention from one
-     * assigned explicitly by the user. §FS-native-invocation.1.2
-     */
-    public void setJavaLauncherConvention(Provider<JavaLauncher> convention) {
-        // The wrapper records that the property was resolved through the convention, so the
-        // plugin can tell a convention-sourced value from one assigned explicitly by the user.
-        // The supplier runs only when the property resolves its convention, never when the
-        // user assigns a value directly. §FS-native-invocation.1.2
-        AtomicBoolean consulted = javaLauncherConventionConsulted;
-        getJavaLauncher().convention(providers.provider(() -> {
-            consulted.set(true);
-            return convention.getOrNull();
-        }));
+    public Property<JavaLauncher> getJavaLauncher() {
+        return javaLauncher;
     }
 
     /**
-     * Returns whether the binary's {@code javaLauncher} was assigned explicitly by the user
+     * Installs the plugin-provided convention launcher on the javaLauncher property.
+     * Provenance is tracked structurally by the property wrapper: consulting the convention
+     * never makes a later explicit assignment look convention-sourced. §FS-native-invocation.1.2
+     */
+    public void setJavaLauncherConvention(Provider<JavaLauncher> convention) {
+        // The supplier runs only when the property resolves its convention, never when the
+        // user assigns a value directly, and it may yield null when no launcher is available.
+        getJavaLauncher().convention(providers.provider(convention::getOrNull));
+    }
+
+    /**
+     * Returns whether the binary's javaLauncher was assigned explicitly by the user
      * rather than supplied by the plugin-installed convention (§FS-native-invocation.1.1).
-     * Querying this provider resolves the property, so it must be read at execution time,
+     * Resolving this provider resolves the property, so it must be read at execution time,
      * never during configuration, where resolving the convention can trigger toolchain
      * detection. §FS-native-invocation.1.2
      */
     public Provider<Boolean> getJavaLauncherExplicit() {
-        // isPresent() must be evaluated before the consulted flag: resolving the property is
-        // what consults the convention, so checking the flag first would answer "explicit"
-        // for a convention-sourced value never resolved before. §FS-native-invocation.1.2
-        return providers.provider(() -> getJavaLauncher().isPresent() && !javaLauncherConventionConsulted.get());
+        return providers.provider(() -> getJavaLauncher().isPresent() && javaLauncher.isExplicit());
     }
 
     /**
@@ -318,6 +310,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         this.tasks = tasks;
         this.objects = objectFactory;
         this.providers = providers;
+        this.javaLauncher = new JavaLauncherProperty(objectFactory.property(JavaLauncher.class));
     }
 
     private static Provider<Boolean> property(ProviderFactory providers, String name) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -75,6 +75,7 @@ import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -94,6 +95,8 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
     private final String name;
     private final transient TaskContainer tasks;
     private final ObjectFactory objects;
+    private final AtomicBoolean javaLauncherConventionConsulted = new AtomicBoolean(false);
+    private final ProviderFactory providers;
 
     @Override
     @Internal
@@ -228,6 +231,37 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
     public abstract Property<JavaLauncher> getJavaLauncher();
 
     /**
+     * Installs the plugin-provided convention launcher on the {@code javaLauncher} property,
+     * wrapped so the plugin can distinguish a value supplied by the convention from one
+     * assigned explicitly by the user. §FS-native-invocation.1.2
+     */
+    public void setJavaLauncherConvention(Provider<JavaLauncher> convention) {
+        // The wrapper records that the property was resolved through the convention, so the
+        // plugin can tell a convention-sourced value from one assigned explicitly by the user.
+        // The supplier runs only when the property resolves its convention, never when the
+        // user assigns a value directly. §FS-native-invocation.1.2
+        AtomicBoolean consulted = javaLauncherConventionConsulted;
+        getJavaLauncher().convention(providers.provider(() -> {
+            consulted.set(true);
+            return convention.getOrNull();
+        }));
+    }
+
+    /**
+     * Returns whether the binary's {@code javaLauncher} was assigned explicitly by the user
+     * rather than supplied by the plugin-installed convention (§FS-native-invocation.1.1).
+     * Querying this provider resolves the property, so it must be read at execution time,
+     * never during configuration, where resolving the convention can trigger toolchain
+     * detection. §FS-native-invocation.1.2
+     */
+    public Provider<Boolean> getJavaLauncherExplicit() {
+        // isPresent() must be evaluated before the consulted flag: resolving the property is
+        // what consults the convention, so checking the flag first would answer "explicit"
+        // for a convention-sourced value never resolved before. §FS-native-invocation.1.2
+        return providers.provider(() -> getJavaLauncher().isPresent() && !javaLauncherConventionConsulted.get());
+    }
+
+    /**
      * Returns the list of configuration file directories (e.g. resource-config.json, ...) which need
      * to be passed to native-image.
      *
@@ -283,6 +317,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         this.layers = objectFactory.domainObjectSet(LayerOptions.class);
         this.tasks = tasks;
         this.objects = objectFactory;
+        this.providers = providers;
     }
 
     private static Provider<Boolean> property(ProviderFactory providers, String name) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -100,6 +100,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
     private final ObjectFactory objects;
     private final ProviderFactory providers;
     private final transient NativeImageLayerRegistry layerRegistry;
+    private final JavaLauncherProperty javaLauncher;
 
     @Override
     @Internal
@@ -231,7 +232,31 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
      */
     @Nested
     @Optional
-    public abstract Property<JavaLauncher> getJavaLauncher();
+    public Property<JavaLauncher> getJavaLauncher() {
+        return javaLauncher.getProperty();
+    }
+
+    /**
+     * Installs the plugin-provided convention launcher on the javaLauncher property.
+     * Provenance is tracked by the property proxy: a user's explicit {@code set}/{@code value}
+     * marks the value non-convention-sourced; installing or consulting the convention never does.
+     * §FS-native-invocation.1.2
+     */
+    public void setJavaLauncherConvention(Provider<JavaLauncher> convention) {
+        // Goes through the proxied property so the provenance flag stays in sync.
+        javaLauncher.getProperty().convention(convention);
+    }
+
+    /**
+     * Returns whether the binary's javaLauncher was assigned explicitly by the user
+     * rather than supplied by the plugin-installed convention (§FS-native-invocation.1.1).
+     * Resolving this provider resolves the property, so it must be read at execution time,
+     * never during configuration, where resolving the convention can trigger toolchain
+     * detection. §FS-native-invocation.1.2
+     */
+    public Provider<Boolean> getJavaLauncherExplicit() {
+        return javaLauncher.explicit();
+    }
 
     /**
      * Returns the list of configuration file directories (e.g. resource-config.json, ...) which need
@@ -295,6 +320,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         this.objects = objectFactory;
         this.providers = providers;
         this.layerRegistry = layerRegistry;
+        this.javaLauncher = JavaLauncherProperty.of(objectFactory.property(JavaLauncher.class), providers);
     }
 
     private static Provider<Boolean> property(ProviderFactory providers, String name) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -76,9 +76,6 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
         this.project = project;
         this.defaultJavaLauncher = project.getObjects().property(JavaLauncher.class);
         getToolchainDetection().convention(false);
-        // Every binary exposes a javaLauncher convention so graalvmNative.binaries.main.javaLauncher
-        // is always resolvable (e.g. its metadata.languageVersion) when toolchain detection is on. §FS-native-invocation.1.5
-        nativeImages.configureEach(options -> options.getJavaLauncher().convention(defaultJavaLauncher));
         getTestSupport().convention(true);
         AgentOptions agentOpts = getAgent();
         agentOpts.getDefaultMode().convention("standard");

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -76,6 +76,12 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
         this.project = project;
         this.defaultJavaLauncher = project.getObjects().property(JavaLauncher.class);
         getToolchainDetection().convention(false);
+        // Restore the public javaLauncher convention on every binary: the property resolves
+        // from the default (toolchain-selected) launcher, with provenance tracked so the
+        // plugin can tell convention-sourced values apart from explicit assignments.
+        // §FS-native-invocation.1.2
+        nativeImages.configureEach(options ->
+                ((BaseNativeImageOptions) options).setJavaLauncherConvention(defaultJavaLauncher));
         getTestSupport().convention(true);
         AgentOptions agentOpts = getAgent();
         agentOpts.getDefaultMode().convention("standard");
@@ -109,7 +115,7 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
                     // metadata.languageVersion) whenever toolchain detection is enabled.
                     // Whether the toolchain actually contains native-image is decided at build
                     // time by NativeImageExecutableLocator, which falls back to GRAALVM_HOME
-                    // when the launcher's installation lacks it. §FS-native-invocation.1.5
+                    // when the launcher's installation lacks it. §FS-native-invocation.1.6
                     JavaPluginExtension javaConvention = project.getExtensions().getByType(JavaPluginExtension.class);
                     return toolchainService.launcherFor(javaConvention.getToolchain());
                 })

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -50,12 +50,12 @@ import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.dsl.NativeImageLayer;
 import org.graalvm.buildtools.gradle.dsl.agent.AgentOptions;
 import org.gradle.api.Action;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Property;
-import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.api.provider.Provider;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 
@@ -80,7 +80,12 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
         this.project = project;
         this.defaultJavaLauncher = project.getObjects().property(JavaLauncher.class);
         getToolchainDetection().convention(false);
-        nativeImages.configureEach(options -> options.getJavaLauncher().convention(defaultJavaLauncher));
+        // Restore the public javaLauncher convention on every binary: the property resolves
+        // from the default (toolchain-selected) launcher, with provenance tracked so the
+        // plugin can tell convention-sourced values apart from explicit assignments.
+        // §FS-native-invocation.1.2
+        nativeImages.configureEach(options ->
+                ((BaseNativeImageOptions) options).setJavaLauncherConvention(defaultJavaLauncher));
         getTestSupport().convention(true);
         AgentOptions agentOpts = getAgent();
         agentOpts.getDefaultMode().convention("standard");
@@ -95,18 +100,28 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
         configureToolchain();
     }
 
+    public Provider<JavaLauncher> getDefaultJavaLauncher() {
+        return defaultJavaLauncher;
+    }
+
     private void configureToolchain() {
         defaultJavaLauncher.convention(
                 getToolchainDetection().flatMap(enabled -> {
-                    if (enabled) {
-                        JavaToolchainService toolchainService = project.getExtensions().findByType(JavaToolchainService.class);
-                        if (toolchainService != null) {
-                            return toolchainService.launcherFor(spec -> {
-                                spec.getLanguageVersion().set(JavaLanguageVersion.of(JavaVersion.current().getMajorVersion()));
-                            });
-                        }
+                    if (!enabled) {
+                        return null;
                     }
-                    return null;
+                    JavaToolchainService toolchainService = project.getExtensions().findByType(JavaToolchainService.class);
+                    if (toolchainService == null) {
+                        return null;
+                    }
+                    // Resolve the toolchain launcher for the configured Java toolchain.
+                    // This keeps graalvmNative.binaries.main.javaLauncher queryable (e.g. its
+                    // metadata.languageVersion) whenever toolchain detection is enabled.
+                    // Whether the toolchain actually contains native-image is decided at build
+                    // time by NativeImageExecutableLocator, which falls back to GRAALVM_HOME
+                    // when the launcher's installation lacks it. §FS-native-invocation.1.6
+                    JavaPluginExtension javaConvention = project.getExtensions().getByType(JavaPluginExtension.class);
+                    return toolchainService.launcherFor(javaConvention.getToolchain());
                 })
         );
     }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -49,12 +49,12 @@ import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.dsl.agent.AgentOptions;
 import org.gradle.api.Action;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Property;
-import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.api.provider.Provider;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 
@@ -76,6 +76,8 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
         this.project = project;
         this.defaultJavaLauncher = project.getObjects().property(JavaLauncher.class);
         getToolchainDetection().convention(false);
+        // Every binary exposes a javaLauncher convention so graalvmNative.binaries.main.javaLauncher
+        // is always resolvable (e.g. its metadata.languageVersion) when toolchain detection is on. §FS-native-invocation.1.5
         nativeImages.configureEach(options -> options.getJavaLauncher().convention(defaultJavaLauncher));
         getTestSupport().convention(true);
         AgentOptions agentOpts = getAgent();
@@ -91,18 +93,28 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
         configureToolchain();
     }
 
+    public Provider<JavaLauncher> getDefaultJavaLauncher() {
+        return defaultJavaLauncher;
+    }
+
     private void configureToolchain() {
         defaultJavaLauncher.convention(
                 getToolchainDetection().flatMap(enabled -> {
-                    if (enabled) {
-                        JavaToolchainService toolchainService = project.getExtensions().findByType(JavaToolchainService.class);
-                        if (toolchainService != null) {
-                            return toolchainService.launcherFor(spec -> {
-                                spec.getLanguageVersion().set(JavaLanguageVersion.of(JavaVersion.current().getMajorVersion()));
-                            });
-                        }
+                    if (!enabled) {
+                        return null;
                     }
-                    return null;
+                    JavaToolchainService toolchainService = project.getExtensions().findByType(JavaToolchainService.class);
+                    if (toolchainService == null) {
+                        return null;
+                    }
+                    // Resolve the toolchain launcher for the configured Java toolchain.
+                    // This keeps graalvmNative.binaries.main.javaLauncher queryable (e.g. its
+                    // metadata.languageVersion) whenever toolchain detection is enabled.
+                    // Whether the toolchain actually contains native-image is decided at build
+                    // time by NativeImageExecutableLocator, which falls back to GRAALVM_HOME
+                    // when the launcher's installation lacks it. §FS-native-invocation.1.5
+                    JavaPluginExtension javaConvention = project.getExtensions().getByType(JavaPluginExtension.class);
+                    return toolchainService.launcherFor(javaConvention.getToolchain());
                 })
         );
     }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/JavaLauncherProperty.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/JavaLauncherProperty.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.gradle.internal;
+
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.specs.Spec;
+import org.gradle.jvm.toolchain.JavaLauncher;
+
+import java.util.function.BiFunction;
+
+/**
+ * A {@link Property} that records whether its current value was assigned explicitly.
+ *
+ * <p>Once a Gradle property has consulted its convention, {@link #isPresent()} can no longer
+ * distinguish the convention-supplied value from one assigned by the user. This wrapper tracks
+ * the current assignment instead: {@link #set(Object)} / {@link #value(Object)} mark the value
+ * explicit, {@link #unset()} restores convention provenance, and installing a convention never
+ * affects the flag. §FS-native-invocation.1.1 §FS-native-invocation.1.2</p>
+ */
+final class JavaLauncherProperty implements Property<JavaLauncher> {
+    private final Property<JavaLauncher> delegate;
+    private volatile boolean explicit;
+
+    JavaLauncherProperty(Property<JavaLauncher> delegate) {
+        this.delegate = delegate;
+    }
+
+    boolean isExplicit() {
+        return explicit;
+    }
+
+    @Override
+    public void set(JavaLauncher value) {
+        if (value == null) {
+            delegate.unset();
+            explicit = false;
+        } else {
+            delegate.set(value);
+            explicit = true;
+        }
+    }
+
+    @Override
+    public void set(Provider<? extends JavaLauncher> provider) {
+        delegate.set(provider);
+        explicit = true;
+    }
+
+    @Override
+    public Property<JavaLauncher> value(JavaLauncher value) {
+        set(value);
+        return this;
+    }
+
+    @Override
+    public Property<JavaLauncher> value(Provider<? extends JavaLauncher> provider) {
+        set(provider);
+        return this;
+    }
+
+    @Override
+    public Property<JavaLauncher> unset() {
+        delegate.unset();
+        explicit = false;
+        return this;
+    }
+
+    @Override
+    public Property<JavaLauncher> convention(JavaLauncher value) {
+        delegate.convention(value);
+        return this;
+    }
+
+    @Override
+    public Property<JavaLauncher> convention(Provider<? extends JavaLauncher> valueProvider) {
+        delegate.convention(valueProvider);
+        return this;
+    }
+
+    @Override
+    public Property<JavaLauncher> unsetConvention() {
+        delegate.unsetConvention();
+        return this;
+    }
+
+    @Override
+    public void finalizeValue() {
+        delegate.finalizeValue();
+    }
+
+    @Override
+    public void finalizeValueOnRead() {
+        delegate.finalizeValueOnRead();
+    }
+
+    @Override
+    public void disallowChanges() {
+        delegate.disallowChanges();
+    }
+
+    @Override
+    public void disallowUnsafeRead() {
+        delegate.disallowUnsafeRead();
+    }
+
+    @Override
+    public JavaLauncher get() {
+        return delegate.get();
+    }
+
+    @Override
+    public JavaLauncher getOrNull() {
+        return delegate.getOrNull();
+    }
+
+    @Override
+    public JavaLauncher getOrElse(JavaLauncher defaultValue) {
+        return delegate.getOrElse(defaultValue);
+    }
+
+    @Override
+    public <O> Provider<O> map(Transformer<? extends O, ? super JavaLauncher> transformer) {
+        return delegate.map(transformer);
+    }
+
+    @Override
+    public Provider<JavaLauncher> filter(Spec<? super JavaLauncher> spec) {
+        return delegate.filter(spec);
+    }
+
+    @Override
+    public <O> Provider<O> flatMap(Transformer<? extends Provider<? extends O>, ? super JavaLauncher> transformer) {
+        return delegate.flatMap(transformer);
+    }
+
+    @Override
+    public boolean isPresent() {
+        return delegate.isPresent();
+    }
+
+    @Override
+    public Provider<JavaLauncher> orElse(JavaLauncher value) {
+        return delegate.orElse(value);
+    }
+
+    @Override
+    public Provider<JavaLauncher> orElse(Provider<? extends JavaLauncher> valueProvider) {
+        return delegate.orElse(valueProvider);
+    }
+
+    @Override
+    public <U, R> Provider<R> zip(Provider<U> rightSide, BiFunction<? super JavaLauncher, ? super U, ? extends R> combiner) {
+        return delegate.zip(rightSide, combiner);
+    }
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/JavaLauncherProperty.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/JavaLauncherProperty.java
@@ -58,15 +58,15 @@ import java.util.function.BiFunction;
  * explicit, {@link #unset()} restores convention provenance, and installing a convention never
  * affects the flag. §FS-native-invocation.1.1 §FS-native-invocation.1.2</p>
  */
-final class JavaLauncherProperty implements Property<JavaLauncher> {
+public final class JavaLauncherProperty implements Property<JavaLauncher> {
     private final Property<JavaLauncher> delegate;
     private volatile boolean explicit;
 
-    JavaLauncherProperty(Property<JavaLauncher> delegate) {
+    public JavaLauncherProperty(Property<JavaLauncher> delegate) {
         this.delegate = delegate;
     }
 
-    boolean isExplicit() {
+    public boolean isExplicit() {
         return explicit;
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/JavaLauncherProperty.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/JavaLauncherProperty.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.gradle.internal;
+
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.jvm.toolchain.JavaLauncher;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+/**
+ * A holder for a {@link Property}{@code <JavaLauncher>} that records whether its value was assigned
+ * explicitly by the user rather than supplied by the plugin-installed convention.
+ *
+ * <p>The underlying {@link Property} is produced as a runtime {@link Proxy} over the real property
+ * returned by Gradle's {@code ObjectFactory}. This avoids compiling a concrete implementation of the
+ * evolving {@code Property} interface against a fixed Gradle API: the proxy matches whatever
+ * {@code Property} looks like in the running Gradle version, staying binary-compatible from Gradle
+ * 8.4 to current without referencing {@code org.gradle.api.provider.SupportsConvention}.</p>
+ *
+ * <p>Provenance is tracked by intercepting the property's mutating methods:
+ * {@code set}/{@code value} mark the value <em>explicit</em> while delegating the mutation;
+ * {@code unset} clears it back to <em>not</em> explicit. Installing or removing a {@code convention}
+ * never marks the value explicit, and consulting it (reading the value) does not either, so a user
+ * re-assigning the same value the convention would supply stays explicit. In particular
+ * {@code unsetConvention()} (which only removes the convention and never touches an explicitly set
+ * value), provenance is left untouched, so an explicitly assigned launcher remains explicit after the
+ * convention is dropped.</p>
+ *
+ * <p>To preserve Gradle's mutation and exception semantics the interceptor first delegates every call
+ * to the real property and only updates the provenance flag once the call has succeeded. This keeps
+ * provenance consistent with Gradle's actual state even when a mutation is rejected by the backing
+ * property (for example a finalized value that must not be reassigned), letting Gradle's own exception
+ * propagate untouched. Fluent/chaining methods ({@code value}, {@code convention}, {@code unset},
+ * {@code unsetConvention}) return the proxy itself so that subsequent mutations remain intercepted.</p>
+ */
+public final class JavaLauncherProperty {
+    private final Property<JavaLauncher> property;
+    private final Provider<Boolean> explicit;
+
+    private JavaLauncherProperty(Property<JavaLauncher> delegate, ProviderFactory providers) {
+        final boolean[] explicitFlag = {false};
+        InvocationHandler handler = (proxy, method, args) ->
+                handle(proxy, method, args, delegate, explicitFlag);
+        this.property = (Property<JavaLauncher>) Proxy.newProxyInstance(
+                JavaLauncher.class.getClassLoader(), new Class<?>[]{Property.class}, handler);
+        this.explicit = providers.provider(() -> property.isPresent() && explicitFlag[0]);
+    }
+
+    public static JavaLauncherProperty of(Property<JavaLauncher> delegate, ProviderFactory providers) {
+        return new JavaLauncherProperty(delegate, providers);
+    }
+
+    /**
+     * The proxied {@link Property} to expose via {@code @Nested} inputs and to users.
+     */
+    public Property<JavaLauncher> getProperty() {
+        return property;
+    }
+
+    /**
+     * Whether the resolved launcher was assigned explicitly by the user rather than supplied by the
+     * convention. Read at execution time (resolves the property, which may trigger toolchain detection).
+     * §FS-native-invocation.1.1, §FS-native-invocation.1.2.
+     */
+    public Provider<Boolean> explicit() {
+        return explicit;
+    }
+
+    private static Object handle(Object proxy, Method method, Object[] args,
+                                 Property<JavaLauncher> delegate, boolean[] explicitFlag)
+            throws Throwable {
+        Object[] actualArgs = args != null ? args : new Object[0];
+        switch (method.getName()) {
+            case "set":
+                // set(value) marks the value explicit; set(null) is the idiomatic unset and clears it.
+                // Delegate first so a failed call cannot corrupt the provenance flag, and return the
+                // delegate's (void) result verbatim.
+                Object setResult = invokeDelegated(method, delegate, actualArgs);
+                explicitFlag[0] = !(actualArgs.length == 1 && actualArgs[0] == null);
+                return setResult;
+            case "value":
+                // Delegate first so a rejected mutation propagates Gradle's exception and leaves
+                // provenance untouched. A null argument is treated by Gradle as a no-op (the value
+                // keeps coming from the convention), so it must not mark the value explicit, matching
+                // Gradle's own semantics. A non-null argument marks the value explicit. Return the
+                // proxy so a subsequent chained mutation still passes through this interceptor.
+                invokeDelegated(method, delegate, actualArgs);
+                if (actualArgs.length == 1 && actualArgs[0] != null) {
+                    explicitFlag[0] = true;
+                }
+                return proxy;
+            case "unset":
+                // Clearing the explicit value restores convention provenance.
+                invokeDelegated(method, delegate, actualArgs);
+                explicitFlag[0] = false;
+                return proxy;
+            case "convention":
+            case "unsetConvention":
+                // Installing or removing a convention never marks the value explicit and neither touches
+                // an explicitly set value, so leave the provenance flag untouched. Delegate first and
+                // return the proxy so chained mutations stay intercepted.
+                invokeDelegated(method, delegate, actualArgs);
+                return proxy;
+            case "equals":
+                // By default this would delegate to delegate.equals(proxy), which is false even for
+                // proxy.equals(proxy). Preserve referential identity, consistent with hashCode/toString.
+                return proxy == actualArgs[0];
+            case "hashCode":
+                return System.identityHashCode(proxy);
+            case "toString":
+                return JavaLauncherProperty.class.getName() + "@"
+                        + Integer.toHexString(System.identityHashCode(proxy));
+            default:
+                return invokeDelegated(method, delegate, actualArgs);
+        }
+    }
+
+    /**
+     * Delegates a call to the real property, unwrapping a Java reflection {@link InvocationTargetException}
+     * so the caller receives Gradle's own exception (e.g. an {@code IllegalStateException} from mutating a
+     * finalized value) rather than a {@code UndeclaredThrowableException} wrapping it.
+     */
+    private static Object invokeDelegated(Method method, Object target, Object[] args) throws Throwable {
+        try {
+            return method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
@@ -41,7 +41,6 @@
 package org.graalvm.buildtools.gradle.internal;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
@@ -69,56 +68,236 @@ public class NativeImageExecutableLocator {
     }
 
     public static Provider<String> graalvmHomeProvider(ProviderFactory providers, Diagnostics diagnostics) {
-        return diagnostics.fromEnvVar("GRAALVM_HOME", providers)
-                .orElse(diagnostics.fromEnvVar("JAVA_HOME", providers));
+        return graalvmHomeProvider(providers, diagnostics, providers.provider(() -> System.getProperty("java.home")));
     }
 
-    public static File findNativeImageExecutable(Property<JavaLauncher> javaLauncher,
-                                                 Provider<Boolean> disableToolchainDetection,
-                                                 Provider<String> graalvmHomeProvider,
-                                                 ExecOperations execOperations,
-                                                 GraalVMLogger logger,
-                                                 Diagnostics diagnostics) {
+    /**
+     * Creates a provider for the GraalVM home path.
+     * The search order is: GRAALVM_HOME, JAVA_HOME, then gradleJvmHome.
+     * gradleJvmHome is the last resort when neither env var is set.
+     */
+    public static Provider<String> graalvmHomeProvider(ProviderFactory providers, Diagnostics diagnostics, Provider<String> gradleJvmHome) {
+        return diagnostics.fromEnvVar("GRAALVM_HOME", providers)
+                .orElse(diagnostics.fromEnvVar("JAVA_HOME", providers))
+                .orElse(diagnostics.fromGradleJvm(gradleJvmHome));
+    }
+
+    /**
+     * A candidate GraalVM home to probe when the primary home lacks native-image.
+     * {@code home} is the resolved path (or null if unset) and {@code label} is the
+     * diagnostic source label recorded when this home is selected
+     * (see §FS-native-invocation.1.5).
+     */
+    public record VmHomeCandidate(String home, String label) {
+    }
+
+    /**
+     * Builds the default cross-home fallback candidates from the process environment:
+     * GRAALVM_HOME, JAVA_HOME, then the Gradle JVM home (java.home). Exposed so callers
+     * can inject resolved candidates and keep {@link #findInOtherGraalVmHomes} deterministic
+     * and testable (§FS-native-invocation.1.3).
+     */
+    public static List<VmHomeCandidate> defaultFallbackCandidates(ProviderFactory providers) {
+        return List.of(
+                new VmHomeCandidate(providers.environmentVariable("GRAALVM_HOME").getOrNull(), "GRAALVM_HOME"),
+                new VmHomeCandidate(providers.environmentVariable("JAVA_HOME").getOrNull(), "JAVA_HOME"),
+                new VmHomeCandidate(providers.provider(() -> System.getProperty("java.home")).getOrNull(), "Gradle JVM (java.home)")
+        );
+    }
+
+    /**
+     * Find the native-image executable from the given Java launcher.
+     * <p>
+     * Search order: launcher first, then environment variables.
+     * <ol>
+     *   <li>Configured Java launcher (toolchain): probe the installation for native-image; if {@code isExplicit},
+     *      fail immediately when native-image is missing; otherwise fall through to step 2
+     *   <li>Environment variables (GRAALVM_HOME or JAVA_HOME): probe and fall back to other GraalVM
+     *      homes (including the Gradle JVM itself) if gu install fails
+     *</ol>
+     *
+     * If native-image is not found and the GraalVM installation has the gu tool
+     * available, attempts to install native-image automatically.
+     *
+     * @param launcher the resolved Java launcher to probe, or null if none available
+     * @param isExplicit whether the launcher was explicitly set by the user
+     * @param disableToolchainDetection provider to disable toolchain detection (used for diagnostics)
+     * @param graalvmHomeProvider provider for GRAALVM_HOME/JAVA_HOME
+     * @param execOperations exec operations for gu install
+     * @param logger logger for messages
+     * @param diagnostics diagnostics collector
+     * @param fallbackVmHomeCandidates resolved cross-home fallback candidates
+     * @return the native-image executable file
+     * @throws GradleException if native-image cannot be found or installed,
+     *     or if an explicitly configured launcher does not contain native-image
+     */
+    public static File findNativeImageExecutable(
+            JavaLauncher launcher,
+            boolean isExplicit,
+            Provider<Boolean> disableToolchainDetection,
+            Provider<String> graalvmHomeProvider,
+            ExecOperations execOperations,
+            GraalVMLogger logger,
+            Diagnostics diagnostics,
+            List<VmHomeCandidate> fallbackVmHomeCandidates) {
         File executablePath = null;
-        boolean toolchainDetectionIsDisabled = Boolean.TRUE.equals(disableToolchainDetection.get());
-        if (toolchainDetectionIsDisabled || !javaLauncher.isPresent()) {
-            if (graalvmHomeProvider.isPresent()) {
-                diagnostics.disableToolchainDetection();
-                String graalvmHome = graalvmHomeProvider.get();
-                executablePath = Paths.get(graalvmHome).resolve("bin/" + NATIVE_IMAGE_EXE).toFile();
-            }
-        }
-        if (executablePath == null) {
-            JavaInstallationMetadata metadata = javaLauncher.get().getMetadata();
+
+        // Try the configured toolchain launcher if provided
+        if (launcher != null) {
+            JavaInstallationMetadata metadata = launcher.getMetadata();
             diagnostics.withToolchain(metadata);
-            executablePath = metadata.getInstallationPath().file("bin/" + NATIVE_IMAGE_EXE).getAsFile();
-        }
-
-        File graalVmHomeGuess = executablePath.getParentFile();
-        File guPath = graalVmHomeGuess.toPath().resolve(GU_EXE).toFile();
-        if (guPath.exists() && !executablePath.exists()) {
-            logger.log("Native Image executable wasn't found. We will now try to download it. ");
-
-            ExecResult res = execOperations.exec(spec -> {
-                spec.args("install", "native-image");
-                spec.setExecutable(Paths.get(graalVmHomeGuess.getAbsolutePath(), GU_EXE));
-            });
-            if (res.getExitValue() != 0) {
-                throw new GradleException("Native Image executable wasn't found, and '" + GU_EXE + "' tool failed to install it.\n" +
-                        "Make sure to declare the GRAALVM_HOME or JAVA_HOME environment variable or install GraalVM with " +
-                        "native-image in a standard location recognized by Gradle Java toolchain support");
+            try {
+                executablePath = metadata.getInstallationPath().file("bin/" + NATIVE_IMAGE_EXE).getAsFile();
+            } catch (Exception e) {
+                // Probe failed, executablePath remains null
             }
-            diagnostics.withGuInstall();
+
+            // If the launcher was explicitly set and native-image is still not found, fail immediately
+            if (isExplicit && (executablePath == null || !executablePath.exists())) {
+                String installPath;
+                try {
+                    installPath = metadata.getInstallationPath().getAsFile().getCanonicalPath();
+                } catch (IOException e) {
+                    installPath = metadata.getInstallationPath().getAsFile().getAbsolutePath();
+                }
+                throw new GradleException(
+                        "The Java toolchain at " + installPath + " does not contain the 'native-image' executable. " +
+                        "Please select a GraalVM-based Java toolchain that includes native-image in its bin/ directory, " +
+                        "or remove the javaLauncher configuration to let the plugin fall back to GRAALVM_HOME/JAVA_HOME " +
+                        "environment variables.");
+            }
         }
 
-        if (!executablePath.exists()) {
-            throw new GradleException(executablePath + " wasn't found. This probably means that JDK isn't a GraalVM distribution.\n" +
-                    "Make sure to declare the GRAALVM_HOME or JAVA_HOME environment variable or install GraalVM with" +
-                    "native-image in a standard location recognized by Gradle Java toolchain support");
+        // If launcher not provided or convention launcher didn't find native-image, try environment variables
+        if ((executablePath == null || !executablePath.exists()) && graalvmHomeProvider.isPresent()) {
+            diagnostics.disableToolchainDetection();
+            String graalvmHome = graalvmHomeProvider.get();
+            executablePath = Paths.get(graalvmHome).resolve("bin/" + NATIVE_IMAGE_EXE).toFile();
+
+            // Try to install native-image via gu if the executable doesn't exist yet
+            tryInstallNativeImageViaGu(executablePath, execOperations, logger, diagnostics);
+
+            // If gu install didn't help (binary still missing), try other GraalVM homes
+            if (!executablePath.exists()) {
+                String fallback = findInOtherGraalVmHomes(graalvmHome, logger, diagnostics, fallbackVmHomeCandidates);
+                if (fallback != null) {
+                    executablePath = Paths.get(fallback).resolve("bin/" + NATIVE_IMAGE_EXE).toFile();
+                }
+            }
+        }
+
+        // Fail if native-image executable still not found
+        if (executablePath == null || !executablePath.exists()) {
+            StringBuilder errorMessage = new StringBuilder();
+
+            // Clarify when toolchain detection was disabled
+            if (disableToolchainDetection.get()) {
+                errorMessage.append("Toolchain detection was disabled, and ");
+            }
+
+            String graalvmHome = graalvmHomeProvider.getOrNull();
+            if (graalvmHome != null) {
+                String envVarName = diagnostics.getEnvVarName() != null
+                        ? diagnostics.getEnvVarName()
+                        : "the resolved GraalVM home";
+                errorMessage.append("native-image was not found at " + envVarName + " (" + graalvmHome + "), even after attempting gu install.");
+            } else {
+                errorMessage.append("Neither GRAALVM_HOME nor JAVA_HOME is set, and no GraalVM toolchain was resolved.");
+            }
+
+            if (graalvmHome == null) {
+                errorMessage.append(" The build is running with Gradle on a non-GraalVM JDK. ");
+            }
+            errorMessage.append("Please configure a GraalVM-based Java toolchain or set GRAALVM_HOME/JAVA_HOME to a GraalVM with native-image.");
+
+            throw new GradleException(errorMessage.toString());
         }
 
         diagnostics.withExecutablePath(executablePath);
         return executablePath;
+    }
+
+    /**
+     * Attempts to install native-image via gu if:
+     * - The executablePath is non-null
+     * - The executable doesn't exist
+     * - The gu tool is available in the same bin/ directory
+     *
+     * Logs a message and updates diagnostics on successful installation.
+     *
+     * @param executablePath path to the expected native-image location
+     * @param execOperations exec operations for running gu
+     * @param logger logger for status messages
+     * @param diagnostics diagnostics collector to track installation
+     */
+    private static void tryInstallNativeImageViaGu(
+            File executablePath,
+            ExecOperations execOperations,
+            GraalVMLogger logger,
+            Diagnostics diagnostics) {
+        if (executablePath == null) {
+            return;
+        }
+
+        File graalVmHomeGuess = executablePath.getParentFile();
+        if (graalVmHomeGuess == null) {
+            return;
+        }
+
+        File guPath = graalVmHomeGuess.toPath().resolve(GU_EXE).toFile();
+        if (!guPath.exists() || executablePath.exists()) {
+            return;
+        }
+
+        logger.lifecycle("Native Image executable wasn't found. Installing via gu...");
+        ExecResult res = execOperations.exec(spec -> {
+            spec.args("install", "native-image");
+            spec.setExecutable(Paths.get(graalVmHomeGuess.getAbsolutePath(), GU_EXE));
+            spec.setIgnoreExitValue(true);
+        });
+        if (res.getExitValue() != 0) {
+            throw new GradleException("gu tool failed to install native-image. " +
+                    "Please install native-image manually via 'gu install native-image' " +
+                    "or configure a GraalVM installation that already includes native-image.");
+        }
+        logger.lifecycle("Native Image installed successfully.");
+        diagnostics.withGuInstall();
+    }
+
+    /**
+     * Finds native-image in alternative GraalVM locations when the primary candidate
+     * lacks native-image even after a gu install attempt.
+     * Checks GRAALVM_HOME, JAVA_HOME, and the Gradle JVM home - whichever is different
+     * from the path that just failed.
+     *
+     * @param currentHome         the GraalVM home that just failed (skip this one)
+     * @param logger              logger for diagnostic messages
+     * @return the path to an alternative GraalVM home with native-image, or null if none found
+     */
+    private static String findInOtherGraalVmHomes(
+            String currentHome,
+            GraalVMLogger logger,
+            Diagnostics diagnostics,
+            List<VmHomeCandidate> vmHomeCandidates) {
+        // Try alternative GraalVM locations. One of these is always the currentHome,
+        // which gets skipped by the equals() check below to avoid re-checking the same path.
+        // Each candidate is paired with the label used for diagnostic reporting so the
+        // selected source is recorded accurately (see §FS-native-invocation.1.5).
+        for (VmHomeCandidate vmHomeCandidate : vmHomeCandidates) {
+            String home = vmHomeCandidate.home;
+            String label = vmHomeCandidate.label;
+            if (home == null || home.equals(currentHome)) {
+                continue;
+            }
+            File candidateExe = Paths.get(home).resolve("bin/" + NATIVE_IMAGE_EXE).toFile();
+            if (candidateExe.exists()) {
+                logger.lifecycle("Using native-image from alternative GraalVM home: " + home);
+                diagnostics.setLocationSource(label);
+                return home;
+            }
+        }
+
+        return null;
     }
 
     public static final class Diagnostics {
@@ -137,6 +316,25 @@ public class NativeImageExecutableLocator {
                     }));
         }
 
+        public Provider<String> fromGradleJvm(Provider<String> gradleJvmHome) {
+            // Records that the Gradle JVM (java.home) was the selected source so diagnostics
+            // can distinguish it from GRAALVM_HOME / JAVA_HOME (see §FS-native-invocation.1.5).
+            return gradleJvmHome.map(ConfigurationCacheSupport.serializableTransformerOf(value -> {
+                this.envVar = "Gradle JVM (java.home)";
+                return value;
+            }));
+        }
+
+        /**
+         * Records the GraalVM location source after native-image was found through an
+         * alternative home (e.g. fallback when gu install failed). Keeps diagnostics in
+         * line with the actually-used source (§FS-native-invocation.1.5).
+         */
+        public void setLocationSource(String source) {
+            this.envVar = source;
+        }
+
+
         public void withToolchain(JavaInstallationMetadata toolchain) {
             this.toolchain = toolchain;
             this.envVar = null;
@@ -150,6 +348,10 @@ public class NativeImageExecutableLocator {
             guInstall = true;
         }
 
+        public String getEnvVarName() {
+            return envVar;
+        }
+
         public void withExecutablePath(File path) {
             executablePath = path;
         }
@@ -158,7 +360,7 @@ public class NativeImageExecutableLocator {
             List<String> diags = new ArrayList<>();
             diags.add("GraalVM Toolchain detection is " + (toolchainDetectionDisabled ? "disabled" : "enabled"));
             if (envVar != null) {
-                diags.add("GraalVM location read from environment variable: " + envVar);
+                diags.add("GraalVM location source: " + envVar);
             }
             if (guInstall) {
                 diags.add("Native Image executable was installed using 'gu' tool");

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
@@ -41,7 +41,6 @@
 package org.graalvm.buildtools.gradle.internal;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
@@ -69,64 +68,295 @@ public class NativeImageExecutableLocator {
     }
 
     public static Provider<String> graalvmHomeProvider(ProviderFactory providers, Diagnostics diagnostics) {
-        return diagnostics.fromEnvVar("GRAALVM_HOME", providers)
-                .orElse(diagnostics.fromEnvVar("JAVA_HOME", providers));
+        return graalvmHomeProvider(providers, diagnostics, providers.provider(() -> System.getProperty("java.home")));
     }
 
-    public static File findNativeImageExecutable(Property<JavaLauncher> javaLauncher,
-                                                 Provider<Boolean> disableToolchainDetection,
-                                                 Provider<String> graalvmHomeProvider,
-                                                 ExecOperations execOperations,
-                                                 GraalVMLogger logger,
-                                                 Diagnostics diagnostics) {
+    /**
+     * Creates a provider for the GraalVM home path.
+     * The search order is: GRAALVM_HOME, JAVA_HOME, then gradleJvmHome.
+     * gradleJvmHome is the last resort when neither env var is set.
+     */
+    public static Provider<String> graalvmHomeProvider(ProviderFactory providers, Diagnostics diagnostics, Provider<String> gradleJvmHome) {
+        return diagnostics.fromEnvVar("GRAALVM_HOME", providers)
+                .orElse(diagnostics.fromEnvVar("JAVA_HOME", providers))
+                .orElse(diagnostics.fromGradleJvm(gradleJvmHome));
+    }
+
+    /**
+     * A candidate GraalVM home to probe when the primary home lacks native-image.
+     * {@code home} is the resolved path (or null if unset) and {@code label} is the
+     * diagnostic source label recorded when this home is selected
+     * (see §FS-native-invocation.1.5).
+     */
+    public record VmHomeCandidate(String home, String label) {
+    }
+
+    /**
+     * Builds the default cross-home fallback candidates from the process environment:
+     * GRAALVM_HOME, JAVA_HOME, then the Gradle JVM home (java.home). Exposed so callers
+     * can inject resolved candidates and keep {@link #findInOtherGraalVmHomes} deterministic
+     * and testable (§FS-native-invocation.1.3).
+     */
+    public static List<VmHomeCandidate> defaultFallbackCandidates(ProviderFactory providers) {
+        return defaultFallbackCandidates(
+                providers.environmentVariable("GRAALVM_HOME"),
+                providers.environmentVariable("JAVA_HOME"),
+                providers.provider(() -> System.getProperty("java.home")));
+    }
+
+    /**
+     * Builds the cross-home fallback candidates from explicit providers. Tasks that
+     * fingerprint these sources as inputs MUST pass the same providers here so the
+     * probed candidate set and the up-to-date inputs stay in sync (§FS-native-invocation.1.3).
+     */
+    public static List<VmHomeCandidate> defaultFallbackCandidates(
+            Provider<String> graalVmHome,
+            Provider<String> javaHome,
+            Provider<String> gradleJvmHome) {
+        return List.of(
+                new VmHomeCandidate(graalVmHome.getOrNull(), "GRAALVM_HOME"),
+                new VmHomeCandidate(javaHome.getOrNull(), "JAVA_HOME"),
+                new VmHomeCandidate(gradleJvmHome.getOrNull(), "Gradle JVM (java.home)")
+        );
+    }
+
+    /**
+     * Find the native-image executable from the given Java launcher.
+     * <p>
+     * Search order: launcher first, then environment variables.
+     * <ol>
+     *   <li>Configured Java launcher (toolchain): probe the installation for native-image; if {@code isExplicit},
+     *      fail immediately when native-image is missing; otherwise fall through to step 2
+     *   <li>Environment variables (GRAALVM_HOME or JAVA_HOME): probe and fall back to other GraalVM
+     *      homes (including the Gradle JVM itself) if gu install fails
+     *</ol>
+     *
+     * If native-image is not found and the GraalVM installation has the gu tool
+     * available, attempts to install native-image automatically.
+     *
+     * @param launcher the resolved Java launcher to probe, or null if none available
+     * @param isExplicit whether the launcher was explicitly set by the user
+     * @param disableToolchainDetection provider to disable toolchain detection (used for diagnostics)
+     * @param graalvmHomeProvider provider for GRAALVM_HOME/JAVA_HOME
+     * @param execOperations exec operations for gu install
+     * @param logger logger for messages
+     * @param diagnostics diagnostics collector
+     * @param fallbackVmHomeCandidates resolved cross-home fallback candidates
+     * @return the native-image executable file
+     * @throws GradleException if native-image cannot be found or installed,
+     *     or if an explicitly configured launcher does not contain native-image
+     */
+    public static File findNativeImageExecutable(
+            JavaLauncher launcher,
+            boolean isExplicit,
+            Provider<Boolean> disableToolchainDetection,
+            Provider<String> graalvmHomeProvider,
+            ExecOperations execOperations,
+            GraalVMLogger logger,
+            Diagnostics diagnostics,
+            List<VmHomeCandidate> fallbackVmHomeCandidates) {
         File executablePath = null;
-        boolean toolchainDetectionIsDisabled = Boolean.TRUE.equals(disableToolchainDetection.get());
-        if (toolchainDetectionIsDisabled || !javaLauncher.isPresent()) {
-            if (graalvmHomeProvider.isPresent()) {
-                diagnostics.disableToolchainDetection();
-                String graalvmHome = graalvmHomeProvider.get();
-                executablePath = Paths.get(graalvmHome).resolve("bin/" + NATIVE_IMAGE_EXE).toFile();
-            }
-        }
-        if (executablePath == null) {
-            JavaInstallationMetadata metadata = javaLauncher.get().getMetadata();
+
+        // Try the configured toolchain launcher if provided
+        if (launcher != null) {
+            JavaInstallationMetadata metadata = launcher.getMetadata();
             diagnostics.withToolchain(metadata);
-            executablePath = metadata.getInstallationPath().file("bin/" + NATIVE_IMAGE_EXE).getAsFile();
-        }
-
-        File graalVmHomeGuess = executablePath.getParentFile();
-        File guPath = graalVmHomeGuess.toPath().resolve(GU_EXE).toFile();
-        if (guPath.exists() && !executablePath.exists()) {
-            logger.log("Native Image executable wasn't found. We will now try to download it. ");
-
-            ExecResult res = execOperations.exec(spec -> {
-                spec.args("install", "native-image");
-                spec.setExecutable(Paths.get(graalVmHomeGuess.getAbsolutePath(), GU_EXE));
-            });
-            if (res.getExitValue() != 0) {
-                throw new GradleException("Native Image executable wasn't found, and '" + GU_EXE + "' tool failed to install it.\n" +
-                        "Make sure to declare the GRAALVM_HOME or JAVA_HOME environment variable or install GraalVM with " +
-                        "native-image in a standard location recognized by Gradle Java toolchain support");
+            try {
+                executablePath = metadata.getInstallationPath().file("bin/" + NATIVE_IMAGE_EXE).getAsFile();
+                diagnostics.addProbedPath(executablePath.getAbsolutePath());
+            } catch (Exception e) {
+                // Probe failed, executablePath remains null
             }
-            diagnostics.withGuInstall();
+
+            // If the launcher was explicitly set and native-image is still not found, fail immediately
+            if (isExplicit && (executablePath == null || !executablePath.exists())) {
+                String installPath;
+                try {
+                    installPath = metadata.getInstallationPath().getAsFile().getCanonicalPath();
+                } catch (IOException e) {
+                    installPath = metadata.getInstallationPath().getAsFile().getAbsolutePath();
+                }
+                throw new GradleException(
+                        "The explicitly configured javaLauncher (" + metadata.getLanguageVersion() + ", " + metadata.getVendor() + ") at " + installPath +
+                        " does not contain the 'native-image' executable. " +
+                        "Please select a GraalVM-based Java toolchain that includes native-image in its bin/ directory, " +
+                        "or remove the javaLauncher configuration to let the plugin fall back to GRAALVM_HOME/JAVA_HOME " +
+                        "environment variables.");
+            }
         }
 
-        if (!executablePath.exists()) {
-            throw new GradleException(executablePath + " wasn't found. This probably means that JDK isn't a GraalVM distribution.\n" +
-                    "Make sure to declare the GRAALVM_HOME or JAVA_HOME environment variable or install GraalVM with" +
-                    "native-image in a standard location recognized by Gradle Java toolchain support");
+        // If launcher not provided or convention launcher didn't find native-image, try environment variables
+        if ((executablePath == null || !executablePath.exists()) && graalvmHomeProvider.isPresent()) {
+            if (disableToolchainDetection.get()) {
+                diagnostics.disableToolchainDetection();
+            }
+            String graalvmHome = graalvmHomeProvider.get();
+            executablePath = Paths.get(graalvmHome).resolve("bin/" + NATIVE_IMAGE_EXE).toFile();
+            diagnostics.addProbedPath(executablePath.getAbsolutePath());
+
+            // Try to install native-image via gu if the executable doesn't exist yet
+            tryInstallNativeImageViaGu(executablePath, execOperations, logger, diagnostics);
+
+            // If gu install didn't help (binary still missing), try other GraalVM homes
+            if (!executablePath.exists()) {
+                String fallback = findInOtherGraalVmHomes(graalvmHome, logger, diagnostics, fallbackVmHomeCandidates);
+                if (fallback != null) {
+                    executablePath = Paths.get(fallback).resolve("bin/" + NATIVE_IMAGE_EXE).toFile();
+                }
+            }
+        }
+
+        // Fail if native-image executable still not found
+        if (executablePath == null || !executablePath.exists()) {
+            StringBuilder errorMessage = new StringBuilder();
+
+            // Clarify when toolchain detection was disabled
+            if (disableToolchainDetection.get()) {
+                errorMessage.append("Toolchain detection was disabled, and ");
+            }
+
+            String graalvmHome = graalvmHomeProvider.getOrNull();
+            if (graalvmHome != null) {
+                String envVarName = diagnostics.getEnvVarName() != null
+                        ? diagnostics.getEnvVarName()
+                        : "the resolved GraalVM home";
+                errorMessage.append("native-image was not found at " + envVarName + " (" + graalvmHome + ")");
+                if (diagnostics.isGuInstallAttempted()) {
+                    errorMessage.append(", even after attempting gu install");
+                } else if (diagnostics.isGuUnavailable()) {
+                    errorMessage.append("; the gu tool was not available in that installation to install native-image");
+                }
+                errorMessage.append(".");
+            } else {
+                errorMessage.append("Neither GRAALVM_HOME nor JAVA_HOME is set, and no GraalVM toolchain was resolved.");
+            }
+
+            if (graalvmHome == null) {
+                errorMessage.append(" The build is running with Gradle on a non-GraalVM JDK. ");
+            }
+            if (fallbackVmHomeCandidates != null && !fallbackVmHomeCandidates.isEmpty()) {
+                errorMessage.append("\nLookup sources:");
+                for (VmHomeCandidate candidate : fallbackVmHomeCandidates) {
+                    errorMessage.append("\n   - " + candidate.label + ": " + (candidate.home == null ? "not set" : candidate.home));
+                }
+            }
+            List<String> probed = diagnostics.getProbedPaths();
+            if (!probed.isEmpty()) {
+                errorMessage.append("\nProbed paths:");
+                for (String p : probed) {
+                    errorMessage.append("\n   - " + p);
+                }
+            }
+            errorMessage.append("\n");
+            errorMessage.append("Please configure a GraalVM-based Java toolchain or set GRAALVM_HOME/JAVA_HOME to a GraalVM with native-image.");
+
+            throw new GradleException(errorMessage.toString());
         }
 
         diagnostics.withExecutablePath(executablePath);
         return executablePath;
     }
 
+    /**
+     * Attempts to install native-image via gu if:
+     * - The executablePath is non-null
+     * - The executable doesn't exist
+     * - The gu tool is available in the same bin/ directory
+     *
+     * Logs a message and updates diagnostics on successful installation.
+     *
+     * @param executablePath path to the expected native-image location
+     * @param execOperations exec operations for running gu
+     * @param logger logger for status messages
+     * @param diagnostics diagnostics collector to track installation
+     */
+    private static void tryInstallNativeImageViaGu(
+            File executablePath,
+            ExecOperations execOperations,
+            GraalVMLogger logger,
+            Diagnostics diagnostics) {
+        if (executablePath == null) {
+            return;
+        }
+
+        File graalVmHomeGuess = executablePath.getParentFile();
+        if (graalVmHomeGuess == null) {
+            return;
+        }
+
+        File guPath = graalVmHomeGuess.toPath().resolve(GU_EXE).toFile();
+        if (!guPath.exists() || executablePath.exists()) {
+            if (!guPath.exists()) {
+                diagnostics.withGuUnavailable();
+            }
+            return;
+        }
+
+        logger.lifecycle("Native Image executable wasn't found. Installing via gu...");
+        diagnostics.withGuAttempted();
+        ExecResult res = execOperations.exec(spec -> {
+            spec.args("install", "native-image");
+            spec.setExecutable(Paths.get(graalVmHomeGuess.getAbsolutePath(), GU_EXE));
+            spec.setIgnoreExitValue(true);
+        });
+        if (res.getExitValue() != 0) {
+            logger.warn("gu tool failed to install native-image. " +
+                    "Please install native-image manually via 'gu install native-image' " +
+                    "or configure a GraalVM installation that already includes native-image.");
+            diagnostics.withGuInstallFailed();
+            return;
+        }
+        logger.lifecycle("Native Image installed successfully.");
+        diagnostics.withGuInstall();
+    }
+
+    /**
+     * Finds native-image in alternative GraalVM locations when the primary candidate
+     * lacks native-image even after a gu install attempt.
+     * Checks GRAALVM_HOME, JAVA_HOME, and the Gradle JVM home - whichever is different
+     * from the path that just failed.
+     *
+     * @param currentHome         the GraalVM home that just failed (skip this one)
+     * @param logger              logger for diagnostic messages
+     * @return the path to an alternative GraalVM home with native-image, or null if none found
+     */
+    private static String findInOtherGraalVmHomes(
+            String currentHome,
+            GraalVMLogger logger,
+            Diagnostics diagnostics,
+            List<VmHomeCandidate> vmHomeCandidates) {
+        // Try alternative GraalVM locations. One of these is always the currentHome,
+        // which gets skipped by the equals() check below to avoid re-checking the same path.
+        // Each candidate is paired with the label used for diagnostic reporting so the
+        // selected source is recorded accurately (see §FS-native-invocation.1.5).
+        for (VmHomeCandidate vmHomeCandidate : vmHomeCandidates) {
+            String home = vmHomeCandidate.home;
+            String label = vmHomeCandidate.label;
+            if (home == null || home.equals(currentHome)) {
+                continue;
+            }
+            File candidateExe = Paths.get(home).resolve("bin/" + NATIVE_IMAGE_EXE).toFile();
+            diagnostics.addProbedPath(candidateExe.getAbsolutePath());
+            if (candidateExe.exists()) {
+                logger.lifecycle("Using native-image from alternative GraalVM home: " + home);
+                diagnostics.setLocationSource(label);
+                return home;
+            }
+        }
+
+        return null;
+    }
+
     public static final class Diagnostics {
         private boolean toolchainDetectionDisabled;
         private String envVar;
+        private boolean guUnavailable;
+        private boolean guAttempted;
+        private boolean guInstallFailed;
         private boolean guInstall;
         private File executablePath;
         private JavaInstallationMetadata toolchain;
+        private final List<String> probedPaths = new ArrayList<>();
 
         public Provider<String> fromEnvVar(String envVar, ProviderFactory factory) {
             return factory.environmentVariable(envVar)
@@ -135,6 +365,28 @@ public class NativeImageExecutableLocator {
                         this.envVar = envVar;
                         return value;
                     }));
+        }
+
+        public Provider<String> fromGradleJvm(Provider<String> gradleJvmHome) {
+            // Records that the Gradle JVM (java.home) was the selected source so diagnostics
+            // can distinguish it from GRAALVM_HOME / JAVA_HOME (see §FS-native-invocation.1.5).
+            return gradleJvmHome.map(ConfigurationCacheSupport.serializableTransformerOf(value -> {
+                this.envVar = "Gradle JVM (java.home)";
+                return value;
+            }));
+        }
+
+        /**
+         * Records the GraalVM location source after native-image was found through an
+         * alternative home (e.g. fallback when gu install failed). Keeps diagnostics in
+         * line with the actually-used source (§FS-native-invocation.1.5).
+         */
+        public void setLocationSource(String source) {
+            this.envVar = source;
+        }
+
+        public void addProbedPath(String path) {
+            probedPaths.add(path);
         }
 
         public void withToolchain(JavaInstallationMetadata toolchain) {
@@ -150,6 +402,30 @@ public class NativeImageExecutableLocator {
             guInstall = true;
         }
 
+        public void withGuUnavailable() {
+            guUnavailable = true;
+        }
+
+        public void withGuAttempted() {
+            guAttempted = true;
+        }
+
+        public void withGuInstallFailed() {
+            guInstallFailed = true;
+        }
+
+        public boolean isGuInstallAttempted() {
+            return guAttempted;
+        }
+
+        public boolean isGuUnavailable() {
+            return guUnavailable;
+        }
+
+        public String getEnvVarName() {
+            return envVar;
+        }
+
         public void withExecutablePath(File path) {
             executablePath = path;
         }
@@ -158,10 +434,16 @@ public class NativeImageExecutableLocator {
             List<String> diags = new ArrayList<>();
             diags.add("GraalVM Toolchain detection is " + (toolchainDetectionDisabled ? "disabled" : "enabled"));
             if (envVar != null) {
-                diags.add("GraalVM location read from environment variable: " + envVar);
+                diags.add("GraalVM location source: " + envVar);
             }
-            if (guInstall) {
-                diags.add("Native Image executable was installed using 'gu' tool");
+            if (guAttempted) {
+                if (guInstall) {
+                    diags.add("Native Image executable was installed using 'gu' tool");
+                } else if (guInstallFailed) {
+                    diags.add("Native Image installation using 'gu' tool was attempted but failed");
+                }
+            } else if (guUnavailable) {
+                diags.add("The 'gu' tool was not available at the selected GraalVM home to install native-image");
             }
             if (toolchain != null) {
                 diags.add("GraalVM uses toolchain detection. Selected:");
@@ -176,7 +458,17 @@ public class NativeImageExecutableLocator {
                     diags.add("Native Image executable path: " + executablePath.getAbsolutePath());
                 }
             }
+            if (!probedPaths.isEmpty()) {
+                diags.add("Probed paths:");
+                for (String path : probedPaths) {
+                    diags.add("   - " + path);
+                }
+            }
             return Collections.unmodifiableList(diags);
+        }
+
+        public List<String> getProbedPaths() {
+            return Collections.unmodifiableList(probedPaths);
         }
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
@@ -177,7 +177,8 @@ public class NativeImageExecutableLocator {
                     installPath = metadata.getInstallationPath().getAsFile().getAbsolutePath();
                 }
                 throw new GradleException(
-                        "The Java toolchain at " + installPath + " does not contain the 'native-image' executable. " +
+                        "The explicitly configured javaLauncher (" + metadata.getLanguageVersion() + ", " + metadata.getVendor() + ") at " + installPath +
+                        " does not contain the 'native-image' executable. " +
                         "Please select a GraalVM-based Java toolchain that includes native-image in its bin/ directory, " +
                         "or remove the javaLauncher configuration to let the plugin fall back to GRAALVM_HOME/JAVA_HOME " +
                         "environment variables.");
@@ -219,7 +220,13 @@ public class NativeImageExecutableLocator {
                 String envVarName = diagnostics.getEnvVarName() != null
                         ? diagnostics.getEnvVarName()
                         : "the resolved GraalVM home";
-                errorMessage.append("native-image was not found at " + envVarName + " (" + graalvmHome + "), even after attempting gu install.");
+                errorMessage.append("native-image was not found at " + envVarName + " (" + graalvmHome + ")");
+                if (diagnostics.isGuInstallAttempted()) {
+                    errorMessage.append(", even after attempting gu install");
+                } else if (diagnostics.isGuUnavailable()) {
+                    errorMessage.append("; the gu tool was not available in that installation to install native-image");
+                }
+                errorMessage.append(".");
             } else {
                 errorMessage.append("Neither GRAALVM_HOME nor JAVA_HOME is set, and no GraalVM toolchain was resolved.");
             }
@@ -227,13 +234,17 @@ public class NativeImageExecutableLocator {
             if (graalvmHome == null) {
                 errorMessage.append(" The build is running with Gradle on a non-GraalVM JDK. ");
             }
+            if (fallbackVmHomeCandidates != null && !fallbackVmHomeCandidates.isEmpty()) {
+                errorMessage.append("\nLookup sources:");
+                for (VmHomeCandidate candidate : fallbackVmHomeCandidates) {
+                    errorMessage.append("\n   - " + candidate.label + ": " + (candidate.home == null ? "not set" : candidate.home));
+                }
+            }
             List<String> probed = diagnostics.getProbedPaths();
             if (!probed.isEmpty()) {
-                errorMessage.append(" Probed paths:");
+                errorMessage.append("\nProbed paths:");
                 for (String p : probed) {
-                    errorMessage.append("\n");
-                    errorMessage.append("   - ");
-                    errorMessage.append(p);
+                    errorMessage.append("\n   - " + p);
                 }
             }
             errorMessage.append("\n");
@@ -275,10 +286,14 @@ public class NativeImageExecutableLocator {
 
         File guPath = graalVmHomeGuess.toPath().resolve(GU_EXE).toFile();
         if (!guPath.exists() || executablePath.exists()) {
+            if (!guPath.exists()) {
+                diagnostics.withGuUnavailable();
+            }
             return;
         }
 
         logger.lifecycle("Native Image executable wasn't found. Installing via gu...");
+        diagnostics.withGuAttempted();
         ExecResult res = execOperations.exec(spec -> {
             spec.args("install", "native-image");
             spec.setExecutable(Paths.get(graalVmHomeGuess.getAbsolutePath(), GU_EXE));
@@ -288,6 +303,7 @@ public class NativeImageExecutableLocator {
             logger.warn("gu tool failed to install native-image. " +
                     "Please install native-image manually via 'gu install native-image' " +
                     "or configure a GraalVM installation that already includes native-image.");
+            diagnostics.withGuInstallFailed();
             return;
         }
         logger.lifecycle("Native Image installed successfully.");
@@ -334,6 +350,9 @@ public class NativeImageExecutableLocator {
     public static final class Diagnostics {
         private boolean toolchainDetectionDisabled;
         private String envVar;
+        private boolean guUnavailable;
+        private boolean guAttempted;
+        private boolean guInstallFailed;
         private boolean guInstall;
         private File executablePath;
         private JavaInstallationMetadata toolchain;
@@ -383,6 +402,26 @@ public class NativeImageExecutableLocator {
             guInstall = true;
         }
 
+        public void withGuUnavailable() {
+            guUnavailable = true;
+        }
+
+        public void withGuAttempted() {
+            guAttempted = true;
+        }
+
+        public void withGuInstallFailed() {
+            guInstallFailed = true;
+        }
+
+        public boolean isGuInstallAttempted() {
+            return guAttempted;
+        }
+
+        public boolean isGuUnavailable() {
+            return guUnavailable;
+        }
+
         public String getEnvVarName() {
             return envVar;
         }
@@ -397,8 +436,14 @@ public class NativeImageExecutableLocator {
             if (envVar != null) {
                 diags.add("GraalVM location source: " + envVar);
             }
-            if (guInstall) {
-                diags.add("Native Image executable was installed using 'gu' tool");
+            if (guAttempted) {
+                if (guInstall) {
+                    diags.add("Native Image executable was installed using 'gu' tool");
+                } else if (guInstallFailed) {
+                    diags.add("Native Image installation using 'gu' tool was attempted but failed");
+                }
+            } else if (guUnavailable) {
+                diags.add("The 'gu' tool was not available at the selected GraalVM home to install native-image");
             }
             if (toolchain != null) {
                 diags.add("GraalVM uses toolchain detection. Selected:");

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
@@ -148,6 +148,7 @@ public class NativeImageExecutableLocator {
             diagnostics.withToolchain(metadata);
             try {
                 executablePath = metadata.getInstallationPath().file("bin/" + NATIVE_IMAGE_EXE).getAsFile();
+                diagnostics.addProbedPath(executablePath.getAbsolutePath());
             } catch (Exception e) {
                 // Probe failed, executablePath remains null
             }
@@ -175,6 +176,7 @@ public class NativeImageExecutableLocator {
             }
             String graalvmHome = graalvmHomeProvider.get();
             executablePath = Paths.get(graalvmHome).resolve("bin/" + NATIVE_IMAGE_EXE).toFile();
+            diagnostics.addProbedPath(executablePath.getAbsolutePath());
 
             // Try to install native-image via gu if the executable doesn't exist yet
             tryInstallNativeImageViaGu(executablePath, execOperations, logger, diagnostics);
@@ -210,6 +212,16 @@ public class NativeImageExecutableLocator {
             if (graalvmHome == null) {
                 errorMessage.append(" The build is running with Gradle on a non-GraalVM JDK. ");
             }
+            List<String> probed = diagnostics.getProbedPaths();
+            if (!probed.isEmpty()) {
+                errorMessage.append(" Probed paths:");
+                for (String p : probed) {
+                    errorMessage.append("\n");
+                    errorMessage.append("   - ");
+                    errorMessage.append(p);
+                }
+            }
+            errorMessage.append("\n");
             errorMessage.append("Please configure a GraalVM-based Java toolchain or set GRAALVM_HOME/JAVA_HOME to a GraalVM with native-image.");
 
             throw new GradleException(errorMessage.toString());
@@ -293,6 +305,7 @@ public class NativeImageExecutableLocator {
                 continue;
             }
             File candidateExe = Paths.get(home).resolve("bin/" + NATIVE_IMAGE_EXE).toFile();
+            diagnostics.addProbedPath(candidateExe.getAbsolutePath());
             if (candidateExe.exists()) {
                 logger.lifecycle("Using native-image from alternative GraalVM home: " + home);
                 diagnostics.setLocationSource(label);
@@ -309,6 +322,7 @@ public class NativeImageExecutableLocator {
         private boolean guInstall;
         private File executablePath;
         private JavaInstallationMetadata toolchain;
+        private final List<String> probedPaths = new ArrayList<>();
 
         public Provider<String> fromEnvVar(String envVar, ProviderFactory factory) {
             return factory.environmentVariable(envVar)
@@ -337,6 +351,9 @@ public class NativeImageExecutableLocator {
             this.envVar = source;
         }
 
+        public void addProbedPath(String path) {
+            probedPaths.add(path);
+        }
 
         public void withToolchain(JavaInstallationMetadata toolchain) {
             this.toolchain = toolchain;
@@ -381,7 +398,17 @@ public class NativeImageExecutableLocator {
                     diags.add("Native Image executable path: " + executablePath.getAbsolutePath());
                 }
             }
+            if (!probedPaths.isEmpty()) {
+                diags.add("Probed paths:");
+                for (String path : probedPaths) {
+                    diags.add("   - " + path);
+                }
+            }
             return Collections.unmodifiableList(diags);
+        }
+
+        public List<String> getProbedPaths() {
+            return Collections.unmodifiableList(probedPaths);
         }
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
@@ -98,10 +98,25 @@ public class NativeImageExecutableLocator {
      * and testable (§FS-native-invocation.1.3).
      */
     public static List<VmHomeCandidate> defaultFallbackCandidates(ProviderFactory providers) {
+        return defaultFallbackCandidates(
+                providers.environmentVariable("GRAALVM_HOME"),
+                providers.environmentVariable("JAVA_HOME"),
+                providers.provider(() -> System.getProperty("java.home")));
+    }
+
+    /**
+     * Builds the cross-home fallback candidates from explicit providers. Tasks that
+     * fingerprint these sources as inputs MUST pass the same providers here so the
+     * probed candidate set and the up-to-date inputs stay in sync (§FS-native-invocation.1.3).
+     */
+    public static List<VmHomeCandidate> defaultFallbackCandidates(
+            Provider<String> graalVmHome,
+            Provider<String> javaHome,
+            Provider<String> gradleJvmHome) {
         return List.of(
-                new VmHomeCandidate(providers.environmentVariable("GRAALVM_HOME").getOrNull(), "GRAALVM_HOME"),
-                new VmHomeCandidate(providers.environmentVariable("JAVA_HOME").getOrNull(), "JAVA_HOME"),
-                new VmHomeCandidate(providers.provider(() -> System.getProperty("java.home")).getOrNull(), "Gradle JVM (java.home)")
+                new VmHomeCandidate(graalVmHome.getOrNull(), "GRAALVM_HOME"),
+                new VmHomeCandidate(javaHome.getOrNull(), "JAVA_HOME"),
+                new VmHomeCandidate(gradleJvmHome.getOrNull(), "Gradle JVM (java.home)")
         );
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocator.java
@@ -170,7 +170,9 @@ public class NativeImageExecutableLocator {
 
         // If launcher not provided or convention launcher didn't find native-image, try environment variables
         if ((executablePath == null || !executablePath.exists()) && graalvmHomeProvider.isPresent()) {
-            diagnostics.disableToolchainDetection();
+            if (disableToolchainDetection.get()) {
+                diagnostics.disableToolchainDetection();
+            }
             String graalvmHome = graalvmHomeProvider.get();
             executablePath = Paths.get(graalvmHome).resolve("bin/" + NATIVE_IMAGE_EXE).toFile();
 
@@ -256,9 +258,10 @@ public class NativeImageExecutableLocator {
             spec.setIgnoreExitValue(true);
         });
         if (res.getExitValue() != 0) {
-            throw new GradleException("gu tool failed to install native-image. " +
+            logger.warn("gu tool failed to install native-image. " +
                     "Please install native-image manually via 'gu install native-image' " +
                     "or configure a GraalVM installation that already includes native-image.");
+            return;
         }
         logger.lifecycle("Native Image installed successfully.");
         diagnostics.withGuInstall();

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -58,10 +58,10 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
@@ -73,6 +73,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
+import org.gradle.process.ExecSpec;
 
 import javax.inject.Inject;
 import java.io.ByteArrayOutputStream;
@@ -80,6 +81,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import static org.graalvm.buildtools.gradle.internal.ConfigurationCacheSupport.serializableBiFunctionOf;
 import static org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator.graalvmHomeProvider;
@@ -97,6 +99,8 @@ public abstract class BuildNativeImageTask extends DefaultTask {
     private final Provider<String> graalvmHomeProvider;
     private final NativeImageExecutableLocator.Diagnostics diagnostics;
     private final boolean plainConsole;
+
+    private Provider<JavaLauncher> conventionJavaLauncher;
 
     @Internal
     public abstract Property<NativeImageOptions> getOptions();
@@ -276,6 +280,10 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         getDisableToolchainDetection().convention(false);
     }
 
+    public void setConventionJavaLauncher(Provider<JavaLauncher> javaLauncher) {
+        this.conventionJavaLauncher = javaLauncher;
+    }
+
     private List<String> buildActualCommandLineArgs(int majorJDKVersion) {
         getOptions().finalizeValue();
         return new NativeImageCommandLineProvider(
@@ -306,14 +314,20 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         NativeImageOptions options = getOptions().get();
         GraalVMLogger logger = GraalVMLogger.of(getLogger());
 
+        var javaLauncherProperty = options.getJavaLauncher();
+        boolean isExplicit = javaLauncherProperty.isPresent();
+        JavaLauncher launcher = isExplicit ? javaLauncherProperty.get() :
+                (conventionJavaLauncher != null ? conventionJavaLauncher.getOrNull() : null);
+
         File executablePath = NativeImageExecutableLocator.findNativeImageExecutable(
-            options.getJavaLauncher(),
+            launcher, isExplicit,
             getDisableToolchainDetection(),
             getGraalVMHome(),
             getExecOperations(),
             logger,
-            diagnostics);
-        String versionString = getVersionString(getExecOperations(), executablePath);
+            diagnostics,
+            NativeImageExecutableLocator.defaultFallbackCandidates(getProviders()));
+        String versionString = getVersionString(getExecOperations(), options, executablePath);
         Boolean metadataEnabled = getMetadataRepositoryEnabled().getOrNull();
         String metadataRoot = getMetadataRepositoryRootPath().getOrNull();
         if (Boolean.TRUE.equals(metadataEnabled) && metadataRoot != null) {
@@ -335,10 +349,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         getFileSystemOperations().delete(d -> d.delete(outputDir));
         if (outputDir.isDirectory() || outputDir.mkdirs()) {
             getExecOperations().exec(spec -> {
-                MapProperty<String, Object> environmentVariables = options.getEnvironmentVariables();
-                if (environmentVariables.isPresent() && !environmentVariables.get().isEmpty()) {
-                    spec.environment(environmentVariables.get());
-                }
+                addEnvironmentVariables(spec, options);
                 spec.setWorkingDir(getWorkingDirectory());
                 if (getTestListDirectory().isPresent()) {
                     NativeImagePlugin.TrackingDirectorySystemPropertyProvider directoryProvider = getObjects().newInstance(NativeImagePlugin.TrackingDirectorySystemPropertyProvider.class);
@@ -353,14 +364,22 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         }
     }
 
-    public static String getVersionString(ExecOperations execOperations, File executablePath) {
+    public static String getVersionString(ExecOperations execOperations, NativeImageOptions options, File executablePath) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         ExecResult execResult = execOperations.exec(spec -> {
+            addEnvironmentVariables(spec, options);
             spec.setStandardOutput(outputStream);
             spec.args("--version");
             spec.setExecutable(executablePath.getAbsolutePath());
         });
         execResult.assertNormalExitValue();
         return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    private static void addEnvironmentVariables(ExecSpec spec, NativeImageOptions options) {
+        // Always inherit current process environment first to ensure PATH and other critical variables are available
+        spec.environment(System.getenv());
+        // Merge custom environment variables
+        spec.environment(options.getEnvironmentVariables().getOrElse(Map.of()));
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -315,7 +315,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         GraalVMLogger logger = GraalVMLogger.of(getLogger());
 
         var javaLauncherProperty = options.getJavaLauncher();
-        boolean isExplicit = javaLauncherProperty.isPresent();
+        boolean isExplicit = javaLauncherProperty.getOrNull() != null;
         JavaLauncher launcher = isExplicit ? javaLauncherProperty.get() :
                 (conventionJavaLauncher != null ? conventionJavaLauncher.getOrNull() : null);
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -100,7 +100,9 @@ public abstract class BuildNativeImageTask extends DefaultTask {
     private final NativeImageExecutableLocator.Diagnostics diagnostics;
     private final boolean plainConsole;
 
-    private Provider<JavaLauncher> conventionJavaLauncher;
+    @Nested
+    @Optional
+    public abstract Property<JavaLauncher> getConventionJavaLauncher();
 
     @Internal
     public abstract Property<NativeImageOptions> getOptions();
@@ -280,10 +282,6 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         getDisableToolchainDetection().convention(false);
     }
 
-    public void setConventionJavaLauncher(Provider<JavaLauncher> javaLauncher) {
-        this.conventionJavaLauncher = javaLauncher;
-    }
-
     private List<String> buildActualCommandLineArgs(int majorJDKVersion) {
         getOptions().finalizeValue();
         return new NativeImageCommandLineProvider(
@@ -316,7 +314,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
 
         var javaLauncherProperty = options.getJavaLauncher();
         JavaLauncher userLauncher = javaLauncherProperty.getOrNull();
-        JavaLauncher conventionValue = conventionJavaLauncher != null ? conventionJavaLauncher.getOrNull() : null;
+        JavaLauncher conventionValue = getConventionJavaLauncher().getOrNull();
         JavaLauncher launcher = userLauncher != null ? userLauncher : conventionValue;
         boolean isExplicit = userLauncher != null;
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -315,9 +315,9 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         GraalVMLogger logger = GraalVMLogger.of(getLogger());
 
         var javaLauncherProperty = options.getJavaLauncher();
-        boolean isExplicit = javaLauncherProperty.getOrNull() != null;
-        JavaLauncher launcher = isExplicit ? javaLauncherProperty.get() :
-                (conventionJavaLauncher != null ? conventionJavaLauncher.getOrNull() : null);
+        JavaLauncher launcher = javaLauncherProperty.getOrNull();
+        JavaLauncher conventionValue = conventionJavaLauncher != null ? conventionJavaLauncher.getOrNull() : null;
+        boolean isExplicit = launcher != null && !sameInstallation(launcher, conventionValue);
 
         File executablePath = NativeImageExecutableLocator.findNativeImageExecutable(
             launcher, isExplicit,
@@ -362,6 +362,14 @@ public abstract class BuildNativeImageTask extends DefaultTask {
             });
             logger.lifecycle("Native Image written to: " + outputDir);
         }
+    }
+
+    private static boolean sameInstallation(JavaLauncher a, JavaLauncher b) {
+        if (a == null || b == null) {
+            return a == b;
+        }
+        return a.getMetadata().getInstallationPath().getAsFile()
+            .equals(b.getMetadata().getInstallationPath().getAsFile());
     }
 
     public static String getVersionString(ExecOperations execOperations, NativeImageOptions options, File executablePath) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -84,6 +84,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.graalvm.buildtools.gradle.internal.ConfigurationCacheSupport.serializableBiFunctionOf;
+import static org.graalvm.buildtools.gradle.internal.ConfigurationCacheSupport.serializableTransformerOf;
 import static org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator.graalvmHomeProvider;
 import static org.graalvm.buildtools.utils.SharedConstants.EXECUTABLE_EXTENSION;
 
@@ -97,6 +98,9 @@ import static org.graalvm.buildtools.utils.SharedConstants.EXECUTABLE_EXTENSION;
  */
 public abstract class BuildNativeImageTask extends DefaultTask {
     private final Provider<String> graalvmHomeProvider;
+    private final Provider<String> graalvmHomeEnv;
+    private final Provider<String> javaHomeEnv;
+    private final Provider<String> gradleJvmHome;
     private final NativeImageExecutableLocator.Diagnostics diagnostics;
     private final boolean plainConsole;
 
@@ -217,6 +221,25 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         return graalvmHomeProvider;
     }
 
+    // The environment sources that can supply native-image through the fallback candidates
+    // (§FS-native-invocation.1.3) are task inputs in a 3-state sentinel form: "set:<value>",
+    // "set:" for an empty value, and "unset". Distinguishing the states makes a change to
+    // any source re-run the task instead of leaving it UP-TO-DATE with the previous executable.
+    @Input
+    protected Provider<String> getGraalvmHomeEnvInput() {
+        return graalvmHomeEnv.map(serializableTransformerOf(value -> "set:" + value)).orElse("unset");
+    }
+
+    @Input
+    protected Provider<String> getJavaHomeEnvInput() {
+        return javaHomeEnv.map(serializableTransformerOf(value -> "set:" + value)).orElse("unset");
+    }
+
+    @Input
+    protected Provider<String> getGradleJvmHomeInput() {
+        return gradleJvmHome.map(serializableTransformerOf(value -> "set:" + value)).orElse("unset");
+    }
+
     @Internal
     public Provider<RegularFile> getCreatedLayerFile() {
         return getOptions().zip(getOutputDirectory(), (options, dir) -> dir.file(options.getLayers().stream()
@@ -278,6 +301,9 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         ProviderFactory providers = getProject().getProviders();
         this.diagnostics = new NativeImageExecutableLocator.Diagnostics();
         this.graalvmHomeProvider = graalvmHomeProvider(providers, diagnostics);
+        this.graalvmHomeEnv = providers.environmentVariable("GRAALVM_HOME");
+        this.javaHomeEnv = providers.environmentVariable("JAVA_HOME");
+        this.gradleJvmHome = providers.systemProperty("java.home");
         this.plainConsole = ConsoleOutput.Plain.equals(getProject().getGradle().getStartParameter().getConsoleOutput());
         getDisableToolchainDetection().convention(false);
     }
@@ -325,7 +351,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
             getExecOperations(),
             logger,
             diagnostics,
-            NativeImageExecutableLocator.defaultFallbackCandidates(getProviders()));
+            NativeImageExecutableLocator.defaultFallbackCandidates(graalvmHomeEnv, javaHomeEnv, gradleJvmHome));
         String versionString = getVersionString(getExecOperations(), options, executablePath);
         Boolean metadataEnabled = getMetadataRepositoryEnabled().getOrNull();
         String metadataRoot = getMetadataRepositoryRootPath().getOrNull();

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -44,6 +44,7 @@ package org.graalvm.buildtools.gradle.tasks;
 import org.graalvm.buildtools.gradle.NativeImagePlugin;
 import org.graalvm.buildtools.gradle.dsl.NativeImageCompileOptions;
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
+import org.graalvm.buildtools.gradle.internal.BaseNativeImageOptions;
 import org.graalvm.buildtools.gradle.internal.GraalVMLogger;
 import org.graalvm.buildtools.gradle.internal.NativeImageCommandLineProvider;
 import org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator;
@@ -60,10 +61,10 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
@@ -75,6 +76,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
+import org.gradle.process.ExecSpec;
 
 import javax.inject.Inject;
 import java.io.ByteArrayOutputStream;
@@ -83,9 +85,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.graalvm.buildtools.gradle.internal.ConfigurationCacheSupport.serializableBiFunctionOf;
+import static org.graalvm.buildtools.gradle.internal.ConfigurationCacheSupport.serializableTransformerOf;
 import static org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator.graalvmHomeProvider;
 import static org.graalvm.buildtools.utils.SharedConstants.EXECUTABLE_EXTENSION;
 
@@ -99,6 +103,9 @@ import static org.graalvm.buildtools.utils.SharedConstants.EXECUTABLE_EXTENSION;
  */
 public abstract class BuildNativeImageTask extends DefaultTask {
     private final Provider<String> graalvmHomeProvider;
+    private final Provider<String> graalvmHomeEnv;
+    private final Provider<String> javaHomeEnv;
+    private final Provider<String> gradleJvmHome;
     private final NativeImageExecutableLocator.Diagnostics diagnostics;
     private final boolean plainConsole;
 
@@ -215,6 +222,41 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         return graalvmHomeProvider;
     }
 
+    // The environment sources that can supply native-image through the fallback candidates
+    // (§FS-native-invocation.1.3) are task inputs in a 3-state sentinel form: "set:<value>",
+    // "set:" for an empty value, and "unset". Distinguishing the states makes a change to
+    // any source re-run the task instead of leaving it UP-TO-DATE with the previous executable.
+    @Input
+    protected Provider<String> getGraalvmHomeEnvInput() {
+        return graalvmHomeEnv.map(serializableTransformerOf(value -> "set:" + value)).orElse("unset");
+    }
+
+    @Input
+    protected Provider<String> getJavaHomeEnvInput() {
+        return javaHomeEnv.map(serializableTransformerOf(value -> "set:" + value)).orElse("unset");
+    }
+
+    @Input
+    protected Provider<String> getGradleJvmHomeInput() {
+        return gradleJvmHome.map(serializableTransformerOf(value -> "set:" + value)).orElse("unset");
+    }
+
+    /**
+     * The explicit/convention provenance of the javaLauncher, tracked as a task input.
+     *
+     * <p>A convention-selected launcher that lacks {@code native-image} falls back to the
+     * environment-variable chain, while an explicitly configured launcher must fail instead
+     * (§FS-native-invocation.1.1). The launcher <em>value</em> alone cannot distinguish these
+     * two cases, so the provenance must be fingerprinted too, or switching from convention to
+     * explicit would leave the task UP-TO-DATE with an executable resolved from the previous
+     * environment (§FS-native-invocation.1.2).</p>
+     */
+    @Input
+    protected Provider<Boolean> getJavaLauncherExplicit() {
+        getOptions().finalizeValue();
+        return ((BaseNativeImageOptions) getOptions().get()).getJavaLauncherExplicit();
+    }
+
     @Internal
     public Provider<RegularFile> getCreatedLayerFile() {
         return getOptions().zip(getOutputDirectory(), (options, dir) ->
@@ -273,6 +315,9 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         ProviderFactory providers = getProject().getProviders();
         this.diagnostics = new NativeImageExecutableLocator.Diagnostics();
         this.graalvmHomeProvider = graalvmHomeProvider(providers, diagnostics);
+        this.graalvmHomeEnv = providers.environmentVariable("GRAALVM_HOME");
+        this.javaHomeEnv = providers.environmentVariable("JAVA_HOME");
+        this.gradleJvmHome = providers.systemProperty("java.home");
         this.plainConsole = ConsoleOutput.Plain.equals(getProject().getGradle().getStartParameter().getConsoleOutput());
         getDisableToolchainDetection().convention(false);
     }
@@ -309,14 +354,21 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         validateLayerConfiguration(options);
         GraalVMLogger logger = GraalVMLogger.of(getLogger());
 
+        var javaLauncherProperty = options.getJavaLauncher();
+        JavaLauncher launcher = javaLauncherProperty.getOrNull();
+        // Provenance: convention-sourced values are never explicit, even though the property
+        // is present in both cases. §FS-native-invocation.1.2
+        boolean isExplicit = ((BaseNativeImageOptions) options).getJavaLauncherExplicit().get();
+
         File executablePath = NativeImageExecutableLocator.findNativeImageExecutable(
-            options.getJavaLauncher(),
+            launcher, isExplicit,
             getDisableToolchainDetection(),
             getGraalVMHome(),
             getExecOperations(),
             logger,
-            diagnostics);
-        String versionString = getVersionString(getExecOperations(), executablePath);
+            diagnostics,
+            NativeImageExecutableLocator.defaultFallbackCandidates(graalvmHomeEnv, javaHomeEnv, gradleJvmHome));
+        String versionString = getVersionString(getExecOperations(), options, executablePath);
         Boolean metadataEnabled = getMetadataRepositoryEnabled().getOrNull();
         String metadataRoot = getMetadataRepositoryRootPath().getOrNull();
         if (Boolean.TRUE.equals(metadataEnabled) && metadataRoot != null) {
@@ -344,10 +396,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         getFileSystemOperations().delete(d -> d.delete(outputDir));
         if (outputDir.isDirectory() || outputDir.mkdirs()) {
             getExecOperations().exec(spec -> {
-                MapProperty<String, Object> environmentVariables = options.getEnvironmentVariables();
-                if (environmentVariables.isPresent() && !environmentVariables.get().isEmpty()) {
-                    spec.environment(environmentVariables.get());
-                }
+                addEnvironmentVariables(spec, options);
                 spec.setWorkingDir(getWorkingDirectory());
                 if (getTestListDirectory().isPresent()) {
                     NativeImagePlugin.TrackingDirectorySystemPropertyProvider directoryProvider = getObjects().newInstance(NativeImagePlugin.TrackingDirectorySystemPropertyProvider.class);
@@ -384,14 +433,22 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         }
     }
 
-    public static String getVersionString(ExecOperations execOperations, File executablePath) {
+    public static String getVersionString(ExecOperations execOperations, NativeImageOptions options, File executablePath) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         ExecResult execResult = execOperations.exec(spec -> {
+            addEnvironmentVariables(spec, options);
             spec.setStandardOutput(outputStream);
             spec.args("--version");
             spec.setExecutable(executablePath.getAbsolutePath());
         });
         execResult.assertNormalExitValue();
         return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    private static void addEnvironmentVariables(ExecSpec spec, NativeImageOptions options) {
+        // Always inherit current process environment first to ensure PATH and other critical variables are available
+        spec.environment(System.getenv());
+        // Merge custom environment variables
+        spec.environment(options.getEnvironmentVariables().getOrElse(Map.of()));
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -315,9 +315,10 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         GraalVMLogger logger = GraalVMLogger.of(getLogger());
 
         var javaLauncherProperty = options.getJavaLauncher();
-        JavaLauncher launcher = javaLauncherProperty.getOrNull();
+        JavaLauncher userLauncher = javaLauncherProperty.getOrNull();
         JavaLauncher conventionValue = conventionJavaLauncher != null ? conventionJavaLauncher.getOrNull() : null;
-        boolean isExplicit = launcher != null && !sameInstallation(launcher, conventionValue);
+        JavaLauncher launcher = userLauncher != null ? userLauncher : conventionValue;
+        boolean isExplicit = userLauncher != null;
 
         File executablePath = NativeImageExecutableLocator.findNativeImageExecutable(
             launcher, isExplicit,
@@ -362,14 +363,6 @@ public abstract class BuildNativeImageTask extends DefaultTask {
             });
             logger.lifecycle("Native Image written to: " + outputDir);
         }
-    }
-
-    private static boolean sameInstallation(JavaLauncher a, JavaLauncher b) {
-        if (a == null || b == null) {
-            return a == b;
-        }
-        return a.getMetadata().getInstallationPath().getAsFile()
-            .equals(b.getMetadata().getInstallationPath().getAsFile());
     }
 
     public static String getVersionString(ExecOperations execOperations, NativeImageOptions options, File executablePath) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -44,6 +44,7 @@ package org.graalvm.buildtools.gradle.tasks;
 import org.graalvm.buildtools.gradle.NativeImagePlugin;
 import org.graalvm.buildtools.gradle.dsl.NativeImageCompileOptions;
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
+import org.graalvm.buildtools.gradle.internal.BaseNativeImageOptions;
 import org.graalvm.buildtools.gradle.internal.GraalVMLogger;
 import org.graalvm.buildtools.gradle.internal.NativeImageCommandLineProvider;
 import org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator;
@@ -103,10 +104,6 @@ public abstract class BuildNativeImageTask extends DefaultTask {
     private final Provider<String> gradleJvmHome;
     private final NativeImageExecutableLocator.Diagnostics diagnostics;
     private final boolean plainConsole;
-
-    @Nested
-    @Optional
-    public abstract Property<JavaLauncher> getConventionJavaLauncher();
 
     @Internal
     public abstract Property<NativeImageOptions> getOptions();
@@ -339,10 +336,10 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         GraalVMLogger logger = GraalVMLogger.of(getLogger());
 
         var javaLauncherProperty = options.getJavaLauncher();
-        JavaLauncher userLauncher = javaLauncherProperty.getOrNull();
-        JavaLauncher conventionValue = getConventionJavaLauncher().getOrNull();
-        JavaLauncher launcher = userLauncher != null ? userLauncher : conventionValue;
-        boolean isExplicit = userLauncher != null;
+        JavaLauncher launcher = javaLauncherProperty.getOrNull();
+        // Provenance: convention-sourced values are never explicit, even though the property
+        // is present in both cases. §FS-native-invocation.1.2
+        boolean isExplicit = ((BaseNativeImageOptions) options).getJavaLauncherExplicit().get();
 
         File executablePath = NativeImageExecutableLocator.findNativeImageExecutable(
             launcher, isExplicit,

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
@@ -173,6 +173,7 @@ public abstract class MetadataCopyTask extends DefaultTask {
                 () -> inputDirectories,
                 () -> outputDirectories,
                 getToolchainDetection().map(enabled -> !enabled),
-                execOperations).execute(this);
+                execOperations,
+                providerFactory).execute(this);
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
@@ -173,12 +173,17 @@ public abstract class MetadataCopyTask extends DefaultTask {
         JavaLauncher resolvedLauncher = userLauncher != null ? userLauncher : conventionValue;
         boolean isExplicit = userLauncher != null;
 
+        Property<JavaLauncher> resolvedLauncherProperty = objectFactory.property(JavaLauncher.class);
+        if (resolvedLauncher != null) {
+            resolvedLauncherProperty.set(resolvedLauncher);
+        }
+
         new MergeAgentFilesAction(
                 isMergeEnabled,
                 agentModeProvider,
                 getMergeWithExisting(),
                 objectFactory,
-                getJavaLauncher(),
+                resolvedLauncherProperty,
                 graalvmHomeProvider(providerFactory),
                 () -> inputDirectories,
                 () -> outputDirectories,

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
@@ -81,7 +81,6 @@ public abstract class MetadataCopyTask extends DefaultTask {
     private final ProviderFactory providerFactory;
     private final ObjectFactory objectFactory;
     private final ExecOperations execOperations;
-    private Provider<JavaLauncher> conventionJavaLauncher;
 
     @Inject
     public MetadataCopyTask(ProjectLayout layout,
@@ -114,9 +113,9 @@ public abstract class MetadataCopyTask extends DefaultTask {
     @Optional
     public abstract Property<JavaLauncher> getJavaLauncher();
 
-    public void setConventionJavaLauncher(Provider<JavaLauncher> javaLauncher) {
-        this.conventionJavaLauncher = javaLauncher;
-    }
+    @Nested
+    @Optional
+    public abstract Property<JavaLauncher> getConventionJavaLauncher();
 
     @Option(option = "task", description = "Executed task previously instrumented with the agent whose metadata should be copied.")
     public void overrideInputTaskNames(List<String> inputTaskNames) {
@@ -169,7 +168,7 @@ public abstract class MetadataCopyTask extends DefaultTask {
         Provider<AgentMode> agentModeProvider = providerFactory.provider(StandardAgentMode::new);
 
         JavaLauncher userLauncher = getJavaLauncher().getOrNull();
-        JavaLauncher conventionValue = conventionJavaLauncher != null ? conventionJavaLauncher.getOrNull() : null;
+        JavaLauncher conventionValue = getConventionJavaLauncher().getOrNull();
         JavaLauncher resolvedLauncher = userLauncher != null ? userLauncher : conventionValue;
         boolean isExplicit = userLauncher != null;
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
@@ -81,6 +81,7 @@ public abstract class MetadataCopyTask extends DefaultTask {
     private final ProviderFactory providerFactory;
     private final ObjectFactory objectFactory;
     private final ExecOperations execOperations;
+    private Provider<JavaLauncher> conventionJavaLauncher;
 
     @Inject
     public MetadataCopyTask(ProjectLayout layout,
@@ -112,6 +113,10 @@ public abstract class MetadataCopyTask extends DefaultTask {
     @Nested
     @Optional
     public abstract Property<JavaLauncher> getJavaLauncher();
+
+    public void setConventionJavaLauncher(Provider<JavaLauncher> javaLauncher) {
+        this.conventionJavaLauncher = javaLauncher;
+    }
 
     @Option(option = "task", description = "Executed task previously instrumented with the agent whose metadata should be copied.")
     public void overrideInputTaskNames(List<String> inputTaskNames) {
@@ -163,6 +168,10 @@ public abstract class MetadataCopyTask extends DefaultTask {
         Provider<Boolean> isMergeEnabled = providerFactory.provider(() -> true);
         Provider<AgentMode> agentModeProvider = providerFactory.provider(StandardAgentMode::new);
 
+        JavaLauncher resolvedLauncher = getJavaLauncher().getOrNull();
+        JavaLauncher conventionValue = conventionJavaLauncher != null ? conventionJavaLauncher.getOrNull() : null;
+        boolean isExplicit = resolvedLauncher != null && !sameInstallation(resolvedLauncher, conventionValue);
+
         new MergeAgentFilesAction(
                 isMergeEnabled,
                 agentModeProvider,
@@ -173,7 +182,16 @@ public abstract class MetadataCopyTask extends DefaultTask {
                 () -> inputDirectories,
                 () -> outputDirectories,
                 getToolchainDetection().map(enabled -> !enabled),
+                providerFactory.provider(() -> isExplicit),
                 execOperations,
                 providerFactory).execute(this);
     }
+
+    private static boolean sameInstallation(JavaLauncher a, JavaLauncher b) {
+        if (a == null || b == null) {
+            return a == b;
+        }
+        return a.getMetadata().getInstallationPath().getAsFile()
+            .equals(b.getMetadata().getInstallationPath().getAsFile());
+}
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
@@ -43,6 +43,7 @@ package org.graalvm.buildtools.gradle.tasks;
 import org.graalvm.buildtools.agent.AgentMode;
 import org.graalvm.buildtools.agent.StandardAgentMode;
 import org.graalvm.buildtools.gradle.internal.GraalVMLogger;
+import org.graalvm.buildtools.gradle.internal.JavaLauncherProperty;
 import org.graalvm.buildtools.gradle.internal.agent.AgentConfigurationFactory;
 import org.graalvm.buildtools.gradle.tasks.actions.MergeAgentFilesAction;
 import org.gradle.api.DefaultTask;
@@ -86,6 +87,7 @@ public abstract class MetadataCopyTask extends DefaultTask {
     private final Provider<String> graalvmHomeEnv;
     private final Provider<String> javaHomeEnv;
     private final Provider<String> gradleJvmHome;
+    private final JavaLauncherProperty javaLauncher;
 
     @Inject
     public MetadataCopyTask(ProjectLayout layout,
@@ -100,6 +102,7 @@ public abstract class MetadataCopyTask extends DefaultTask {
         this.graalvmHomeEnv = providerFactory.environmentVariable("GRAALVM_HOME");
         this.javaHomeEnv = providerFactory.environmentVariable("JAVA_HOME");
         this.gradleJvmHome = providerFactory.systemProperty("java.home");
+        this.javaLauncher = new JavaLauncherProperty(objectFactory.property(JavaLauncher.class));
     }
 
     @Internal
@@ -119,11 +122,9 @@ public abstract class MetadataCopyTask extends DefaultTask {
      */
     @Nested
     @Optional
-    public abstract Property<JavaLauncher> getJavaLauncher();
-
-    @Nested
-    @Optional
-    public abstract Property<JavaLauncher> getConventionJavaLauncher();
+    public Property<JavaLauncher> getJavaLauncher() {
+        return javaLauncher;
+    }
 
     // The environment sources that can supply native-image through the fallback candidates
     // (§FS-native-invocation.1.3) are task inputs in a 3-state sentinel form: "set:<value>",
@@ -194,10 +195,8 @@ public abstract class MetadataCopyTask extends DefaultTask {
         Provider<Boolean> isMergeEnabled = providerFactory.provider(() -> true);
         Provider<AgentMode> agentModeProvider = providerFactory.provider(StandardAgentMode::new);
 
-        JavaLauncher userLauncher = getJavaLauncher().getOrNull();
-        JavaLauncher conventionValue = getConventionJavaLauncher().getOrNull();
-        JavaLauncher resolvedLauncher = userLauncher != null ? userLauncher : conventionValue;
-        boolean isExplicit = userLauncher != null;
+        JavaLauncher resolvedLauncher = javaLauncher.getOrNull();
+        boolean isExplicit = javaLauncher.isExplicit();
 
         Property<JavaLauncher> resolvedLauncherProperty = objectFactory.property(JavaLauncher.class);
         if (resolvedLauncher != null) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
@@ -43,6 +43,7 @@ package org.graalvm.buildtools.gradle.tasks;
 import org.graalvm.buildtools.agent.AgentMode;
 import org.graalvm.buildtools.agent.StandardAgentMode;
 import org.graalvm.buildtools.gradle.internal.GraalVMLogger;
+import org.graalvm.buildtools.gradle.internal.JavaLauncherProperty;
 import org.graalvm.buildtools.gradle.internal.agent.AgentConfigurationFactory;
 import org.graalvm.buildtools.gradle.tasks.actions.MergeAgentFilesAction;
 import org.gradle.api.DefaultTask;
@@ -53,6 +54,7 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
@@ -68,6 +70,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.graalvm.buildtools.gradle.internal.ConfigurationCacheSupport.serializableTransformerOf;
 import static org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator.graalvmHomeProvider;
 
 /**
@@ -81,6 +84,10 @@ public abstract class MetadataCopyTask extends DefaultTask {
     private final ProviderFactory providerFactory;
     private final ObjectFactory objectFactory;
     private final ExecOperations execOperations;
+    private final Provider<String> graalvmHomeEnv;
+    private final Provider<String> javaHomeEnv;
+    private final Provider<String> gradleJvmHome;
+    private final JavaLauncherProperty javaLauncher;
 
     @Inject
     public MetadataCopyTask(ProjectLayout layout,
@@ -92,6 +99,10 @@ public abstract class MetadataCopyTask extends DefaultTask {
         this.providerFactory = providerFactory;
         this.objectFactory = objectFactory;
         this.execOperations = execOperations;
+        this.graalvmHomeEnv = providerFactory.environmentVariable("GRAALVM_HOME");
+        this.javaHomeEnv = providerFactory.environmentVariable("JAVA_HOME");
+        this.gradleJvmHome = providerFactory.systemProperty("java.home");
+        this.javaLauncher = JavaLauncherProperty.of(objectFactory.property(JavaLauncher.class), providerFactory);
     }
 
     @Internal
@@ -111,7 +122,50 @@ public abstract class MetadataCopyTask extends DefaultTask {
      */
     @Nested
     @Optional
-    public abstract Property<JavaLauncher> getJavaLauncher();
+    public Property<JavaLauncher> getJavaLauncher() {
+        return javaLauncher.getProperty();
+    }
+
+    /**
+     * Installs the plugin-provided convention launcher; an explicit {@code set}/{@code value} later
+     * still marks the value explicit (tracked by the property proxy). §FS-native-invocation.1.2
+     */
+    public void setJavaLauncherConvention(Provider<JavaLauncher> convention) {
+        // Goes through the proxied property so the provenance flag stays in sync.
+        javaLauncher.getProperty().convention(convention);
+    }
+
+    /**
+     * The explicit/convention provenance of the javaLauncher, tracked as a task input.
+     *
+     * <p>A convention-selected launcher that lacks {@code native-image} falls back to the
+     * environment-variable chain, while an explicitly configured launcher must fail instead
+     * (§FS-native-invocation.1.1). The launcher <em>value</em> alone cannot distinguish these
+     * two cases, so the provenance must be fingerprinted too (§FS-native-invocation.1.2).</p>
+     */
+    @Input
+    protected Provider<Boolean> getJavaLauncherExplicit() {
+        return javaLauncher.explicit();
+    }
+
+    // The environment sources that can supply native-image through the fallback candidates
+    // (§FS-native-invocation.1.3) are task inputs in a 3-state sentinel form: "set:<value>",
+    // "set:" for an empty value, and "unset". Distinguishing the states makes a change to
+    // any source re-run the task instead of leaving it UP-TO-DATE with the previous executable.
+    @Input
+    protected Provider<String> getGraalvmHomeEnvInput() {
+        return graalvmHomeEnv.map(serializableTransformerOf(value -> "set:" + value)).orElse("unset");
+    }
+
+    @Input
+    protected Provider<String> getJavaHomeEnvInput() {
+        return javaHomeEnv.map(serializableTransformerOf(value -> "set:" + value)).orElse("unset");
+    }
+
+    @Input
+    protected Provider<String> getGradleJvmHomeInput() {
+        return gradleJvmHome.map(serializableTransformerOf(value -> "set:" + value)).orElse("unset");
+    }
 
     @Option(option = "task", description = "Executed task previously instrumented with the agent whose metadata should be copied.")
     public void overrideInputTaskNames(List<String> inputTaskNames) {
@@ -163,16 +217,28 @@ public abstract class MetadataCopyTask extends DefaultTask {
         Provider<Boolean> isMergeEnabled = providerFactory.provider(() -> true);
         Provider<AgentMode> agentModeProvider = providerFactory.provider(StandardAgentMode::new);
 
+        JavaLauncher resolvedLauncher = javaLauncher.getProperty().getOrNull();
+        boolean isExplicit = javaLauncher.explicit().get();
+
+        Property<JavaLauncher> resolvedLauncherProperty = objectFactory.property(JavaLauncher.class);
+        if (resolvedLauncher != null) {
+            resolvedLauncherProperty.set(resolvedLauncher);
+        }
+
         new MergeAgentFilesAction(
                 isMergeEnabled,
                 agentModeProvider,
                 getMergeWithExisting(),
                 objectFactory,
-                getJavaLauncher(),
+                resolvedLauncherProperty,
                 graalvmHomeProvider(providerFactory),
                 () -> inputDirectories,
                 () -> outputDirectories,
                 getToolchainDetection().map(enabled -> !enabled),
-                execOperations).execute(this);
+                providerFactory.provider(() -> isExplicit),
+                execOperations,
+                graalvmHomeEnv,
+                javaHomeEnv,
+                gradleJvmHome).execute(this);
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
@@ -168,9 +168,10 @@ public abstract class MetadataCopyTask extends DefaultTask {
         Provider<Boolean> isMergeEnabled = providerFactory.provider(() -> true);
         Provider<AgentMode> agentModeProvider = providerFactory.provider(StandardAgentMode::new);
 
-        JavaLauncher resolvedLauncher = getJavaLauncher().getOrNull();
+        JavaLauncher userLauncher = getJavaLauncher().getOrNull();
         JavaLauncher conventionValue = conventionJavaLauncher != null ? conventionJavaLauncher.getOrNull() : null;
-        boolean isExplicit = resolvedLauncher != null && !sameInstallation(resolvedLauncher, conventionValue);
+        JavaLauncher resolvedLauncher = userLauncher != null ? userLauncher : conventionValue;
+        boolean isExplicit = userLauncher != null;
 
         new MergeAgentFilesAction(
                 isMergeEnabled,
@@ -186,12 +187,4 @@ public abstract class MetadataCopyTask extends DefaultTask {
                 execOperations,
                 providerFactory).execute(this);
     }
-
-    private static boolean sameInstallation(JavaLauncher a, JavaLauncher b) {
-        if (a == null || b == null) {
-            return a == b;
-        }
-        return a.getMetadata().getInstallationPath().getAsFile()
-            .equals(b.getMetadata().getInstallationPath().getAsFile());
-}
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
@@ -53,6 +53,7 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
@@ -68,6 +69,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.graalvm.buildtools.gradle.internal.ConfigurationCacheSupport.serializableTransformerOf;
 import static org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator.graalvmHomeProvider;
 
 /**
@@ -81,6 +83,9 @@ public abstract class MetadataCopyTask extends DefaultTask {
     private final ProviderFactory providerFactory;
     private final ObjectFactory objectFactory;
     private final ExecOperations execOperations;
+    private final Provider<String> graalvmHomeEnv;
+    private final Provider<String> javaHomeEnv;
+    private final Provider<String> gradleJvmHome;
 
     @Inject
     public MetadataCopyTask(ProjectLayout layout,
@@ -92,6 +97,9 @@ public abstract class MetadataCopyTask extends DefaultTask {
         this.providerFactory = providerFactory;
         this.objectFactory = objectFactory;
         this.execOperations = execOperations;
+        this.graalvmHomeEnv = providerFactory.environmentVariable("GRAALVM_HOME");
+        this.javaHomeEnv = providerFactory.environmentVariable("JAVA_HOME");
+        this.gradleJvmHome = providerFactory.systemProperty("java.home");
     }
 
     @Internal
@@ -116,6 +124,25 @@ public abstract class MetadataCopyTask extends DefaultTask {
     @Nested
     @Optional
     public abstract Property<JavaLauncher> getConventionJavaLauncher();
+
+    // The environment sources that can supply native-image through the fallback candidates
+    // (§FS-native-invocation.1.3) are task inputs in a 3-state sentinel form: "set:<value>",
+    // "set:" for an empty value, and "unset". Distinguishing the states makes a change to
+    // any source re-run the task instead of leaving it UP-TO-DATE with the previous executable.
+    @Input
+    protected Provider<String> getGraalvmHomeEnvInput() {
+        return graalvmHomeEnv.map(serializableTransformerOf(value -> "set:" + value)).orElse("unset");
+    }
+
+    @Input
+    protected Provider<String> getJavaHomeEnvInput() {
+        return javaHomeEnv.map(serializableTransformerOf(value -> "set:" + value)).orElse("unset");
+    }
+
+    @Input
+    protected Provider<String> getGradleJvmHomeInput() {
+        return gradleJvmHome.map(serializableTransformerOf(value -> "set:" + value)).orElse("unset");
+    }
 
     @Option(option = "task", description = "Executed task previously instrumented with the agent whose metadata should be copied.")
     public void overrideInputTaskNames(List<String> inputTaskNames) {
@@ -189,6 +216,8 @@ public abstract class MetadataCopyTask extends DefaultTask {
                 getToolchainDetection().map(enabled -> !enabled),
                 providerFactory.provider(() -> isExplicit),
                 execOperations,
-                providerFactory).execute(this);
+                graalvmHomeEnv,
+                javaHomeEnv,
+                gradleJvmHome).execute(this);
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesAction.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesAction.java
@@ -49,6 +49,7 @@ import org.gradle.api.Task;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
@@ -74,6 +75,7 @@ public class MergeAgentFilesAction implements Action<Task> {
     private final Provider<Boolean> disableToolchainDetection;
     private final Property<JavaLauncher> javaLauncher;
     private final ExecOperations execOperations;
+    private final ProviderFactory providers;
 
     public MergeAgentFilesAction(Provider<Boolean> isMergingEnabled,
                                  Provider<AgentMode> agentMode,
@@ -84,7 +86,8 @@ public class MergeAgentFilesAction implements Action<Task> {
                                  Supplier<List<String>> inputDirs,
                                  Supplier<List<String>> outputDirs,
                                  Provider<Boolean> disableToolchainDetection,
-                                 ExecOperations execOperations) {
+                                 ExecOperations execOperations,
+                                 ProviderFactory providers) {
         this.isMergingEnabled = isMergingEnabled;
         this.agentMode = agentMode;
         this.mergeWithOutputs = mergeWithOutputs;
@@ -95,6 +98,7 @@ public class MergeAgentFilesAction implements Action<Task> {
         this.execOperations = execOperations;
         this.javaLauncher = objectFactory.property(JavaLauncher.class);
         this.javaLauncher.convention(javaLauncher);
+        this.providers = providers;
     }
 
     private static final Set<String> METADATA_FILES = Set.of("reflect-config.json", "jni-config.json", "proxy-config.json", "resource-config.json", "reachability-metadata.json");
@@ -108,7 +112,15 @@ public class MergeAgentFilesAction implements Action<Task> {
     public void execute(Task task) {
         if (isMergingEnabled.get()) {
             // Preserve Native Image executable discovery for agent post-processing. §FS-native-invocation.1.
-            File nativeImage = findNativeImageExecutable(javaLauncher, disableToolchainDetection, graalvmHomeProvider, execOperations, GraalVMLogger.of(task.getLogger()), new NativeImageExecutableLocator.Diagnostics());
+            File nativeImage = findNativeImageExecutable(
+                    javaLauncher.getOrNull(),
+                    javaLauncher.isPresent(),
+                    disableToolchainDetection,
+                    graalvmHomeProvider,
+                    execOperations,
+                    GraalVMLogger.of(task.getLogger()),
+                    new NativeImageExecutableLocator.Diagnostics(),
+                    NativeImageExecutableLocator.defaultFallbackCandidates(providers));
             File workingDir = nativeImage.getParentFile();
             File launcher = new File(workingDir, nativeImageConfigureFileName());
             if (!launcher.exists()) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesAction.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesAction.java
@@ -74,6 +74,7 @@ public class MergeAgentFilesAction implements Action<Task> {
     private final Supplier<List<String>> outputDirs;
     private final Provider<Boolean> disableToolchainDetection;
     private final Property<JavaLauncher> javaLauncher;
+    private final Provider<Boolean> isExplicitLauncher;
     private final ExecOperations execOperations;
     private final ProviderFactory providers;
 
@@ -86,6 +87,7 @@ public class MergeAgentFilesAction implements Action<Task> {
                                  Supplier<List<String>> inputDirs,
                                  Supplier<List<String>> outputDirs,
                                  Provider<Boolean> disableToolchainDetection,
+                                 Provider<Boolean> isExplicitLauncher,
                                  ExecOperations execOperations,
                                  ProviderFactory providers) {
         this.isMergingEnabled = isMergingEnabled;
@@ -95,6 +97,7 @@ public class MergeAgentFilesAction implements Action<Task> {
         this.inputDirs = inputDirs;
         this.outputDirs = outputDirs;
         this.disableToolchainDetection = disableToolchainDetection;
+        this.isExplicitLauncher = isExplicitLauncher;
         this.execOperations = execOperations;
         this.javaLauncher = objectFactory.property(JavaLauncher.class);
         this.javaLauncher.convention(javaLauncher);
@@ -114,7 +117,7 @@ public class MergeAgentFilesAction implements Action<Task> {
             // Preserve Native Image executable discovery for agent post-processing. §FS-native-invocation.1.
             File nativeImage = findNativeImageExecutable(
                     javaLauncher.getOrNull(),
-                    javaLauncher.getOrNull() != null,
+                    isExplicitLauncher.get(),
                     disableToolchainDetection,
                     graalvmHomeProvider,
                     execOperations,

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesAction.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesAction.java
@@ -49,7 +49,6 @@ import org.gradle.api.Task;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.provider.ProviderFactory;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
@@ -76,7 +75,9 @@ public class MergeAgentFilesAction implements Action<Task> {
     private final Property<JavaLauncher> javaLauncher;
     private final Provider<Boolean> isExplicitLauncher;
     private final ExecOperations execOperations;
-    private final ProviderFactory providers;
+    private final Provider<String> graalvmHomeEnv;
+    private final Provider<String> javaHomeEnv;
+    private final Provider<String> gradleJvmHome;
 
     public MergeAgentFilesAction(Provider<Boolean> isMergingEnabled,
                                  Provider<AgentMode> agentMode,
@@ -89,7 +90,9 @@ public class MergeAgentFilesAction implements Action<Task> {
                                  Provider<Boolean> disableToolchainDetection,
                                  Provider<Boolean> isExplicitLauncher,
                                  ExecOperations execOperations,
-                                 ProviderFactory providers) {
+                                 Provider<String> graalvmHomeEnv,
+                                 Provider<String> javaHomeEnv,
+                                 Provider<String> gradleJvmHome) {
         this.isMergingEnabled = isMergingEnabled;
         this.agentMode = agentMode;
         this.mergeWithOutputs = mergeWithOutputs;
@@ -101,7 +104,9 @@ public class MergeAgentFilesAction implements Action<Task> {
         this.execOperations = execOperations;
         this.javaLauncher = objectFactory.property(JavaLauncher.class);
         this.javaLauncher.convention(javaLauncher);
-        this.providers = providers;
+        this.graalvmHomeEnv = graalvmHomeEnv;
+        this.javaHomeEnv = javaHomeEnv;
+        this.gradleJvmHome = gradleJvmHome;
     }
 
     private static final Set<String> METADATA_FILES = Set.of("reflect-config.json", "jni-config.json", "proxy-config.json", "resource-config.json", "reachability-metadata.json");
@@ -123,7 +128,7 @@ public class MergeAgentFilesAction implements Action<Task> {
                     execOperations,
                     GraalVMLogger.of(task.getLogger()),
                     new NativeImageExecutableLocator.Diagnostics(),
-                    NativeImageExecutableLocator.defaultFallbackCandidates(providers));
+                    NativeImageExecutableLocator.defaultFallbackCandidates(graalvmHomeEnv, javaHomeEnv, gradleJvmHome));
             File workingDir = nativeImage.getParentFile();
             File launcher = new File(workingDir, nativeImageConfigureFileName());
             if (!launcher.exists()) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesAction.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesAction.java
@@ -73,7 +73,11 @@ public class MergeAgentFilesAction implements Action<Task> {
     private final Supplier<List<String>> outputDirs;
     private final Provider<Boolean> disableToolchainDetection;
     private final Property<JavaLauncher> javaLauncher;
+    private final Provider<Boolean> isExplicitLauncher;
     private final ExecOperations execOperations;
+    private final Provider<String> graalvmHomeEnv;
+    private final Provider<String> javaHomeEnv;
+    private final Provider<String> gradleJvmHome;
 
     public MergeAgentFilesAction(Provider<Boolean> isMergingEnabled,
                                  Provider<AgentMode> agentMode,
@@ -84,7 +88,11 @@ public class MergeAgentFilesAction implements Action<Task> {
                                  Supplier<List<String>> inputDirs,
                                  Supplier<List<String>> outputDirs,
                                  Provider<Boolean> disableToolchainDetection,
-                                 ExecOperations execOperations) {
+                                 Provider<Boolean> isExplicitLauncher,
+                                 ExecOperations execOperations,
+                                 Provider<String> graalvmHomeEnv,
+                                 Provider<String> javaHomeEnv,
+                                 Provider<String> gradleJvmHome) {
         this.isMergingEnabled = isMergingEnabled;
         this.agentMode = agentMode;
         this.mergeWithOutputs = mergeWithOutputs;
@@ -92,9 +100,13 @@ public class MergeAgentFilesAction implements Action<Task> {
         this.inputDirs = inputDirs;
         this.outputDirs = outputDirs;
         this.disableToolchainDetection = disableToolchainDetection;
+        this.isExplicitLauncher = isExplicitLauncher;
         this.execOperations = execOperations;
         this.javaLauncher = objectFactory.property(JavaLauncher.class);
         this.javaLauncher.convention(javaLauncher);
+        this.graalvmHomeEnv = graalvmHomeEnv;
+        this.javaHomeEnv = javaHomeEnv;
+        this.gradleJvmHome = gradleJvmHome;
     }
 
     private static final Set<String> METADATA_FILES = Set.of("reflect-config.json", "jni-config.json", "proxy-config.json", "resource-config.json", "reachability-metadata.json");
@@ -108,7 +120,15 @@ public class MergeAgentFilesAction implements Action<Task> {
     public void execute(Task task) {
         if (isMergingEnabled.get()) {
             // Preserve Native Image executable discovery for agent post-processing. §FS-native-invocation.1.
-            File nativeImage = findNativeImageExecutable(javaLauncher, disableToolchainDetection, graalvmHomeProvider, execOperations, GraalVMLogger.of(task.getLogger()), new NativeImageExecutableLocator.Diagnostics());
+            File nativeImage = findNativeImageExecutable(
+                    javaLauncher.getOrNull(),
+                    isExplicitLauncher.get(),
+                    disableToolchainDetection,
+                    graalvmHomeProvider,
+                    execOperations,
+                    GraalVMLogger.of(task.getLogger()),
+                    new NativeImageExecutableLocator.Diagnostics(),
+                    NativeImageExecutableLocator.defaultFallbackCandidates(graalvmHomeEnv, javaHomeEnv, gradleJvmHome));
             File workingDir = nativeImage.getParentFile();
             File launcher = new File(workingDir, nativeImageConfigureFileName());
             if (!launcher.exists()) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesAction.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesAction.java
@@ -114,7 +114,7 @@ public class MergeAgentFilesAction implements Action<Task> {
             // Preserve Native Image executable discovery for agent post-processing. §FS-native-invocation.1.
             File nativeImage = findNativeImageExecutable(
                     javaLauncher.getOrNull(),
-                    javaLauncher.isPresent(),
+                    javaLauncher.getOrNull() != null,
                     disableToolchainDetection,
                     graalvmHomeProvider,
                     execOperations,

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -295,6 +295,96 @@ class NativeImagePluginTest extends Specification {
         ]
     }
 
+    // §FS-native-invocation.1.2 — the plugin installs the javaLauncher convention on the public
+    // binary property; provenance distinguishes convention-sourced from user-explicit launchers.
+    def "binary javaLauncher resolves from the toolchain convention and is not explicit"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def main = extension.binaries.getByName("main")
+        extension.toolchainDetection.set(true)
+
+        expect:
+        // The restored convention supplies a launcher...
+        main.javaLauncher.isPresent()
+        // ...but the value came from the convention, not from an explicit assignment.
+        !main.javaLauncherExplicit.get()
+    }
+
+    // §FS-native-invocation.1.2 — a user-assigned launcher is explicit even when it equals the
+    // convention value: provenance tracks the assignment, not the resolved launcher.
+    def "explicit javaLauncher set by user is reported explicit"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def main = extension.binaries.getByName("main")
+        extension.toolchainDetection.set(true)
+
+        when:
+        // Same launcher the convention would supply, but assigned directly by the user.
+        main.javaLauncher.set(extension.defaultJavaLauncher.get())
+
+        then:
+        main.javaLauncherExplicit.get()
+    }
+
+    // §FS-native-invocation.1.1 — an explicit assignment made after querying the convention value
+    // is still explicit: provenance tracks the current assignment, not resolution history.
+    def "querying the convention launcher then assigning it back is reported explicit"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def main = extension.binaries.getByName("main")
+        extension.toolchainDetection.set(true)
+
+        when:
+        // Query the effective (convention-supplied) launcher, then assign it back explicitly.
+        def launcher = main.javaLauncher.get()
+        main.javaLauncher.set(launcher)
+
+        then:
+        main.javaLauncherExplicit.get()
+    }
+
+    // §FS-native-invocation.1.2 — unsetting an explicit assignment restores the convention
+    // provenance: the value is present again but no longer explicit.
+    def "unsetting an explicit launcher assignment is no longer reported explicit"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def main = extension.binaries.getByName("main")
+        extension.toolchainDetection.set(true)
+
+        when:
+        def launcher = main.javaLauncher.get()
+        main.javaLauncher.set(launcher)
+        main.javaLauncher.unset()
+
+        then:
+        main.javaLauncher.isPresent()
+        !main.javaLauncherExplicit.get()
+    }
+
+    // §FS-native-invocation.1.1 — removing a convention (unsetConvention) must NOT clear explicit
+    // provenance: it only drops the convention and never touches an explicitly assigned value, so an
+    // explicit launcher stays explicit after the convention is removed.
+    def "unsetting the convention does not clear an explicit launcher assignment"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def main = extension.binaries.getByName("main")
+        extension.toolchainDetection.set(true)
+
+        when:
+        def launcher = main.javaLauncher.get()
+        main.javaLauncher.set(launcher)
+        main.javaLauncher.unsetConvention()
+
+        then:
+        main.javaLauncher.isPresent()
+        main.javaLauncherExplicit.get()
+    }
+
     private String taskDescription(String name) {
         Task task = project.tasks.getByName(name)
         assert task.description != null

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -110,6 +110,34 @@ class NativeImagePluginTest extends Specification {
         ]
     }
 
+    // §FS-native-invocation.1.5 — no convention on getJavaLauncher() means isPresent reflects explicit user config only
+    // Without convention, compatibility mode fallback to defaultJavaLauncher works correctly.
+    def "binary javaLauncher has no convention so isPresent is false by default"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+
+        expect:
+        // No convention: isPresent() is false when user hasn't set anything
+        !extension.binaries.getByName("main").javaLauncher.isPresent()
+    }
+
+    // §FS-native-invocation.1.5 — explicit launcher matching convention installation path is still authoritative
+    // With structural provenance (no convention on property), user-set launcher is always treated as explicit.
+    def "explicit javaLauncher set by user is present regardless of convention"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def main = extension.binaries.getByName("main")
+
+        when:
+        // Set a launcher directly (simulates explicit user configuration)
+        main.javaLauncher.set(project.provider { null } as org.gradle.jvm.toolchain.JavaLauncher)
+
+        then:
+        main.javaLauncher.isPresent()
+    }
+
     private String taskDescription(String name) {
         Task task = project.tasks.getByName(name)
         assert task.description != null

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -110,32 +110,37 @@ class NativeImagePluginTest extends Specification {
         ]
     }
 
-    // §FS-native-invocation.1.5 — no convention on getJavaLauncher() means isPresent reflects explicit user config only
-    // Without convention, compatibility mode fallback to defaultJavaLauncher works correctly.
-    def "binary javaLauncher has no convention so isPresent is false by default"() {
-        given:
-        project.plugins.apply("java")
-        def extension = project.extensions.getByType(GraalVMExtension)
-
-        expect:
-        // No convention: isPresent() is false when user hasn't set anything
-        !extension.binaries.getByName("main").javaLauncher.isPresent()
-    }
-
-    // §FS-native-invocation.1.5 — explicit launcher matching convention installation path is still authoritative
-    // With structural provenance (no convention on property), user-set launcher is always treated as explicit.
-    def "explicit javaLauncher set by user is present regardless of convention"() {
+    // §FS-native-invocation.1.2 — the plugin installs the javaLauncher convention on the public
+    // binary property; provenance distinguishes convention-sourced from user-explicit launchers.
+    def "binary javaLauncher resolves from the toolchain convention and is not explicit"() {
         given:
         project.plugins.apply("java")
         def extension = project.extensions.getByType(GraalVMExtension)
         def main = extension.binaries.getByName("main")
+        extension.toolchainDetection.set(true)
+
+        expect:
+        // The restored convention supplies a launcher...
+        main.javaLauncher.isPresent()
+        // ...but the value came from the convention, not from an explicit assignment.
+        !main.javaLauncherExplicit.get()
+    }
+
+    // §FS-native-invocation.1.2 — a user-assigned launcher is explicit even when it equals the
+    // convention value: provenance tracks the assignment, not the resolved launcher.
+    def "explicit javaLauncher set by user is reported explicit"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def main = extension.binaries.getByName("main")
+        extension.toolchainDetection.set(true)
 
         when:
-        // Set a launcher directly (simulates explicit user configuration)
-        main.javaLauncher.set(project.provider { null } as org.gradle.jvm.toolchain.JavaLauncher)
+        // Same launcher the convention would supply, but assigned directly by the user.
+        main.javaLauncher.set(extension.defaultJavaLauncher.get())
 
         then:
-        main.javaLauncher.isPresent()
+        main.javaLauncherExplicit.get()
     }
 
     private String taskDescription(String name) {

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -143,6 +143,43 @@ class NativeImagePluginTest extends Specification {
         main.javaLauncherExplicit.get()
     }
 
+    // §FS-native-invocation.1.1 — an explicit assignment made after querying the convention value
+    // is still explicit: provenance tracks the current assignment, not resolution history.
+    def "querying the convention launcher then assigning it back is reported explicit"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def main = extension.binaries.getByName("main")
+        extension.toolchainDetection.set(true)
+
+        when:
+        // Query the effective (convention-supplied) launcher, then assign it back explicitly.
+        def launcher = main.javaLauncher.get()
+        main.javaLauncher.set(launcher)
+
+        then:
+        main.javaLauncherExplicit.get()
+    }
+
+    // §FS-native-invocation.1.2 — unsetting an explicit assignment restores the convention
+    // provenance: the value is present again but no longer explicit.
+    def "unsetting an explicit launcher assignment is no longer reported explicit"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def main = extension.binaries.getByName("main")
+        extension.toolchainDetection.set(true)
+
+        when:
+        def launcher = main.javaLauncher.get()
+        main.javaLauncher.set(launcher)
+        main.javaLauncher.unset()
+
+        then:
+        main.javaLauncher.isPresent()
+        !main.javaLauncherExplicit.get()
+    }
+
     private String taskDescription(String name) {
         Task task = project.tasks.getByName(name)
         assert task.description != null

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/internal/JavaLauncherPropertyTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/internal/JavaLauncherPropertyTest.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned by
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.gradle.internal
+
+import org.gradle.api.Project
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+/**
+ * Focused unit tests for the {@link JavaLauncherProperty} runtime proxy. They pin the three cases the
+ * proxy must handle without deviating from the underlying Gradle {@code Property} contract:
+ * {@code value(null)} as a no-op, exception propagation, and {@link Object} identity methods.
+ */
+class JavaLauncherPropertyTest extends Specification {
+
+    private Project project
+    private JavaLauncherProperty holder
+
+    def setup() {
+        project = ProjectBuilder.builder().build()
+        holder = JavaLauncherProperty.of(
+                project.objects.property(JavaLauncher.class),
+                project.providers)
+    }
+
+    private JavaLauncher launcher() {
+        Mock(JavaLauncher)
+    }
+
+    // §FS-native-invocation.1.2 — value(null) is a no-op on a convention-sourced property and must
+    // not mark the value explicit, matching the underlying Property's behavior.
+    def "value(null) on a convention-sourced property keeps the launcher non-explicit"() {
+        given:
+        holder.getProperty().convention(launcher())
+        assert holder.getProperty().isPresent() // force evaluation of the convention
+
+        when:
+        holder.getProperty().value(null)
+
+        then: "the convention still supplies the value and it is not explicit"
+        holder.getProperty().isPresent()
+        !holder.explicit().get()
+    }
+
+    // §FS-native-invocation.1.2 — a non-null assignment marks the value explicit.
+    def "value(nonNull) marks the launcher explicit"() {
+        given:
+        holder.getProperty().convention(launcher())
+
+        when:
+        holder.getProperty().value(launcher())
+
+        then:
+        holder.getProperty().isPresent()
+        holder.explicit().get()
+    }
+
+    // §FS-native-invocation.1.1 — a user-assigned launcher stays explicit across Object identity calls.
+    def "proxied Property satisfies Object identity methods"() {
+        when: "the property is assigned explicitly"
+        holder.getProperty().set(launcher())
+        def prop = holder.getProperty()
+
+        then: "equals is referential and hashCode/toString are consistent"
+        prop.equals(prop)
+        prop == prop
+        prop.hashCode() == System.identityHashCode(prop)
+        prop.toString().contains(JavaLauncherProperty.name)
+    }
+
+    // §FS-native-invocation.1.2 — Gradle's own exception must propagate unwrapped rather than as a
+    // reflection wrapping (UndeclaredThrowableException) when mutating a finalized property.
+    def "mutating a finalized property propagates Gradle's exception unwrapped"() {
+        given: "a property that is finalized to a fixed value"
+        def prop = holder.getProperty()
+        prop.value(launcher()).finalizeValue()
+
+        when: "a mutation is attempted on the finalized property"
+        prop.unset()
+
+        then: "Gradle's IllegalStateException surfaces directly, not wrapped in InvocationTargetException"
+        def e = thrown(IllegalStateException)
+        e.cause == null
+    }
+}

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocatorTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocatorTest.groovy
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.internal
+
+import org.gradle.api.GradleException
+import org.gradle.api.logging.Logger
+import org.gradle.api.provider.Provider
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.jvm.toolchain.JavaInstallationMetadata
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.process.ExecOperations
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import static org.graalvm.buildtools.utils.SharedConstants.NATIVE_IMAGE_EXE
+
+/**
+ * Unit tests for {@link NativeImageExecutableLocator}.
+ * Covers the explicit-vs-convention launcher selection logic (§FS-native-invocation.1).
+ */
+class NativeImageExecutableLocatorTest extends Specification {
+
+    @TempDir
+    File tempDir
+
+    def "explicit launcher with missing native-image fails with diagnostic for §FS-native-invocation.1.1"() {
+        given:
+        def toolchainDir = new File(tempDir, "toolchain-jdk")
+        toolchainDir.mkdirs()
+        def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
+
+        def metadata = Stub(JavaInstallationMetadata) {
+            getInstallationPath() >> Stub(Directory) {
+                file(_) >> Stub(RegularFile) {
+                    getAsFile() >> toolchainNativeImage
+                }
+                getAsFile() >> toolchainDir
+            }
+        }
+        def launcher = Stub(JavaLauncher) {
+            getMetadata() >> metadata
+        }
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def logger = GraalVMLogger.of(Stub(Logger))
+        def execOperations = Stub(ExecOperations)
+
+        when:
+        NativeImageExecutableLocator.findNativeImageExecutable(
+                launcher, true,
+                Stub(Provider),
+                Stub(Provider),
+                execOperations,
+                logger,
+                diagnostics,
+                List.of())
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains("does not contain the 'native-image' executable")
+        ex.message.contains("remove the javaLauncher configuration")
+    }
+
+    def "convention launcher without native-image falls back to GRAALVM_HOME for §FS-native-invocation.1.2/1.3"() {
+        given:
+        def toolchainDir = new File(tempDir, "toolchain-jdk")
+        toolchainDir.mkdirs()
+        def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
+
+        def graalvmHome = new File(tempDir, "graalvm")
+        new File(graalvmHome, "bin").mkdirs()
+        def graalvmNativeImage = new File(graalvmHome, "bin/$NATIVE_IMAGE_EXE")
+        graalvmNativeImage.createNewFile()
+        assert graalvmNativeImage.exists()
+
+        def metadata = Stub(JavaInstallationMetadata) {
+            getInstallationPath() >> Stub(Directory) {
+                file(_) >> Stub(RegularFile) {
+                    getAsFile() >> toolchainNativeImage
+                }
+                getAsFile() >> toolchainDir
+            }
+        }
+        def launcher = Stub(JavaLauncher) {
+            getMetadata() >> metadata
+        }
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def logger = GraalVMLogger.of(Stub(Logger))
+        def execOperations = Stub(ExecOperations)
+        def graalvmHomeProvider = Stub(Provider) {
+            isPresent() >> true
+            get() >> graalvmHome.absolutePath
+            getOrNull() >> graalvmHome.absolutePath
+        }
+
+        when:
+        def result = NativeImageExecutableLocator.findNativeImageExecutable(
+                launcher, false,
+                Stub(Provider),
+                graalvmHomeProvider,
+                execOperations,
+                logger,
+                diagnostics,
+                List.of())
+
+        then:
+        result != null
+        result.absolutePath == graalvmNativeImage.absolutePath
+    }
+
+    def "convention launcher falls back to alternative GraalVM home when gu install cannot provide native-image for §FS-native-invocation.1.3"() {
+        given:
+        def toolchainDir = new File(tempDir, "toolchain-jdk")
+        toolchainDir.mkdirs()
+        def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
+
+        // Primary candidate (from the graalvmHome provider) has no native-image and no gu.
+        def primaryHome = new File(tempDir, "primary-graalvm")
+        new File(primaryHome, "bin").mkdirs()
+
+        // Alternative home provided as a fallback candidate contains native-image.
+        def altHome = new File(tempDir, "alt-graalvm")
+        new File(altHome, "bin").mkdirs()
+        def altNativeImage = new File(altHome, "bin/$NATIVE_IMAGE_EXE")
+        altNativeImage.createNewFile()
+        assert altNativeImage.exists()
+
+        def metadata = Stub(JavaInstallationMetadata) {
+            getInstallationPath() >> Stub(Directory) {
+                file(_) >> Stub(RegularFile) {
+                    getAsFile() >> toolchainNativeImage
+                }
+                getAsFile() >> toolchainDir
+            }
+        }
+        def launcher = Stub(JavaLauncher) {
+            getMetadata() >> metadata
+        }
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def logger = GraalVMLogger.of(Stub(Logger))
+        def execOperations = Stub(ExecOperations)
+        def graalvmHomeProvider = Stub(Provider) {
+            isPresent() >> true
+            get() >> primaryHome.absolutePath
+            getOrNull() >> primaryHome.absolutePath
+        }
+        def fallbackCandidates = List.of(
+                new NativeImageExecutableLocator.VmHomeCandidate(altHome.absolutePath, "GRAALVM_HOME"),
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "JAVA_HOME"),
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "Gradle JVM (java.home)")
+        )
+
+        when:
+        def result = NativeImageExecutableLocator.findNativeImageExecutable(
+                launcher, false,
+                Stub(Provider),
+                graalvmHomeProvider,
+                execOperations,
+                logger,
+                diagnostics,
+                fallbackCandidates)
+
+        then:
+        result != null
+        result.absolutePath == altNativeImage.absolutePath
+        diagnostics.getEnvVarName() == "GRAALVM_HOME"
+    }
+
+    def "failure message notes non-GraalVM JDK only when no environment home is set for §FS-native-invocation.1.5"() {
+        given:
+        def toolchainDir = new File(tempDir, "toolchain-jdk")
+        toolchainDir.mkdirs()
+        def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
+
+        def metadata = Stub(JavaInstallationMetadata) {
+            getInstallationPath() >> Stub(Directory) {
+                file(_) >> Stub(RegularFile) {
+                    getAsFile() >> toolchainNativeImage
+                }
+                getAsFile() >> toolchainDir
+            }
+        }
+        def launcher = Stub(JavaLauncher) {
+            getMetadata() >> metadata
+        }
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def logger = GraalVMLogger.of(Stub(Logger))
+        def execOperations = Stub(ExecOperations)
+        // graalvmHome provider present but points at a home without native-image and without gu.
+        def graalvmHome = new File(tempDir, "empty-graalvm")
+        new File(graalvmHome, "bin").mkdirs()
+        def graalvmHomeProvider = Stub(Provider) {
+            isPresent() >> true
+            get() >> graalvmHome.absolutePath
+            getOrNull() >> graalvmHome.absolutePath
+        }
+        // All fallback candidates are null, so no alternative GraalVM home is found.
+        def fallbackCandidates = List.of(
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "GRAALVM_HOME"),
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "JAVA_HOME"),
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "Gradle JVM (java.home)")
+        )
+
+        when:
+        NativeImageExecutableLocator.findNativeImageExecutable(
+                launcher, false,
+                Stub(Provider) { get() >> false },
+                graalvmHomeProvider,
+                execOperations,
+                logger,
+                diagnostics,
+                fallbackCandidates)
+
+        then:
+        def ex = thrown(GradleException)
+        // env-var home is set, so the message must not claim a non-GraalVM JDK.
+        !ex.message.contains("non-GraalVM JDK")
+        ex.message.contains("even after attempting gu install")
+    }
+
+    def "Gradle JVM source is recorded in diagnostics when used as last resort for §FS-native-invocation.1.5"() {
+        given:
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def gradleJvmHome = Mock(Provider)
+        def resolved = Stub(Provider) {
+            getOrNull() >> System.getProperty("java.home")
+            get() >> System.getProperty("java.home")
+        }
+        gradleJvmHome.map(_) >> { transformer ->
+            def t = (transformer instanceof List) ? transformer[0] : transformer
+            t.transform(System.getProperty("java.home"))
+            return resolved
+        }
+
+        when:
+        def provider = diagnostics.fromGradleJvm(gradleJvmHome)
+        provider.getOrNull()
+
+        then:
+        diagnostics.getEnvVarName() == "Gradle JVM (java.home)"
+        provider.getOrNull() == System.getProperty("java.home")
+    }
+}

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocatorTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocatorTest.groovy
@@ -134,7 +134,7 @@ class NativeImageExecutableLocatorTest extends Specification {
         when:
         def result = NativeImageExecutableLocator.findNativeImageExecutable(
                 launcher, false,
-                Stub(Provider),
+                Stub(Provider) { get() >> false },
                 graalvmHomeProvider,
                 execOperations,
                 logger,
@@ -191,7 +191,7 @@ class NativeImageExecutableLocatorTest extends Specification {
         when:
         def result = NativeImageExecutableLocator.findNativeImageExecutable(
                 launcher, false,
-                Stub(Provider),
+                Stub(Provider) { get() >> false },
                 graalvmHomeProvider,
                 execOperations,
                 logger,

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocatorTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocatorTest.groovy
@@ -46,12 +46,15 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.jvm.toolchain.JavaInstallationMetadata
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.process.ExecOperations
+import org.gradle.process.ExecResult
 import spock.lang.Specification
 import spock.lang.TempDir
 
 import static org.graalvm.buildtools.utils.SharedConstants.NATIVE_IMAGE_EXE
+import static org.graalvm.buildtools.utils.SharedConstants.GU_EXE
 
 /**
  * Unit tests for {@link NativeImageExecutableLocator}.
@@ -69,6 +72,8 @@ class NativeImageExecutableLocatorTest extends Specification {
         def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
 
         def metadata = Stub(JavaInstallationMetadata) {
+            getLanguageVersion() >> JavaLanguageVersion.of(17)
+            getVendor() >> "TestVendor"
             getInstallationPath() >> Stub(Directory) {
                 file(_) >> Stub(RegularFile) {
                     getAsFile() >> toolchainNativeImage
@@ -97,6 +102,8 @@ class NativeImageExecutableLocatorTest extends Specification {
         def ex = thrown(GradleException)
         ex.message.contains("does not contain the 'native-image' executable")
         ex.message.contains("remove the javaLauncher configuration")
+        ex.message.contains("explicitly configured javaLauncher (17")
+        ex.message.contains(toolchainDir.absolutePath)
     }
 
     def "convention launcher without native-image falls back to GRAALVM_HOME for §FS-native-invocation.1.2/1.3"() {
@@ -253,7 +260,114 @@ class NativeImageExecutableLocatorTest extends Specification {
         def ex = thrown(GradleException)
         // env-var home is set, so the message must not claim a non-GraalVM JDK.
         !ex.message.contains("non-GraalVM JDK")
+        ex.message.contains("gu tool was not available")
+    }
+
+    def "failure message enumerates which environment candidates were set or unset for §FS-native-invocation.1.5"() {
+        given:
+        def toolchainDir = new File(tempDir, "toolchain-jdk")
+        toolchainDir.mkdirs()
+        def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
+
+        def metadata = Stub(JavaInstallationMetadata) {
+            getLanguageVersion() >> JavaLanguageVersion.of(17)
+            getVendor() >> "TestVendor"
+            getInstallationPath() >> Stub(Directory) {
+                file(_) >> Stub(RegularFile) {
+                    getAsFile() >> toolchainNativeImage
+                }
+                getAsFile() >> toolchainDir
+            }
+        }
+        def launcher = Stub(JavaLauncher) {
+            getMetadata() >> metadata
+        }
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def logger = GraalVMLogger.of(Stub(Logger))
+        def execOperations = Stub(ExecOperations)
+        // Primary home resolved from the provider lacks native-image and has no gu.
+        def graalvmHome = new File(tempDir, "set-graalvm")
+        new File(graalvmHome, "bin").mkdirs()
+        def graalvmHomeProvider = Stub(Provider) {
+            isPresent() >> true
+            get() >> graalvmHome.absolutePath
+            getOrNull() >> graalvmHome.absolutePath
+        }
+        // GRAALVM_HOME is set to the failing home; JAVA_HOME and the Gradle JVM are not set.
+        def fallbackCandidates = List.of(
+                new NativeImageExecutableLocator.VmHomeCandidate(graalvmHome.absolutePath, "GRAALVM_HOME"),
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "JAVA_HOME"),
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "Gradle JVM (java.home)")
+        )
+
+        when:
+        NativeImageExecutableLocator.findNativeImageExecutable(
+                launcher, false,
+                Stub(Provider) { get() >> false },
+                graalvmHomeProvider,
+                execOperations,
+                logger,
+                diagnostics,
+                fallbackCandidates)
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains("GRAALVM_HOME: " + graalvmHome.absolutePath)
+        ex.message.contains("JAVA_HOME: not set")
+        ex.message.contains("Gradle JVM (java.home): not set")
+    }
+
+    def "failure message reports the gu install attempt when gu exists but fails for §FS-native-invocation.1.5"() {
+        given:
+        def toolchainDir = new File(tempDir, "toolchain-jdk")
+        toolchainDir.mkdirs()
+        def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
+
+        def metadata = Stub(JavaInstallationMetadata) {
+            getLanguageVersion() >> JavaLanguageVersion.of(17)
+            getVendor() >> "TestVendor"
+            getInstallationPath() >> Stub(Directory) {
+                file(_) >> Stub(RegularFile) {
+                    getAsFile() >> toolchainNativeImage
+                }
+                getAsFile() >> toolchainDir
+            }
+        }
+        def launcher = Stub(JavaLauncher) {
+            getMetadata() >> metadata
+        }
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def logger = GraalVMLogger.of(Stub(Logger))
+        // Selected home has a gu tool, but invoking it fails with a non-zero exit code.
+        def graalvmHome = new File(tempDir, "gu-graalvm")
+        def graalvmBin = new File(graalvmHome, "bin")
+        graalvmBin.mkdirs()
+        new File(graalvmBin, GU_EXE).createNewFile()
+        def execOperations = Stub(ExecOperations) {
+            exec(_) >> Stub(ExecResult) {
+                getExitValue() >> 1
+            }
+        }
+        def graalvmHomeProvider = Stub(Provider) {
+            isPresent() >> true
+            get() >> graalvmHome.absolutePath
+            getOrNull() >> graalvmHome.absolutePath
+        }
+
+        when:
+        NativeImageExecutableLocator.findNativeImageExecutable(
+                launcher, false,
+                Stub(Provider) { get() >> false },
+                graalvmHomeProvider,
+                execOperations,
+                logger,
+                diagnostics,
+                List.of())
+
+        then:
+        def ex = thrown(GradleException)
         ex.message.contains("even after attempting gu install")
+        !ex.message.contains("gu tool was not available")
     }
 
     def "Gradle JVM source is recorded in diagnostics when used as last resort for §FS-native-invocation.1.5"() {

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocatorTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/internal/NativeImageExecutableLocatorTest.groovy
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.internal
+
+import org.gradle.api.GradleException
+import org.gradle.api.logging.Logger
+import org.gradle.api.provider.Provider
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.jvm.toolchain.JavaInstallationMetadata
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecResult
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import static org.graalvm.buildtools.utils.SharedConstants.NATIVE_IMAGE_EXE
+import static org.graalvm.buildtools.utils.SharedConstants.GU_EXE
+
+/**
+ * Unit tests for {@link NativeImageExecutableLocator}.
+ * Covers the explicit-vs-convention launcher selection logic (§FS-native-invocation.1).
+ */
+class NativeImageExecutableLocatorTest extends Specification {
+
+    @TempDir
+    File tempDir
+
+    def "explicit launcher with missing native-image fails with diagnostic for §FS-native-invocation.1.1"() {
+        given:
+        def toolchainDir = new File(tempDir, "toolchain-jdk")
+        toolchainDir.mkdirs()
+        def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
+
+        def metadata = Stub(JavaInstallationMetadata) {
+            getLanguageVersion() >> JavaLanguageVersion.of(17)
+            getVendor() >> "TestVendor"
+            getInstallationPath() >> Stub(Directory) {
+                file(_) >> Stub(RegularFile) {
+                    getAsFile() >> toolchainNativeImage
+                }
+                getAsFile() >> toolchainDir
+            }
+        }
+        def launcher = Stub(JavaLauncher) {
+            getMetadata() >> metadata
+        }
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def logger = GraalVMLogger.of(Stub(Logger))
+        def execOperations = Stub(ExecOperations)
+
+        when:
+        NativeImageExecutableLocator.findNativeImageExecutable(
+                launcher, true,
+                Stub(Provider),
+                Stub(Provider),
+                execOperations,
+                logger,
+                diagnostics,
+                List.of())
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains("does not contain the 'native-image' executable")
+        ex.message.contains("remove the javaLauncher configuration")
+        ex.message.contains("explicitly configured javaLauncher (17")
+        ex.message.contains(toolchainDir.absolutePath)
+    }
+
+    def "convention launcher without native-image falls back to GRAALVM_HOME for §FS-native-invocation.1.2/1.3"() {
+        given:
+        def toolchainDir = new File(tempDir, "toolchain-jdk")
+        toolchainDir.mkdirs()
+        def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
+
+        def graalvmHome = new File(tempDir, "graalvm")
+        new File(graalvmHome, "bin").mkdirs()
+        def graalvmNativeImage = new File(graalvmHome, "bin/$NATIVE_IMAGE_EXE")
+        graalvmNativeImage.createNewFile()
+        assert graalvmNativeImage.exists()
+
+        def metadata = Stub(JavaInstallationMetadata) {
+            getInstallationPath() >> Stub(Directory) {
+                file(_) >> Stub(RegularFile) {
+                    getAsFile() >> toolchainNativeImage
+                }
+                getAsFile() >> toolchainDir
+            }
+        }
+        def launcher = Stub(JavaLauncher) {
+            getMetadata() >> metadata
+        }
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def logger = GraalVMLogger.of(Stub(Logger))
+        def execOperations = Stub(ExecOperations)
+        def graalvmHomeProvider = Stub(Provider) {
+            isPresent() >> true
+            get() >> graalvmHome.absolutePath
+            getOrNull() >> graalvmHome.absolutePath
+        }
+
+        when:
+        def result = NativeImageExecutableLocator.findNativeImageExecutable(
+                launcher, false,
+                Stub(Provider) { get() >> false },
+                graalvmHomeProvider,
+                execOperations,
+                logger,
+                diagnostics,
+                List.of())
+
+        then:
+        result != null
+        result.absolutePath == graalvmNativeImage.absolutePath
+    }
+
+    def "convention launcher falls back to alternative GraalVM home when gu install cannot provide native-image for §FS-native-invocation.1.3"() {
+        given:
+        def toolchainDir = new File(tempDir, "toolchain-jdk")
+        toolchainDir.mkdirs()
+        def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
+
+        // Primary candidate (from the graalvmHome provider) has no native-image and no gu.
+        def primaryHome = new File(tempDir, "primary-graalvm")
+        new File(primaryHome, "bin").mkdirs()
+
+        // Alternative home provided as a fallback candidate contains native-image.
+        def altHome = new File(tempDir, "alt-graalvm")
+        new File(altHome, "bin").mkdirs()
+        def altNativeImage = new File(altHome, "bin/$NATIVE_IMAGE_EXE")
+        altNativeImage.createNewFile()
+        assert altNativeImage.exists()
+
+        def metadata = Stub(JavaInstallationMetadata) {
+            getInstallationPath() >> Stub(Directory) {
+                file(_) >> Stub(RegularFile) {
+                    getAsFile() >> toolchainNativeImage
+                }
+                getAsFile() >> toolchainDir
+            }
+        }
+        def launcher = Stub(JavaLauncher) {
+            getMetadata() >> metadata
+        }
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def logger = GraalVMLogger.of(Stub(Logger))
+        def execOperations = Stub(ExecOperations)
+        def graalvmHomeProvider = Stub(Provider) {
+            isPresent() >> true
+            get() >> primaryHome.absolutePath
+            getOrNull() >> primaryHome.absolutePath
+        }
+        def fallbackCandidates = List.of(
+                new NativeImageExecutableLocator.VmHomeCandidate(altHome.absolutePath, "GRAALVM_HOME"),
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "JAVA_HOME"),
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "Gradle JVM (java.home)")
+        )
+
+        when:
+        def result = NativeImageExecutableLocator.findNativeImageExecutable(
+                launcher, false,
+                Stub(Provider) { get() >> false },
+                graalvmHomeProvider,
+                execOperations,
+                logger,
+                diagnostics,
+                fallbackCandidates)
+
+        then:
+        result != null
+        result.absolutePath == altNativeImage.absolutePath
+        diagnostics.getEnvVarName() == "GRAALVM_HOME"
+    }
+
+    def "failure message notes non-GraalVM JDK only when no environment home is set for §FS-native-invocation.1.5"() {
+        given:
+        def toolchainDir = new File(tempDir, "toolchain-jdk")
+        toolchainDir.mkdirs()
+        def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
+
+        def metadata = Stub(JavaInstallationMetadata) {
+            getInstallationPath() >> Stub(Directory) {
+                file(_) >> Stub(RegularFile) {
+                    getAsFile() >> toolchainNativeImage
+                }
+                getAsFile() >> toolchainDir
+            }
+        }
+        def launcher = Stub(JavaLauncher) {
+            getMetadata() >> metadata
+        }
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def logger = GraalVMLogger.of(Stub(Logger))
+        def execOperations = Stub(ExecOperations)
+        // graalvmHome provider present but points at a home without native-image and without gu.
+        def graalvmHome = new File(tempDir, "empty-graalvm")
+        new File(graalvmHome, "bin").mkdirs()
+        def graalvmHomeProvider = Stub(Provider) {
+            isPresent() >> true
+            get() >> graalvmHome.absolutePath
+            getOrNull() >> graalvmHome.absolutePath
+        }
+        // All fallback candidates are null, so no alternative GraalVM home is found.
+        def fallbackCandidates = List.of(
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "GRAALVM_HOME"),
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "JAVA_HOME"),
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "Gradle JVM (java.home)")
+        )
+
+        when:
+        NativeImageExecutableLocator.findNativeImageExecutable(
+                launcher, false,
+                Stub(Provider) { get() >> false },
+                graalvmHomeProvider,
+                execOperations,
+                logger,
+                diagnostics,
+                fallbackCandidates)
+
+        then:
+        def ex = thrown(GradleException)
+        // env-var home is set, so the message must not claim a non-GraalVM JDK.
+        !ex.message.contains("non-GraalVM JDK")
+        ex.message.contains("gu tool was not available")
+    }
+
+    def "failure message enumerates which environment candidates were set or unset for §FS-native-invocation.1.5"() {
+        given:
+        def toolchainDir = new File(tempDir, "toolchain-jdk")
+        toolchainDir.mkdirs()
+        def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
+
+        def metadata = Stub(JavaInstallationMetadata) {
+            getLanguageVersion() >> JavaLanguageVersion.of(17)
+            getVendor() >> "TestVendor"
+            getInstallationPath() >> Stub(Directory) {
+                file(_) >> Stub(RegularFile) {
+                    getAsFile() >> toolchainNativeImage
+                }
+                getAsFile() >> toolchainDir
+            }
+        }
+        def launcher = Stub(JavaLauncher) {
+            getMetadata() >> metadata
+        }
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def logger = GraalVMLogger.of(Stub(Logger))
+        def execOperations = Stub(ExecOperations)
+        // Primary home resolved from the provider lacks native-image and has no gu.
+        def graalvmHome = new File(tempDir, "set-graalvm")
+        new File(graalvmHome, "bin").mkdirs()
+        def graalvmHomeProvider = Stub(Provider) {
+            isPresent() >> true
+            get() >> graalvmHome.absolutePath
+            getOrNull() >> graalvmHome.absolutePath
+        }
+        // GRAALVM_HOME is set to the failing home; JAVA_HOME and the Gradle JVM are not set.
+        def fallbackCandidates = List.of(
+                new NativeImageExecutableLocator.VmHomeCandidate(graalvmHome.absolutePath, "GRAALVM_HOME"),
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "JAVA_HOME"),
+                new NativeImageExecutableLocator.VmHomeCandidate(null, "Gradle JVM (java.home)")
+        )
+
+        when:
+        NativeImageExecutableLocator.findNativeImageExecutable(
+                launcher, false,
+                Stub(Provider) { get() >> false },
+                graalvmHomeProvider,
+                execOperations,
+                logger,
+                diagnostics,
+                fallbackCandidates)
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains("GRAALVM_HOME: " + graalvmHome.absolutePath)
+        ex.message.contains("JAVA_HOME: not set")
+        ex.message.contains("Gradle JVM (java.home): not set")
+    }
+
+    def "failure message reports the gu install attempt when gu exists but fails for §FS-native-invocation.1.5"() {
+        given:
+        def toolchainDir = new File(tempDir, "toolchain-jdk")
+        toolchainDir.mkdirs()
+        def toolchainNativeImage = new File(toolchainDir, "bin/$NATIVE_IMAGE_EXE")
+
+        def metadata = Stub(JavaInstallationMetadata) {
+            getLanguageVersion() >> JavaLanguageVersion.of(17)
+            getVendor() >> "TestVendor"
+            getInstallationPath() >> Stub(Directory) {
+                file(_) >> Stub(RegularFile) {
+                    getAsFile() >> toolchainNativeImage
+                }
+                getAsFile() >> toolchainDir
+            }
+        }
+        def launcher = Stub(JavaLauncher) {
+            getMetadata() >> metadata
+        }
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def logger = GraalVMLogger.of(Stub(Logger))
+        // Selected home has a gu tool, but invoking it fails with a non-zero exit code.
+        def graalvmHome = new File(tempDir, "gu-graalvm")
+        def graalvmBin = new File(graalvmHome, "bin")
+        graalvmBin.mkdirs()
+        new File(graalvmBin, GU_EXE).createNewFile()
+        def execOperations = Stub(ExecOperations) {
+            exec(_) >> Stub(ExecResult) {
+                getExitValue() >> 1
+            }
+        }
+        def graalvmHomeProvider = Stub(Provider) {
+            isPresent() >> true
+            get() >> graalvmHome.absolutePath
+            getOrNull() >> graalvmHome.absolutePath
+        }
+
+        when:
+        NativeImageExecutableLocator.findNativeImageExecutable(
+                launcher, false,
+                Stub(Provider) { get() >> false },
+                graalvmHomeProvider,
+                execOperations,
+                logger,
+                diagnostics,
+                List.of())
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains("even after attempting gu install")
+        !ex.message.contains("gu tool was not available")
+    }
+
+    def "Gradle JVM source is recorded in diagnostics when used as last resort for §FS-native-invocation.1.5"() {
+        given:
+        def diagnostics = new NativeImageExecutableLocator.Diagnostics()
+        def gradleJvmHome = Mock(Provider)
+        def resolved = Stub(Provider) {
+            getOrNull() >> System.getProperty("java.home")
+            get() >> System.getProperty("java.home")
+        }
+        gradleJvmHome.map(_) >> { transformer ->
+            def t = (transformer instanceof List) ? transformer[0] : transformer
+            t.transform(System.getProperty("java.home"))
+            return resolved
+        }
+
+        when:
+        def provider = diagnostics.fromGradleJvm(gradleJvmHome)
+        provider.getOrNull()
+
+        then:
+        diagnostics.getEnvVarName() == "Gradle JVM (java.home)"
+        provider.getOrNull() == System.getProperty("java.home")
+    }
+}

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesActionTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesActionTest.groovy
@@ -91,7 +91,8 @@ class MergeAgentFilesActionTest extends Specification {
                 { [new File(fakeGraalVmHome, "agent-input").absolutePath] },
                 { [new File(fakeGraalVmHome, "agent-output").absolutePath] },
                 project.provider { false },
-                execOperations)
+                execOperations,
+                project.getProviders())
 
         when:
         action.execute(task)

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesActionTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesActionTest.groovy
@@ -91,7 +91,54 @@ class MergeAgentFilesActionTest extends Specification {
                 { [new File(fakeGraalVmHome, "agent-input").absolutePath] },
                 { [new File(fakeGraalVmHome, "agent-output").absolutePath] },
                 project.provider { false },
-                execOperations)
+                project.provider { false },
+                execOperations,
+                project.providers.provider { environmentGraalVmHome.absolutePath },
+                project.providers.provider { null },
+                project.providers.provider { null })
+
+        when:
+        action.execute(task)
+
+        then:
+        noExceptionThrown()
+        0 * execOperations.exec(_)
+    }
+
+    // §FS-native-invocation.1.3: fallback candidates must come from the same environment providers the task models as inputs.
+    def "derives fallback candidates from the injected environment providers"() {
+        given:
+        def project = ProjectBuilder.builder()
+                .withProjectDir(testDirectory.resolve("project").toFile())
+                .build()
+        def emptyGraalVmHome = testDirectory.resolve("empty-graalvm").toFile()
+        def emptyGraalVmBin = new File(emptyGraalVmHome, "bin")
+        assert emptyGraalVmBin.mkdirs()
+        def environmentGraalVmHome = testDirectory.resolve("environment-graalvm").toFile()
+        def environmentGraalVmBin = new File(environmentGraalVmHome, "bin")
+        assert environmentGraalVmBin.mkdirs()
+        assert new File(environmentGraalVmBin, NATIVE_IMAGE_EXE).createNewFile()
+        assert new File(environmentGraalVmBin, nativeImageConfigureFileName()).createNewFile()
+
+        def javaLauncher = project.objects.property(JavaLauncher)
+        def task = project.tasks.create("mergeAgentFiles")
+        def execOperations = Mock(ExecOperations)
+
+        def action = new MergeAgentFilesAction(
+                project.provider { true },
+                project.provider { new DisabledAgentMode() },
+                project.provider { false },
+                project.objects,
+                javaLauncher,
+                project.provider { emptyGraalVmHome.absolutePath },
+                { [new File(environmentGraalVmHome, "agent-input").absolutePath] },
+                { [new File(environmentGraalVmHome, "agent-output").absolutePath] },
+                project.provider { false },
+                project.provider { false },
+                execOperations,
+                project.providers.provider { environmentGraalVmHome.absolutePath },
+                project.providers.provider { null },
+                project.providers.provider { null })
 
         when:
         action.execute(task)

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesActionTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesActionTest.groovy
@@ -91,6 +91,7 @@ class MergeAgentFilesActionTest extends Specification {
                 { [new File(fakeGraalVmHome, "agent-input").absolutePath] },
                 { [new File(fakeGraalVmHome, "agent-output").absolutePath] },
                 project.provider { false },
+                project.provider { false },
                 execOperations,
                 project.getProviders())
 

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesActionTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesActionTest.groovy
@@ -93,7 +93,52 @@ class MergeAgentFilesActionTest extends Specification {
                 project.provider { false },
                 project.provider { false },
                 execOperations,
-                project.getProviders())
+                project.providers.provider { environmentGraalVmHome.absolutePath },
+                project.providers.provider { null },
+                project.providers.provider { null })
+
+        when:
+        action.execute(task)
+
+        then:
+        noExceptionThrown()
+        0 * execOperations.exec(_)
+    }
+
+    // §FS-native-invocation.1.3: fallback candidates must come from the same environment providers the task models as inputs.
+    def "derives fallback candidates from the injected environment providers"() {
+        given:
+        def project = ProjectBuilder.builder()
+                .withProjectDir(testDirectory.resolve("project").toFile())
+                .build()
+        def emptyGraalVmHome = testDirectory.resolve("empty-graalvm").toFile()
+        def emptyGraalVmBin = new File(emptyGraalVmHome, "bin")
+        assert emptyGraalVmBin.mkdirs()
+        def environmentGraalVmHome = testDirectory.resolve("environment-graalvm").toFile()
+        def environmentGraalVmBin = new File(environmentGraalVmHome, "bin")
+        assert environmentGraalVmBin.mkdirs()
+        assert new File(environmentGraalVmBin, NATIVE_IMAGE_EXE).createNewFile()
+        assert new File(environmentGraalVmBin, nativeImageConfigureFileName()).createNewFile()
+
+        def javaLauncher = project.objects.property(JavaLauncher)
+        def task = project.tasks.create("mergeAgentFiles")
+        def execOperations = Mock(ExecOperations)
+
+        def action = new MergeAgentFilesAction(
+                project.provider { true },
+                project.provider { new DisabledAgentMode() },
+                project.provider { false },
+                project.objects,
+                javaLauncher,
+                project.provider { emptyGraalVmHome.absolutePath },
+                { [new File(environmentGraalVmHome, "agent-input").absolutePath] },
+                { [new File(environmentGraalVmHome, "agent-output").absolutePath] },
+                project.provider { false },
+                project.provider { false },
+                execOperations,
+                project.providers.provider { environmentGraalVmHome.absolutePath },
+                project.providers.provider { null },
+                project.providers.provider { null })
 
         when:
         action.execute(task)

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -209,6 +209,35 @@ abstract class AbstractFunctionalTest extends Specification {
         }
     }
 
+    // Helper method to run Gradle with custom environment variables
+    void runWithEnv(Map<String, String> env, String... args) {
+        // Debug mode is not allowed when environment variables are set
+        // because Gradle TestKit needs to fork a separate process
+        def wasDebug = debug
+        debug = false
+        try {
+            def runner = newRunner(*args)
+            // Preserve current environment and override only specified variables
+            // This prevents issues like NPE when PATH is missing
+            def currentEnv = System.getenv() as Map<String, String> ?: [:]
+            def mergedEnv = new HashMap<>(currentEnv)
+            mergedEnv.putAll(env)
+            runner.withEnvironment(mergedEnv)
+            result = runner.run()
+            if (hasConfigurationCache) {
+                // run a 2d time to check that not only we can store in
+                // the configuration cache, but that we can also load from it
+                result = newRunner(*[*args, "--rerun-tasks"] as String[])
+                        .withEnvironment(mergedEnv)
+                        .run()
+            }
+        } finally {
+            recordOutputs()
+
+            debug = wasDebug
+        }
+    }
+
     void outputContains(String text) {
         assert output.contains(normalizeString(text))
     }

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -225,7 +225,11 @@ abstract class AbstractFunctionalTest extends Specification {
             runner.withEnvironment(mergedEnv)
             result = runner.run()
             if (hasConfigurationCache) {
-                // run a 2d time to check that not only we can store in
+                // Save first-run output before the second run resets the writer.
+                // Configuration-time messages (afterEvaluate) only fire on the store run.
+                configurationCacheStoreResult = result
+                configurationCacheStoreOutput = normalizeString(outputWriter.toString())
+                // run a 2nd time to check that not only we can store in
                 // the configuration cache, but that we can also load from it
                 result = newRunner(*[*args, "--rerun-tasks"] as String[])
                         .withEnvironment(mergedEnv)

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -214,6 +214,39 @@ abstract class AbstractFunctionalTest extends Specification {
         }
     }
 
+    // Helper method to run Gradle with custom environment variables
+    void runWithEnv(Map<String, String> env, String... args) {
+        // Debug mode is not allowed when environment variables are set
+        // because Gradle TestKit needs to fork a separate process
+        def wasDebug = debug
+        debug = false
+        try {
+            def runner = newRunner(*args)
+            // Preserve current environment and override only specified variables
+            // This prevents issues like NPE when PATH is missing
+            def currentEnv = System.getenv() as Map<String, String> ?: [:]
+            def mergedEnv = new HashMap<>(currentEnv)
+            mergedEnv.putAll(env)
+            runner.withEnvironment(mergedEnv)
+            result = runner.run()
+            if (hasConfigurationCache) {
+                // Save first-run output before the second run resets the writer.
+                // Configuration-time messages (afterEvaluate) only fire on the store run.
+                configurationCacheStoreResult = result
+                configurationCacheStoreOutput = normalizeString(outputWriter.toString())
+                // run a 2nd time to check that not only we can store in
+                // the configuration cache, but that we can also load from it
+                result = newRunner(*[*args, "--rerun-tasks"] as String[])
+                        .withEnvironment(mergedEnv)
+                        .run()
+            }
+        } finally {
+            recordOutputs()
+
+            debug = wasDebug
+        }
+    }
+
     void outputContains(String text) {
         assert output.contains(normalizeString(text))
     }


### PR DESCRIPTION
## Summary

This PR makes native-image executable discovery safer and more predictable by distinguishing an **explicitly configured** launcher from one selected **by convention**, so the plugin always builds against a launcher that actually provides `native-image`, and fails with a clear message when it cannot.

### Before this PR

- Toolchain detection (`toolchainDetection = true`) used the toolchain-resolved JDK as the launcher without checking whether that JDK contained `native-image`, leading to confusing failures.
- When the explicit `javaLauncher` lacked `native-image`, the build failed silently or with an opaque downstream error.
- There was no clear, documented rule for how an explicitly chosen launcher relates to the `GRAALVM_HOME` / `JAVA_HOME` fallback chain.

### After this PR

**Explicit `javaLauncher` — treated as authoritative.**

- If the user explicitly sets `graalvmNative.binaries.<name>.javaLauncher` and that launcher does not contain `bin/native-image`, the build fails immediately with a message naming the launcher and its installation path. No fallback, no `gu install`.

**Convention launcher (toolchain detection) — used only when it can supply Native Image.**

- When `toolchainDetection = true`, toolchain detection is used as the `javaLauncher` convention, so `graalvmNative.binaries.main.javaLauncher` stays queryable.
- At build time the plugin checks whether the resolved launcher actually contains `bin/native-image`. If it does, that launcher is used.
- If it does not, the plugin transparently falls back to the environment chain (`GRAALVM_HOME` → `JAVA_HOME` → the Gradle JVM `java-home`), optionally installing `native-image` via `gu` there. A convention-selected launcher never blocks a working GraalVM in the environment. §FS-native-invocation.1.5
- `gu install native-image` runs only on this environment-fallback path, never against a user-configured or toolchain installation (a convention launcher is never mutated in place).
- If no source yields `native-image`, the build fails with a diagnostic that lists the probed paths and the selected location source.

Net effect: the plugin finds a usable `native-image` whenever one exists on the machine, fails fast with actionable messages when it does not, and always respects an explicit choice over automation.

### Spec documentation

- `FS-native-invocation.1` (Executable discovery) documented in `native-gradle-plugin/docs/functional/native-image-invocation.md`:
  - §1.1: Explicit java launcher
  - §1.2: Convention-selected launcher
  - §1.3: Environment-variable fallback (GRAALVM_HOME → JAVA_HOME → Gradle JVM)
  - §1.4: gu-based installation
  - §1.5: Failure messages
  - §1.6: Toolchain detection interaction

### Test coverage

- **`NativeImageExecutableLocatorTest`** (unit tests):
  - Explicit launcher with missing `native-image` → `GradleException` with diagnostic message
  - Convention launcher without `native-image` → falls back to `GRAALVM_HOME`

- **`ToolchainDiscoveryTest`** (functional tests, `src/functionalTest`):
  - `explicit javaLauncher overrides toolchain` (§1.1) — explicit launcher used, not GRAALVM_HOME
  - `toolchain takes precedence over GRAALVM_HOME env var when running nativeCompile` (§1.2)
  - `disabling toolchainDetection uses GRAALVM_HOME fallback` (§1.3)
  - `native-image found in alternative GraalVM home when GRAALVM_HOME has no native-image and no gu` (§1.3 cross-home fallback) — when `GRAALVM_HOME` lacks `native-image` and has no `gu`, the locator probes `JAVA_HOME` and resolves `native-image` from there
  - `gu installs native-image when not found` (§1.4)
  - `gu installation failure falls back to error message` (§1.5)
  - `convention launcher provides native-image when no explicit launcher set` (§1.2) — toolchain convention used when user sets no explicit launcher
  - `compatibility mode detects and uses convention fallback launcher` (§1.2/§1.6) — toolchain-detection active + convention fallback message on both runs
  - `changing JAVA_HOME re-runs nativeCompile when native-image comes from JAVA_HOME fallback` (§1.3) — env fallback candidates are task inputs: switching JAVA_HOME forces re-run, not UP-TO-DATE
  - `unchanged environment keeps nativeCompile UP-TO-DATE` (§1.3) — control: proves the JAVA_HOME swap is what forces the re-run

Fixes #542