### PR TITLE
Fix order of access filter files by moving default to the start

### DIFF
--- a/common/docs/functional-spec.md
+++ b/common/docs/functional-spec.md
@@ -56,6 +56,15 @@ option list. Advanced options such as caller filters, access filters, predefined
 allocation tracing, and reflection metadata tracking must be represented once so both plugins
 expose the same mode semantics.
 
+#### 3.1.1 Access-filter precedence
+
+The shared agent model must emit its built-in default access filter before every user-provided
+access-filter file, so that user configuration takes precedence over the built-in defaults.
+`native-image-agent` evaluates access filters in order and lets later rules override earlier ones,
+so ordering the built-in filter first leaves it as a baseline that user rules override.
+
+A disabled agent configuration must emit no agent command-line options.
+
 ### 3.2 Plugin invocation and output
 
 Plugin-specific enablement, instrumentation hooks, and output locations are specified by

--- a/common/docs/functional-spec.md
+++ b/common/docs/functional-spec.md
@@ -59,11 +59,15 @@ expose the same mode semantics.
 #### 3.1.1 Access-filter precedence
 
 The shared agent model must emit its built-in default access filter before every user-provided
-access-filter file, so that user configuration takes precedence over the built-in defaults.
+access-filter file, including filters supplied as raw direct-mode options, so that user
+configuration takes precedence over the built-in defaults.
 `native-image-agent` evaluates access filters in order and lets later rules override earlier ones,
 so ordering the built-in filter first leaves it as a baseline that user rules override.
 
 A disabled agent configuration must emit no agent command-line options.
+
+Constructing the agent command line must not create the built-in filter. The shared model describes
+the filter's path, while each build-tool adapter must materialize the file at a lifecycle-safe point.
 
 ### 3.2 Plugin invocation and output
 

--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -101,9 +101,9 @@ public class AgentConfiguration implements Serializable {
     }
 
     public List<String> getAgentCommandLine() {
-        addDefaultAccessFilter();
         List<String> cmdLine = new ArrayList<>(agentMode.getAgentCommandLine());
         appendOptionToValues("caller-filter-file=", callerFilterFiles, cmdLine);
+        appendOptionToValues("access-filter-file=", List.of(getDefaultAccessFilter()), cmdLine);
         appendOptionToValues("access-filter-file=", accessFilterFiles, cmdLine);
         addToCmd("builtin-caller-filter=", builtinCallerFilter, cmdLine);
         addToCmd("builtin-heuristic-filter=", builtinHeuristicFilter, cmdLine);
@@ -141,18 +141,12 @@ public class AgentConfiguration implements Serializable {
         }
     }
 
-    private void addDefaultAccessFilter() {
-        if (accessFilterFiles == null) {
-            // this could only happen if we instantiated disabled agent configuration
-            return;
-        }
-
+    private String getDefaultAccessFilter() {
         String tempDir = System.getProperty("java.io.tmpdir");
         Path agentDir = Path.of(tempDir).resolve("agent-config");
         Path accessFilterFile = agentDir.resolve(ACCESS_FILTER_PREFIX + ACCESS_FILTER_SUFFIX);
         if (Files.exists(accessFilterFile)) {
-            accessFilterFiles.add(accessFilterFile.toString());
-            return;
+            return accessFilterFile.toString();
         }
 
         try (InputStream accessFilterData = AgentConfiguration.class.getResourceAsStream(DEFAULT_ACCESS_FILTER_FILE_LOCATION)) {
@@ -176,7 +170,7 @@ public class AgentConfiguration implements Serializable {
                 logger.info(accessFilterFile + " already exists. Delete " + tmpAccessFilter);
             }
 
-            accessFilterFiles.add(accessFilterFile.toString());
+            return accessFilterFile.toString();
         } catch (IOException e) {
             throw new RuntimeException("Cannot add default access-filter.json", e);
         }

--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -48,15 +48,12 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.logging.Logger;
 
 public class AgentConfiguration implements Serializable {
 
     private static final String ACCESS_FILTER_PREFIX = "access-filter";
     private static final String ACCESS_FILTER_SUFFIX = ".json";
     private static final String DEFAULT_ACCESS_FILTER_FILE_LOCATION = "/" + ACCESS_FILTER_PREFIX + ACCESS_FILTER_SUFFIX;
-
-    private static final Logger logger = Logger.getGlobal();
 
     private final Collection<String> callerFilterFiles;
     private final Collection<String> accessFilterFiles;

--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -104,9 +104,9 @@ public class AgentConfiguration implements Serializable {
         if (!isEnabled()) {
             return List.of();
         }
-        addDefaultAccessFilter();
         List<String> cmdLine = new ArrayList<>(agentMode.getAgentCommandLine());
         appendOptionToValues("caller-filter-file=", callerFilterFiles, cmdLine);
+        cmdLine.add("access-filter-file=" + getDefaultAccessFilter());
         appendOptionToValues("access-filter-file=", accessFilterFiles, cmdLine);
         addToCmd("builtin-caller-filter=", builtinCallerFilter, cmdLine);
         addToCmd("builtin-heuristic-filter=", builtinHeuristicFilter, cmdLine);
@@ -144,18 +144,12 @@ public class AgentConfiguration implements Serializable {
         }
     }
 
-    private void addDefaultAccessFilter() {
-        if (accessFilterFiles == null) {
-            // this could only happen if we instantiated disabled agent configuration
-            return;
-        }
-
+    private String getDefaultAccessFilter() {
         String tempDir = System.getProperty("java.io.tmpdir");
         Path agentDir = Path.of(tempDir).resolve("agent-config");
         Path accessFilterFile = agentDir.resolve(ACCESS_FILTER_PREFIX + ACCESS_FILTER_SUFFIX);
         if (Files.exists(accessFilterFile)) {
-            accessFilterFiles.add(accessFilterFile.toString());
-            return;
+            return accessFilterFile.toString();
         }
 
         try (InputStream accessFilterData = AgentConfiguration.class.getResourceAsStream(DEFAULT_ACCESS_FILTER_FILE_LOCATION)) {
@@ -179,7 +173,7 @@ public class AgentConfiguration implements Serializable {
                 logger.info(accessFilterFile + " already exists. Delete " + tmpAccessFilter);
             }
 
-            accessFilterFiles.add(accessFilterFile.toString());
+            return accessFilterFile.toString();
         } catch (IOException e) {
             throw new RuntimeException("Cannot add default access-filter.json", e);
         }

--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -162,12 +162,7 @@ public class AgentConfiguration implements Serializable {
             if (accessFilterData == null) {
                 throw new IOException("Cannot access data from: " + DEFAULT_ACCESS_FILTER_FILE_LOCATION);
             }
-
-            try {
-                Files.createDirectories(agentConfigDir);
-            } catch (FileAlreadyExistsException e) {
-                logger.info("Skip creation of directory " + agentConfigDir + " (already created).");
-            }
+            Files.createDirectories(agentConfigDir);
 
             Path tmpAccessFilter = Files.createTempFile(agentConfigDir, ACCESS_FILTER_PREFIX, ACCESS_FILTER_SUFFIX);
             Files.copy(accessFilterData, tmpAccessFilter, StandardCopyOption.REPLACE_EXISTING);

--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -101,6 +101,9 @@ public class AgentConfiguration implements Serializable {
     }
 
     public List<String> getAgentCommandLine() {
+        if (!isEnabled()) {
+            return List.of();
+        }
         addDefaultAccessFilter();
         List<String> cmdLine = new ArrayList<>(agentMode.getAgentCommandLine());
         appendOptionToValues("caller-filter-file=", callerFilterFiles, cmdLine);

--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -43,10 +43,8 @@ package org.graalvm.buildtools.agent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -163,17 +161,7 @@ public class AgentConfiguration implements Serializable {
                 throw new IOException("Cannot access data from: " + DEFAULT_ACCESS_FILTER_FILE_LOCATION);
             }
             Files.createDirectories(agentConfigDir);
-
-            Path tmpAccessFilter = Files.createTempFile(agentConfigDir, ACCESS_FILTER_PREFIX, ACCESS_FILTER_SUFFIX);
-            Files.copy(accessFilterData, tmpAccessFilter, StandardCopyOption.REPLACE_EXISTING);
-
-            try {
-                Files.move(tmpAccessFilter, accessFilterFile, StandardCopyOption.ATOMIC_MOVE);
-            } catch (FileAlreadyExistsException e) {
-                Files.delete(tmpAccessFilter);
-                logger.info(accessFilterFile + " already exists. Delete " + tmpAccessFilter);
-            }
-
+            Files.copy(accessFilterData, accessFilterFile);
             return accessFilterFile.toString();
         } catch (IOException e) {
             throw new RuntimeException("Cannot add default access-filter.json", e);

--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -109,6 +109,8 @@ public class AgentConfiguration implements Serializable {
         }
         List<String> cmdLine = new ArrayList<>(agentMode.getAgentCommandLine());
         appendOptionToValues("caller-filter-file=", callerFilterFiles, cmdLine);
+        // The default filter precedes user filters so user rules have final precedence.
+        // §FS-common-libraries.3.1.1
         cmdLine.add("access-filter-file=" + getDefaultAccessFilter());
         appendOptionToValues("access-filter-file=", accessFilterFiles, cmdLine);
         addToCmd("builtin-caller-filter=", builtinCallerFilter, cmdLine);

--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -62,7 +62,7 @@ public class AgentConfiguration implements Serializable {
     private final Boolean experimentalPredefinedClasses;
     private final Boolean experimentalUnsafeAllocationTracing;
     private final Boolean trackReflectionMetadata;
-    private final Path agentConfigDir;
+    private final String agentConfigDir;
 
     private final AgentMode agentMode;
 
@@ -71,7 +71,7 @@ public class AgentConfiguration implements Serializable {
         this(null, new DisabledAgentMode());
     }
 
-    public AgentConfiguration(Path agentConfigDir, AgentMode agentMode) {
+    public AgentConfiguration(String agentConfigDir, AgentMode agentMode) {
         this.callerFilterFiles = null;
         this.accessFilterFiles = null;
         this.builtinCallerFilter = null;
@@ -91,7 +91,7 @@ public class AgentConfiguration implements Serializable {
                               Boolean experimentalUnsafeAllocationTracing,
                               Boolean trackReflectionMetadata,
                               AgentMode agentMode,
-                              Path agentConfigDir) {
+                              String agentConfigDir) {
         this.callerFilterFiles = callerFilterFiles;
         this.accessFilterFiles = accessFilterFiles;
         this.builtinCallerFilter = builtinCallerFilter;
@@ -148,7 +148,8 @@ public class AgentConfiguration implements Serializable {
     }
 
     private String getDefaultAccessFilter() {
-        Path accessFilterFile = agentConfigDir.resolve(ACCESS_FILTER_PREFIX + ACCESS_FILTER_SUFFIX);
+        Path agentConfigDirPath = Path.of(agentConfigDir);
+        Path accessFilterFile = agentConfigDirPath.resolve(ACCESS_FILTER_PREFIX + ACCESS_FILTER_SUFFIX);
         if (Files.exists(accessFilterFile)) {
             return accessFilterFile.toString();
         }
@@ -157,7 +158,7 @@ public class AgentConfiguration implements Serializable {
             if (accessFilterData == null) {
                 throw new IOException("Cannot access data from: " + DEFAULT_ACCESS_FILTER_FILE_LOCATION);
             }
-            Files.createDirectories(agentConfigDir);
+            Files.createDirectories(agentConfigDirPath);
             Files.copy(accessFilterData, accessFilterFile);
             return accessFilterFile.toString();
         } catch (IOException e) {

--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -67,11 +67,16 @@ public class AgentConfiguration implements Serializable {
     private final Boolean experimentalPredefinedClasses;
     private final Boolean experimentalUnsafeAllocationTracing;
     private final Boolean trackReflectionMetadata;
+    private final Path agentConfigDir;
 
     private final AgentMode agentMode;
 
     // This constructor should be used only to specify that we have instance of agent that is disabled (to avoid using null for agent enable check)
-    public AgentConfiguration(AgentMode... modes) {
+    public AgentConfiguration() {
+        this(null, new DisabledAgentMode());
+    }
+
+    public AgentConfiguration(Path agentConfigDir, AgentMode agentMode) {
         this.callerFilterFiles = null;
         this.accessFilterFiles = null;
         this.builtinCallerFilter = null;
@@ -79,7 +84,8 @@ public class AgentConfiguration implements Serializable {
         this.experimentalPredefinedClasses = null;
         this.experimentalUnsafeAllocationTracing = null;
         this.trackReflectionMetadata = null;
-        this.agentMode = modes.length == 1 ? modes[0] : new DisabledAgentMode();
+        this.agentConfigDir = agentConfigDir;
+        this.agentMode = agentMode;
     }
 
     public AgentConfiguration(Collection<String> callerFilterFiles,
@@ -89,7 +95,8 @@ public class AgentConfiguration implements Serializable {
                               Boolean experimentalPredefinedClasses,
                               Boolean experimentalUnsafeAllocationTracing,
                               Boolean trackReflectionMetadata,
-                              AgentMode agentMode) {
+                              AgentMode agentMode,
+                              Path agentConfigDir) {
         this.callerFilterFiles = callerFilterFiles;
         this.accessFilterFiles = accessFilterFiles;
         this.builtinCallerFilter = builtinCallerFilter;
@@ -98,6 +105,7 @@ public class AgentConfiguration implements Serializable {
         this.experimentalUnsafeAllocationTracing = experimentalUnsafeAllocationTracing;
         this.trackReflectionMetadata = trackReflectionMetadata;
         this.agentMode = agentMode;
+        this.agentConfigDir = agentConfigDir;
     }
 
     public List<String> getAgentCommandLine() {
@@ -145,9 +153,7 @@ public class AgentConfiguration implements Serializable {
     }
 
     private String getDefaultAccessFilter() {
-        String tempDir = System.getProperty("java.io.tmpdir");
-        Path agentDir = Path.of(tempDir).resolve("agent-config");
-        Path accessFilterFile = agentDir.resolve(ACCESS_FILTER_PREFIX + ACCESS_FILTER_SUFFIX);
+        Path accessFilterFile = agentConfigDir.resolve(ACCESS_FILTER_PREFIX + ACCESS_FILTER_SUFFIX);
         if (Files.exists(accessFilterFile)) {
             return accessFilterFile.toString();
         }
@@ -158,12 +164,12 @@ public class AgentConfiguration implements Serializable {
             }
 
             try {
-                Files.createDirectory(agentDir);
+                Files.createDirectories(agentConfigDir);
             } catch (FileAlreadyExistsException e) {
-                logger.info("Skip creation of directory " + agentDir + " (already created).");
+                logger.info("Skip creation of directory " + agentConfigDir + " (already created).");
             }
 
-            Path tmpAccessFilter = Files.createTempFile(agentDir, ACCESS_FILTER_PREFIX, ACCESS_FILTER_SUFFIX);
+            Path tmpAccessFilter = Files.createTempFile(agentConfigDir, ACCESS_FILTER_PREFIX, ACCESS_FILTER_SUFFIX);
             Files.copy(accessFilterData, tmpAccessFilter, StandardCopyOption.REPLACE_EXISTING);
 
             try {

--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -45,6 +45,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -62,7 +63,7 @@ public class AgentConfiguration implements Serializable {
     private final Boolean experimentalPredefinedClasses;
     private final Boolean experimentalUnsafeAllocationTracing;
     private final Boolean trackReflectionMetadata;
-    private final String agentConfigDir;
+    private final String defaultAccessFilterFile;
 
     private final AgentMode agentMode;
 
@@ -71,7 +72,7 @@ public class AgentConfiguration implements Serializable {
         this(null, new DisabledAgentMode());
     }
 
-    public AgentConfiguration(String agentConfigDir, AgentMode agentMode) {
+    public AgentConfiguration(String defaultAccessFilterFile, AgentMode agentMode) {
         this.callerFilterFiles = null;
         this.accessFilterFiles = null;
         this.builtinCallerFilter = null;
@@ -79,7 +80,7 @@ public class AgentConfiguration implements Serializable {
         this.experimentalPredefinedClasses = null;
         this.experimentalUnsafeAllocationTracing = null;
         this.trackReflectionMetadata = null;
-        this.agentConfigDir = agentConfigDir;
+        this.defaultAccessFilterFile = defaultAccessFilterFile;
         this.agentMode = agentMode;
     }
 
@@ -91,7 +92,7 @@ public class AgentConfiguration implements Serializable {
                               Boolean experimentalUnsafeAllocationTracing,
                               Boolean trackReflectionMetadata,
                               AgentMode agentMode,
-                              String agentConfigDir) {
+                              String defaultAccessFilterFile) {
         this.callerFilterFiles = callerFilterFiles;
         this.accessFilterFiles = accessFilterFiles;
         this.builtinCallerFilter = builtinCallerFilter;
@@ -100,18 +101,19 @@ public class AgentConfiguration implements Serializable {
         this.experimentalUnsafeAllocationTracing = experimentalUnsafeAllocationTracing;
         this.trackReflectionMetadata = trackReflectionMetadata;
         this.agentMode = agentMode;
-        this.agentConfigDir = agentConfigDir;
+        this.defaultAccessFilterFile = defaultAccessFilterFile;
     }
 
     public List<String> getAgentCommandLine() {
         if (!isEnabled()) {
             return List.of();
         }
-        List<String> cmdLine = new ArrayList<>(agentMode.getAgentCommandLine());
-        appendOptionToValues("caller-filter-file=", callerFilterFiles, cmdLine);
+        List<String> cmdLine = new ArrayList<>();
         // The default filter precedes user filters so user rules have final precedence.
         // §FS-common-libraries.3.1.1
-        cmdLine.add("access-filter-file=" + getDefaultAccessFilter());
+        cmdLine.add("access-filter-file=" + defaultAccessFilterFile);
+        cmdLine.addAll(agentMode.getAgentCommandLine());
+        appendOptionToValues("caller-filter-file=", callerFilterFiles, cmdLine);
         appendOptionToValues("access-filter-file=", accessFilterFiles, cmdLine);
         addToCmd("builtin-caller-filter=", builtinCallerFilter, cmdLine);
         addToCmd("builtin-heuristic-filter=", builtinHeuristicFilter, cmdLine);
@@ -122,7 +124,8 @@ public class AgentConfiguration implements Serializable {
     }
 
     public Collection<String> getAgentFiles() {
-        List<String> files = new ArrayList<>(callerFilterFiles.size() + accessFilterFiles.size());
+        List<String> files = new ArrayList<>(callerFilterFiles.size() + accessFilterFiles.size() + 1);
+        files.add(defaultAccessFilterFile);
         files.addAll(callerFilterFiles);
         files.addAll(accessFilterFiles);
         files.addAll(agentMode.getInputFiles());
@@ -149,20 +152,17 @@ public class AgentConfiguration implements Serializable {
         }
     }
 
-    private String getDefaultAccessFilter() {
-        Path agentConfigDirPath = Path.of(agentConfigDir);
-        Path accessFilterFile = agentConfigDirPath.resolve(ACCESS_FILTER_PREFIX + ACCESS_FILTER_SUFFIX);
-        if (Files.exists(accessFilterFile)) {
-            return accessFilterFile.toString();
-        }
+    public static Path getDefaultAccessFilterPath(Path agentConfigDir) {
+        return agentConfigDir.resolve(ACCESS_FILTER_PREFIX + ACCESS_FILTER_SUFFIX);
+    }
 
+    public static void writeDefaultAccessFilter(Path accessFilterFile) {
         try (InputStream accessFilterData = AgentConfiguration.class.getResourceAsStream(DEFAULT_ACCESS_FILTER_FILE_LOCATION)) {
             if (accessFilterData == null) {
                 throw new IOException("Cannot access data from: " + DEFAULT_ACCESS_FILTER_FILE_LOCATION);
             }
-            Files.createDirectories(agentConfigDirPath);
-            Files.copy(accessFilterData, accessFilterFile);
-            return accessFilterFile.toString();
+            Files.createDirectories(accessFilterFile.getParent());
+            Files.copy(accessFilterData, accessFilterFile, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             throw new RuntimeException("Cannot add default access-filter.json", e);
         }

--- a/common/utils/src/test/java/org/graalvm/buildtools/agent/AgentConfigurationTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/agent/AgentConfigurationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.agent;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentConfigurationTest {
+
+    @Test
+    void disabledConfigurationReturnsEmptyCommandLine() {
+        AgentConfiguration disabled = new AgentConfiguration();
+
+        List<String> cmdLine = disabled.getAgentCommandLine();
+
+        assertTrue(cmdLine.isEmpty(), "Disabled agent configuration should not emit any options, but was: " + cmdLine);
+    }
+}

--- a/common/utils/src/test/java/org/graalvm/buildtools/agent/AgentConfigurationTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/agent/AgentConfigurationTest.java
@@ -41,12 +41,21 @@
 package org.graalvm.buildtools.agent;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AgentConfigurationTest {
+
+    private static final String ACCESS_FILTER_OPTION = "access-filter-file=";
+
+    @TempDir
+    Path agentConfigDir;
 
     @Test
     void disabledConfigurationReturnsEmptyCommandLine() {
@@ -55,5 +64,34 @@ class AgentConfigurationTest {
         List<String> cmdLine = disabled.getAgentCommandLine();
 
         assertTrue(cmdLine.isEmpty(), "Disabled agent configuration should not emit any options, but was: " + cmdLine);
+    }
+
+    @Test
+    void standardConfigurationEmitsDefaultAccessFilterBeforeUserAccessFilters() {
+        List<String> userAccessFilters = List.of("user-1.json", "user-2.json");
+        AgentConfiguration configuration = new AgentConfiguration(
+                List.of(),
+                new ArrayList<>(userAccessFilters),
+                null,
+                null,
+                null,
+                null,
+                null,
+                new StandardAgentMode(),
+                agentConfigDir);
+
+        List<String> cmdLine = configuration.getAgentCommandLine();
+
+        List<String> accessFilterOptions = cmdLine.stream()
+                .filter(option -> option.startsWith(ACCESS_FILTER_OPTION))
+                .toList();
+
+        assertEquals(userAccessFilters.size() + 1, accessFilterOptions.size(),
+                "Expected one default access filter plus user access filters, but got: " + accessFilterOptions);
+
+        for (int i = 0; i < userAccessFilters.size(); i++) {
+            assertEquals(ACCESS_FILTER_OPTION + userAccessFilters.get(i), accessFilterOptions.get(i + 1),
+                    "User access filters must follow the default in their original order");
+        }
     }
 }

--- a/common/utils/src/test/java/org/graalvm/buildtools/agent/AgentConfigurationTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/agent/AgentConfigurationTest.java
@@ -45,12 +45,14 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AgentConfigurationTest {
@@ -74,6 +76,7 @@ class AgentConfigurationTest {
     @Test
     void standardConfigurationEmitsDefaultAccessFilterBeforeUserAccessFilters() {
         List<String> userAccessFilters = List.of("user-1.json", "user-2.json");
+        Path defaultAccessFilter = AgentConfiguration.getDefaultAccessFilterPath(agentConfigDir);
         AgentConfiguration configuration = new AgentConfiguration(
                 List.of(),
                 new ArrayList<>(userAccessFilters),
@@ -83,7 +86,7 @@ class AgentConfigurationTest {
                 null,
                 null,
                 new StandardAgentMode(),
-                agentConfigDir.toString());
+                defaultAccessFilter.toString());
 
         List<String> cmdLine = configuration.getAgentCommandLine();
 
@@ -93,6 +96,8 @@ class AgentConfigurationTest {
 
         assertEquals(userAccessFilters.size() + 1, accessFilterOptions.size(),
                 "Expected one default access filter plus user access filters, but got: " + accessFilterOptions);
+        assertEquals(ACCESS_FILTER_OPTION + defaultAccessFilter, accessFilterOptions.get(0));
+        assertFalse(Files.exists(defaultAccessFilter), "Constructing the command line must not create the default filter");
 
         for (int i = 0; i < userAccessFilters.size(); i++) {
             assertEquals(ACCESS_FILTER_OPTION + userAccessFilters.get(i), accessFilterOptions.get(i + 1),
@@ -100,8 +105,35 @@ class AgentConfigurationTest {
         }
     }
 
+    // Raw direct-mode options must follow the built-in default without being reordered. §FS-common-libraries.3.1.1
+    @Test
+    void directConfigurationEmitsDefaultAccessFilterBeforeModeOptions() {
+        List<String> directOptions = List.of(
+                "config-output-dir=metadata",
+                "access-filter-file=direct-1.json",
+                "access-filter-file=direct-2.json");
+        Path defaultAccessFilter = AgentConfiguration.getDefaultAccessFilterPath(agentConfigDir);
+        AgentConfiguration configuration = new AgentConfiguration(
+                List.of(),
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                new DirectAgentMode(directOptions),
+                defaultAccessFilter.toString());
+
+        List<String> cmdLine = configuration.getAgentCommandLine();
+
+        assertEquals(ACCESS_FILTER_OPTION + defaultAccessFilter, cmdLine.get(0));
+        assertEquals(directOptions, cmdLine.subList(1, directOptions.size() + 1));
+        assertFalse(Files.exists(defaultAccessFilter), "Constructing the command line must not create the default filter");
+    }
+
     @Test
     void configurationIsSerializable() {
+        Path defaultAccessFilter = AgentConfiguration.getDefaultAccessFilterPath(agentConfigDir);
         AgentConfiguration configuration = new AgentConfiguration(
                 List.of(),
                 new ArrayList<>(List.of("user-1.json")),
@@ -111,7 +143,7 @@ class AgentConfigurationTest {
                 null,
                 null,
                 new StandardAgentMode(),
-                agentConfigDir.toString());
+                defaultAccessFilter.toString());
 
         assertDoesNotThrow(() -> {
             try (ObjectOutputStream out = new ObjectOutputStream(new ByteArrayOutputStream())) {

--- a/common/utils/src/test/java/org/graalvm/buildtools/agent/AgentConfigurationTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/agent/AgentConfigurationTest.java
@@ -60,6 +60,7 @@ class AgentConfigurationTest {
     @TempDir
     Path agentConfigDir;
 
+    // §FS-common-libraries.3.1.1
     @Test
     void disabledConfigurationReturnsEmptyCommandLine() {
         AgentConfiguration disabled = new AgentConfiguration();
@@ -69,6 +70,7 @@ class AgentConfigurationTest {
         assertTrue(cmdLine.isEmpty(), "Disabled agent configuration should not emit any options, but was: " + cmdLine);
     }
 
+    // §FS-common-libraries.3.1.1
     @Test
     void standardConfigurationEmitsDefaultAccessFilterBeforeUserAccessFilters() {
         List<String> userAccessFilters = List.of("user-1.json", "user-2.json");

--- a/common/utils/src/test/java/org/graalvm/buildtools/agent/AgentConfigurationTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/agent/AgentConfigurationTest.java
@@ -43,10 +43,13 @@ package org.graalvm.buildtools.agent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -78,7 +81,7 @@ class AgentConfigurationTest {
                 null,
                 null,
                 new StandardAgentMode(),
-                agentConfigDir);
+                agentConfigDir.toString());
 
         List<String> cmdLine = configuration.getAgentCommandLine();
 
@@ -93,5 +96,25 @@ class AgentConfigurationTest {
             assertEquals(ACCESS_FILTER_OPTION + userAccessFilters.get(i), accessFilterOptions.get(i + 1),
                     "User access filters must follow the default in their original order");
         }
+    }
+
+    @Test
+    void configurationIsSerializable() {
+        AgentConfiguration configuration = new AgentConfiguration(
+                List.of(),
+                new ArrayList<>(List.of("user-1.json")),
+                null,
+                null,
+                null,
+                null,
+                null,
+                new StandardAgentMode(),
+                agentConfigDir.toString());
+
+        assertDoesNotThrow(() -> {
+            try (ObjectOutputStream out = new ObjectOutputStream(new ByteArrayOutputStream())) {
+                out.writeObject(configuration);
+            }
+        }, "AgentConfiguration must be serializable to support the Gradle configuration cache");
     }
 }

--- a/native-gradle-plugin/docs/functional/tracing-agent.md
+++ b/native-gradle-plugin/docs/functional/tracing-agent.md
@@ -41,6 +41,13 @@ Gradle-managed agent output directory so users can find collected metadata witho
 aligning with [§root/GOAL-concise-actionable-output](../../../docs/spec/goals.md#goal-concise-actionable-output-build-output-is-concise-actionable-and-token-efficient). Generated output must be suitable for later
 merge and copy steps.
 
+### 4.1 Default access filter
+
+When the agent is enabled, Gradle must generate the built-in default access filter as a declared
+task output under `build/native/agent-config` before an instrumented task runs. Configuration and
+command-line argument calculation must remain side-effect-free so generating the filter does not
+invalidate the configuration cache.
+
 ## 5. Metadata copy
 
 `metadataCopy` copies or merges agent output from configured input tasks into configured output

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -427,6 +427,7 @@ org.gradle.java.installations.auto-download=false
         junitVersion = System.getProperty('versions.junit')
     }
 
+    // The default filter is generated as task output without invalidating the configuration cache. §FS-tracing-agent.4.1
     @Unroll("plugin supports configuration cache (JUnit Platform #junitVersion)")
     def "supports configuration cache"() {
         given:
@@ -437,12 +438,14 @@ org.gradle.java.installations.auto-download=false
 
         then:
         tasks {
-            succeeded ':run'
+            succeeded ':generateAgentAccessFilter',
+                    ':run'
             doesNotContain ':jar'
         }
 
         and:
         assert metadataExistsAt("build/native/agent-output/run")
+        file("build/native/agent-config/access-filter.json").exists()
 
         when:
         run'run', '-Pagent', '--configuration-cache', '--rerun-tasks'

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -60,6 +60,7 @@ import org.graalvm.buildtools.gradle.internal.agent.AgentConfigurationFactory;
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask;
 import org.graalvm.buildtools.gradle.tasks.CollectReachabilityMetadata;
 import org.graalvm.buildtools.gradle.tasks.CreateLayerOptions;
+import org.graalvm.buildtools.gradle.tasks.GenerateAgentAccessFilter;
 import org.graalvm.buildtools.gradle.tasks.GenerateDynamicAccessMetadata;
 import org.graalvm.buildtools.gradle.tasks.GenerateResourcesConfigFile;
 import org.graalvm.buildtools.gradle.tasks.ListLibrariesMissingMetadata;
@@ -244,10 +245,18 @@ public class NativeImagePlugin implements Plugin<Project> {
             logger.log("Not instrumenting tasks with native-image-agent because the agent is disabled.");
             return;
         }
+        TaskProvider<GenerateAgentAccessFilter> defaultAccessFilter = project.getTasks().register(
+                "generateAgentAccessFilter",
+                GenerateAgentAccessFilter.class,
+                task -> {
+                    task.setDescription("Generates the native-image-agent built-in access filter.");
+                    task.getOutputFile().convention(project.getLayout().getBuildDirectory()
+                            .file("native/agent-config/access-filter.json"));
+                });
         Predicate<? super Task> taskPredicate = graalExtension.getAgent().getTasksToInstrumentPredicate().getOrElse(serializablePredicateOf(t -> true));
         project.getTasks().configureEach(t -> {
             if (isTaskInstrumentableByAgent(t) && taskPredicate.test(t)) {
-                configureAgent(project, agentMode, graalExtension, getExecOperations(), getFileOperations(), t, (JavaForkOptions) t);
+                configureAgent(project, agentMode, graalExtension, defaultAccessFilter, getExecOperations(), getFileOperations(), t, (JavaForkOptions) t);
             } else {
                 String reason;
                 if (isTaskInstrumentableByAgent(t)) {
@@ -1107,6 +1116,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     private void configureAgent(Project project,
                                 Provider<String> agentMode,
                                 GraalVMExtension graalExtension,
+                                TaskProvider<GenerateAgentAccessFilter> defaultAccessFilter,
                                 ExecOperations execOperations,
                                 FileSystemOperations fileOperations,
                                 Task taskToInstrument,
@@ -1114,7 +1124,7 @@ public class NativeImagePlugin implements Plugin<Project> {
         Provider<AgentConfiguration> agentConfiguration = AgentConfigurationFactory.getAgentConfiguration(
                 agentMode,
                 graalExtension.getAgent(),
-                project.getLayout().getBuildDirectory().dir("native/agent-config"));
+                defaultAccessFilter.flatMap(GenerateAgentAccessFilter::getOutputFile));
         Provider<Directory> outputDir = AgentConfigurationFactory.getAgentOutputDirectoryForTask(project.getLayout(), taskToInstrument.getName());
         Provider<JavaLauncher> javaLauncherForAgent = javaLauncherForAgent(project.getProviders());
         // Agent runs prefer an available GraalVM Java without replacing task configuration with a regular JAVA_HOME. §FS-tracing-agent.2.1
@@ -1160,6 +1170,8 @@ public class NativeImagePlugin implements Plugin<Project> {
         cliProvider.getOutputDirectory().set(outputDir);
         cliProvider.getAgentOptions().set(agentConfiguration.map(serializableTransformerOf(AgentConfiguration::getAgentCommandLine)));
         javaForkOptions.getJvmArgumentProviders().add(cliProvider);
+        // The generated filter is a declared output and is materialized only during task execution. §FS-tracing-agent.4.1
+        taskToInstrument.dependsOn(defaultAccessFilter);
 
         taskToInstrument.doLast(new MergeAgentFilesAction(
             isMergingEnabled,

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -1111,7 +1111,10 @@ public class NativeImagePlugin implements Plugin<Project> {
                                 FileSystemOperations fileOperations,
                                 Task taskToInstrument,
                                 JavaForkOptions javaForkOptions) {
-        Provider<AgentConfiguration> agentConfiguration = AgentConfigurationFactory.getAgentConfiguration(agentMode, graalExtension.getAgent());
+        Provider<AgentConfiguration> agentConfiguration = AgentConfigurationFactory.getAgentConfiguration(
+                agentMode,
+                graalExtension.getAgent(),
+                project.getLayout().getBuildDirectory().dir("native/agent-config"));
         Provider<Directory> outputDir = AgentConfigurationFactory.getAgentOutputDirectoryForTask(project.getLayout(), taskToInstrument.getName());
         Provider<JavaLauncher> javaLauncherForAgent = javaLauncherForAgent(project.getProviders());
         // Agent runs prefer an available GraalVM Java without replacing task configuration with a regular JAVA_HOME. §FS-tracing-agent.2.1

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/agent/AgentConfigurationFactory.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/agent/AgentConfigurationFactory.java
@@ -59,12 +59,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
-import static org.graalvm.buildtools.gradle.internal.ConfigurationCacheSupport.serializableTransformerOf;
+import static org.graalvm.buildtools.gradle.internal.ConfigurationCacheSupport.serializableBiFunctionOf;
 import static org.graalvm.buildtools.utils.SharedConstants.AGENT_OUTPUT_FOLDER;
 
 public class AgentConfigurationFactory {
-    public static Provider<AgentConfiguration> getAgentConfiguration(Provider<String> modeName, AgentOptions options) {
-        return modeName.map(serializableTransformerOf(name -> {
+    public static Provider<AgentConfiguration> getAgentConfiguration(Provider<String> modeName, AgentOptions options, Provider<Directory> agentConfigDir) {
+        return modeName.zip(agentConfigDir, serializableBiFunctionOf((name, configDir) -> {
             AgentMode agentMode;
             ConfigurableFileCollection callerFilterFiles = options.getCallerFilterFiles();
             ConfigurableFileCollection accessFilterFiles = options.getAccessFilterFiles();
@@ -95,7 +95,8 @@ public class AgentConfigurationFactory {
                     options.getEnableExperimentalPredefinedClasses().get(),
                     options.getEnableExperimentalUnsafeAllocationTracing().get(),
                     options.getTrackReflectionMetadata().get(),
-                    agentMode);
+                    agentMode,
+                    configDir.getAsFile().toPath());
         }));
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/agent/AgentConfigurationFactory.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/agent/AgentConfigurationFactory.java
@@ -96,7 +96,7 @@ public class AgentConfigurationFactory {
                     options.getEnableExperimentalUnsafeAllocationTracing().get(),
                     options.getTrackReflectionMetadata().get(),
                     agentMode,
-                    configDir.getAsFile().toPath());
+                    configDir.getAsFile().getAbsolutePath());
         }));
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/agent/AgentConfigurationFactory.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/agent/AgentConfigurationFactory.java
@@ -52,6 +52,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
 
 import java.io.File;
@@ -63,8 +64,10 @@ import static org.graalvm.buildtools.gradle.internal.ConfigurationCacheSupport.s
 import static org.graalvm.buildtools.utils.SharedConstants.AGENT_OUTPUT_FOLDER;
 
 public class AgentConfigurationFactory {
-    public static Provider<AgentConfiguration> getAgentConfiguration(Provider<String> modeName, AgentOptions options, Provider<Directory> agentConfigDir) {
-        return modeName.zip(agentConfigDir, serializableBiFunctionOf((name, configDir) -> {
+    public static Provider<AgentConfiguration> getAgentConfiguration(Provider<String> modeName,
+                                                                     AgentOptions options,
+                                                                     Provider<RegularFile> defaultAccessFilter) {
+        return modeName.zip(defaultAccessFilter, serializableBiFunctionOf((name, accessFilter) -> {
             AgentMode agentMode;
             ConfigurableFileCollection callerFilterFiles = options.getCallerFilterFiles();
             ConfigurableFileCollection accessFilterFiles = options.getAccessFilterFiles();
@@ -96,7 +99,7 @@ public class AgentConfigurationFactory {
                     options.getEnableExperimentalUnsafeAllocationTracing().get(),
                     options.getTrackReflectionMetadata().get(),
                     agentMode,
-                    configDir.getAsFile().getAbsolutePath());
+                    accessFilter.getAsFile().getAbsolutePath());
         }));
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/GenerateAgentAccessFilter.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/GenerateAgentAccessFilter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.tasks;
+
+import org.graalvm.buildtools.agent.AgentConfiguration;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * Generates the tracing agent's built-in access filter as a declared task output.
+ * §FS-tracing-agent.4.1
+ */
+@CacheableTask
+public abstract class GenerateAgentAccessFilter extends DefaultTask {
+
+    @OutputFile
+    public abstract RegularFileProperty getOutputFile();
+
+    @TaskAction
+    public void generate() {
+        AgentConfiguration.writeDefaultAccessFilter(getOutputFile().getAsFile().get().toPath());
+    }
+}

--- a/native-maven-plugin/docs/functional/tracing-agent.md
+++ b/native-maven-plugin/docs/functional/tracing-agent.md
@@ -36,7 +36,8 @@ without debug logging, aligning with
 Maven must materialize the built-in default access filter in a unique per-session directory under
 `java.io.tmpdir` before configuring instrumented executions. The filter must remain outside the
 project build directory so a later `clean` lifecycle phase cannot delete a path already injected
-into test or application JVM arguments.
+into test or application JVM arguments. Maven must create this directory only for enabled agent
+configurations and must remove the filter and its directory when the Maven session ends.
 
 ## 4. Merge and copy
 

--- a/native-maven-plugin/docs/functional/tracing-agent.md
+++ b/native-maven-plugin/docs/functional/tracing-agent.md
@@ -31,6 +31,13 @@ output must report the Maven-managed agent output directory so users can find co
 without debug logging, aligning with
 [§root/GOAL-concise-actionable-output](../../../docs/spec/goals.md#goal-concise-actionable-output-build-output-is-concise-actionable-and-token-efficient).
 
+### 3.1 Default access filter
+
+Maven must materialize the built-in default access filter in a unique per-session directory under
+`java.io.tmpdir` before configuring instrumented executions. The filter must remain outside the
+project build directory so a later `clean` lifecycle phase cannot delete a path already injected
+into test or application JVM arguments.
+
 ## 4. Merge and copy
 
 `native:merge-agent-files` must merge generated agent output through `native-image-configure`.

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
@@ -73,8 +73,8 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
 
         when:
         // Run Maven in debug mode (-X) in order to capture the command line arguments
-        // used to launch Surefire with the agent.
-        mvnDebug '-Pnative', '-DquickBuild', 'test', '-Dagent=true', '-DskipNativeTests'
+        // used to launch Surefire with the agent. Clean must not delete the eagerly generated filter. §FS-tracing-agent.3.1
+        mvnDebug '-Pnative', '-DquickBuild', 'clean', 'test', '-Dagent=true', '-DskipNativeTests'
 
         then:
         // Agent is used with Surefire

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
@@ -57,6 +57,7 @@ import org.graalvm.buildtools.utils.AgentUtils;
 import org.graalvm.buildtools.utils.SharedConstants;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -147,7 +148,7 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                 Xpp3Dom configurationRoot = (Xpp3Dom) nativePlugin.getConfiguration();
                 AgentConfiguration agent;
                 try {
-                    agent = AgentUtils.collectAgentProperties(session, configurationRoot);
+                    agent = AgentUtils.collectAgentProperties(session, configurationRoot, Path.of(target, "native", "agent-config"));
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
@@ -87,6 +87,8 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
 
     private static Logger logger;
 
+    private Path sessionAgentConfigDirectory;
+
     @Override
     public void enableLogging(Logger logger) {
         this.logger = logger;
@@ -141,7 +143,6 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
 
     @Override
     public void afterProjectsRead(MavenSession session) {
-        Path defaultAccessFilter = AgentConfiguration.getDefaultAccessFilterPath(createSessionAgentConfigDirectory());
         for (MavenProject project : session.getProjects()) {
             Build build = project.getBuild();
             withPlugin(build, "native-maven-plugin", nativePlugin -> {
@@ -151,11 +152,11 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                 Xpp3Dom configurationRoot = (Xpp3Dom) nativePlugin.getConfiguration();
                 AgentConfiguration agent;
                 try {
-                    agent = AgentUtils.collectAgentProperties(session, configurationRoot, defaultAccessFilter);
+                    agent = AgentUtils.collectAgentProperties(session, configurationRoot, this::defaultAccessFilter);
                     if (agent.isEnabled()) {
-                        // Keep the eagerly created filter outside target so a later clean cannot remove it.
+                        // Keep the generated filter outside target so a later clean cannot remove it.
                         // §FS-tracing-agent.3.1
-                        AgentConfiguration.writeDefaultAccessFilter(defaultAccessFilter);
+                        AgentConfiguration.writeDefaultAccessFilter(defaultAccessFilter());
                     }
                 } catch (Exception e) {
                     throw new RuntimeException(e);
@@ -228,6 +229,33 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
         } catch (IOException e) {
             throw new RuntimeException("Cannot create the native-image-agent session configuration directory", e);
         }
+    }
+
+    private Path defaultAccessFilter() {
+        if (sessionAgentConfigDirectory == null) {
+            sessionAgentConfigDirectory = createSessionAgentConfigDirectory();
+        }
+        return AgentConfiguration.getDefaultAccessFilterPath(sessionAgentConfigDirectory);
+    }
+
+    @Override
+    public void afterSessionEnd(MavenSession session) {
+        if (sessionAgentConfigDirectory == null) {
+            return;
+        }
+        try {
+            deleteSessionAgentConfigDirectory(sessionAgentConfigDirectory);
+        } catch (IOException e) {
+            logger.warn("Cannot delete native-image-agent session configuration directory " + sessionAgentConfigDirectory + ".", e);
+        } finally {
+            sessionAgentConfigDirectory = null;
+        }
+    }
+
+    // Deletes the filter before its parent directory so each enabled session leaves no temporary state. §FS-tracing-agent.3.1
+    static void deleteSessionAgentConfigDirectory(Path agentConfigDirectory) throws IOException {
+        Files.deleteIfExists(AgentConfiguration.getDefaultAccessFilterPath(agentConfigDirectory));
+        Files.deleteIfExists(agentConfigDirectory);
     }
 
     static String mainAgentExecutionId(Xpp3Dom configurationRoot) {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
@@ -57,6 +57,8 @@ import org.graalvm.buildtools.utils.AgentUtils;
 import org.graalvm.buildtools.utils.SharedConstants;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -139,6 +141,7 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
 
     @Override
     public void afterProjectsRead(MavenSession session) {
+        Path defaultAccessFilter = AgentConfiguration.getDefaultAccessFilterPath(createSessionAgentConfigDirectory());
         for (MavenProject project : session.getProjects()) {
             Build build = project.getBuild();
             withPlugin(build, "native-maven-plugin", nativePlugin -> {
@@ -148,7 +151,12 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                 Xpp3Dom configurationRoot = (Xpp3Dom) nativePlugin.getConfiguration();
                 AgentConfiguration agent;
                 try {
-                    agent = AgentUtils.collectAgentProperties(session, configurationRoot, Path.of(target, "native", "agent-config"));
+                    agent = AgentUtils.collectAgentProperties(session, configurationRoot, defaultAccessFilter);
+                    if (agent.isEnabled()) {
+                        // Keep the eagerly created filter outside target so a later clean cannot remove it.
+                        // §FS-tracing-agent.3.1
+                        AgentConfiguration.writeDefaultAccessFilter(defaultAccessFilter);
+                    }
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -211,6 +219,14 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                     instrumentedContexts.forEach(context -> logAgentOutput(target, context));
                 }
             });
+        }
+    }
+
+    static Path createSessionAgentConfigDirectory() {
+        try {
+            return Files.createTempDirectory("native-build-tools-agent-config-");
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot create the native-image-agent session configuration directory", e);
         }
     }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/AgentUtils.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/AgentUtils.java
@@ -51,6 +51,7 @@ import org.graalvm.buildtools.agent.ConditionalAgentMode;
 import org.graalvm.buildtools.agent.AgentConfiguration;
 
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -117,13 +118,13 @@ public abstract class AgentUtils {
         return agentMode;
     }
 
-    public static AgentConfiguration collectAgentProperties(MavenSession session, Xpp3Dom rootNode) throws RuntimeException {
+    public static AgentConfiguration collectAgentProperties(MavenSession session, Xpp3Dom rootNode, Path agentConfigDir) throws RuntimeException {
         Xpp3Dom agent = Xpp3DomParser.getTagByName(rootNode, "agent");
         if (agent == null) {
             Boolean agentEnabledInCmd = isAgentEnabledInCmd(session);
             if (agentEnabledInCmd != null && agentEnabledInCmd) {
                 // if agent is only enabled from command line but there is no configuration in pom.xml, we use default options
-                return new AgentConfiguration(new StandardAgentMode());
+                return new AgentConfiguration(agentConfigDir, new StandardAgentMode());
             } else {
                 return new AgentConfiguration();
             }
@@ -153,7 +154,7 @@ public abstract class AgentUtils {
 
         return new AgentConfiguration(callerFilterFiles, accessFilterFiles, builtinCallerFilter,
                 builtinHeuristicFilter, enableExperimentalPredefinedClasses, enableExperimentalUnsafeAllocationTracing,
-                trackReflectionMetadata, mode);
+                trackReflectionMetadata, mode, agentConfigDir);
     }
 
     public static List<String> getDisabledStages(Xpp3Dom rootNode) {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/AgentUtils.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/AgentUtils.java
@@ -124,7 +124,7 @@ public abstract class AgentUtils {
             Boolean agentEnabledInCmd = isAgentEnabledInCmd(session);
             if (agentEnabledInCmd != null && agentEnabledInCmd) {
                 // if agent is only enabled from command line but there is no configuration in pom.xml, we use default options
-                return new AgentConfiguration(agentConfigDir, new StandardAgentMode());
+                return new AgentConfiguration(agentConfigDir.toString(), new StandardAgentMode());
             } else {
                 return new AgentConfiguration();
             }
@@ -154,7 +154,7 @@ public abstract class AgentUtils {
 
         return new AgentConfiguration(callerFilterFiles, accessFilterFiles, builtinCallerFilter,
                 builtinHeuristicFilter, enableExperimentalPredefinedClasses, enableExperimentalUnsafeAllocationTracing,
-                trackReflectionMetadata, mode, agentConfigDir);
+                trackReflectionMetadata, mode, agentConfigDir.toString());
     }
 
     public static List<String> getDisabledStages(Xpp3Dom rootNode) {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/AgentUtils.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/AgentUtils.java
@@ -55,6 +55,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.graalvm.buildtools.utils.Utils.parseBoolean;
@@ -118,13 +119,13 @@ public abstract class AgentUtils {
         return agentMode;
     }
 
-    public static AgentConfiguration collectAgentProperties(MavenSession session, Xpp3Dom rootNode, Path defaultAccessFilter) throws RuntimeException {
+    public static AgentConfiguration collectAgentProperties(MavenSession session, Xpp3Dom rootNode, Supplier<Path> defaultAccessFilter) throws RuntimeException {
         Xpp3Dom agent = Xpp3DomParser.getTagByName(rootNode, "agent");
         if (agent == null) {
             Boolean agentEnabledInCmd = isAgentEnabledInCmd(session);
             if (agentEnabledInCmd != null && agentEnabledInCmd) {
                 // if agent is only enabled from command line but there is no configuration in pom.xml, we use default options
-                return new AgentConfiguration(defaultAccessFilter.toString(), new StandardAgentMode());
+                return new AgentConfiguration(defaultAccessFilter.get().toString(), new StandardAgentMode());
             } else {
                 return new AgentConfiguration();
             }
@@ -152,9 +153,13 @@ public abstract class AgentUtils {
             throw new RuntimeException("Agent mode configuration error. Reason: " + e.getMessage());
         }
 
+        if (mode instanceof DisabledAgentMode) {
+            return new AgentConfiguration();
+        }
+
         return new AgentConfiguration(callerFilterFiles, accessFilterFiles, builtinCallerFilter,
                 builtinHeuristicFilter, enableExperimentalPredefinedClasses, enableExperimentalUnsafeAllocationTracing,
-                trackReflectionMetadata, mode, defaultAccessFilter.toString());
+                trackReflectionMetadata, mode, defaultAccessFilter.get().toString());
     }
 
     public static List<String> getDisabledStages(Xpp3Dom rootNode) {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/AgentUtils.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/utils/AgentUtils.java
@@ -118,13 +118,13 @@ public abstract class AgentUtils {
         return agentMode;
     }
 
-    public static AgentConfiguration collectAgentProperties(MavenSession session, Xpp3Dom rootNode, Path agentConfigDir) throws RuntimeException {
+    public static AgentConfiguration collectAgentProperties(MavenSession session, Xpp3Dom rootNode, Path defaultAccessFilter) throws RuntimeException {
         Xpp3Dom agent = Xpp3DomParser.getTagByName(rootNode, "agent");
         if (agent == null) {
             Boolean agentEnabledInCmd = isAgentEnabledInCmd(session);
             if (agentEnabledInCmd != null && agentEnabledInCmd) {
                 // if agent is only enabled from command line but there is no configuration in pom.xml, we use default options
-                return new AgentConfiguration(agentConfigDir.toString(), new StandardAgentMode());
+                return new AgentConfiguration(defaultAccessFilter.toString(), new StandardAgentMode());
             } else {
                 return new AgentConfiguration();
             }
@@ -154,7 +154,7 @@ public abstract class AgentUtils {
 
         return new AgentConfiguration(callerFilterFiles, accessFilterFiles, builtinCallerFilter,
                 builtinHeuristicFilter, enableExperimentalPredefinedClasses, enableExperimentalUnsafeAllocationTracing,
-                trackReflectionMetadata, mode, agentConfigDir.toString());
+                trackReflectionMetadata, mode, defaultAccessFilter.toString());
     }
 
     public static List<String> getDisabledStages(Xpp3Dom rootNode) {

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
@@ -50,6 +50,9 @@ import org.codehaus.plexus.util.cli.CommandLineUtils
 import org.codehaus.plexus.util.xml.Xpp3Dom
 import spock.lang.Specification
 
+import java.nio.file.Files
+import java.nio.file.Path
+
 class NativeExtensionTest extends Specification {
     private static final String JUNIT_TRACKING_ENABLED = "junit.platform.listeners.uid.tracking.enabled"
     private static final String JUNIT_TRACKING_OUTPUT_DIR = "junit.platform.listeners.uid.tracking.output.dir"
@@ -113,6 +116,22 @@ class NativeExtensionTest extends Specification {
 
         expect:
         NativeExtension.quoteAgentArgumentForArgLine(agentArgument) == agentArgument
+    }
+
+    // Each Maven session uses a unique filter directory outside project build output. §FS-tracing-agent.3.1
+    void "creates unique agent configuration directories under the system temporary directory"() {
+        given:
+        Path first = NativeExtension.createSessionAgentConfigDirectory()
+        Path second = NativeExtension.createSessionAgentConfigDirectory()
+
+        expect:
+        first.parent == Path.of(System.getProperty("java.io.tmpdir")).toAbsolutePath()
+        second.parent == first.parent
+        first != second
+
+        cleanup:
+        Files.deleteIfExists(first)
+        Files.deleteIfExists(second)
     }
 
     private static Plugin plugin(String artifactId) {

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
@@ -48,6 +48,7 @@ import org.apache.maven.model.PluginExecution
 import org.apache.maven.project.MavenProject
 import org.codehaus.plexus.util.cli.CommandLineUtils
 import org.codehaus.plexus.util.xml.Xpp3Dom
+import org.graalvm.buildtools.agent.AgentConfiguration
 import spock.lang.Specification
 
 import java.nio.file.Files
@@ -118,7 +119,7 @@ class NativeExtensionTest extends Specification {
         NativeExtension.quoteAgentArgumentForArgLine(agentArgument) == agentArgument
     }
 
-    // Each Maven session uses a unique filter directory outside project build output. §FS-tracing-agent.3.1
+    // Enabled Maven sessions use a temporary filter directory and remove it at session end. §FS-tracing-agent.3.1
     void "creates unique agent configuration directories under the system temporary directory"() {
         given:
         Path first = NativeExtension.createSessionAgentConfigDirectory()
@@ -128,10 +129,14 @@ class NativeExtensionTest extends Specification {
         first.parent == Path.of(System.getProperty("java.io.tmpdir")).toAbsolutePath()
         second.parent == first.parent
         first != second
+        !Files.exists(AgentConfiguration.getDefaultAccessFilterPath(first))
 
         cleanup:
-        Files.deleteIfExists(first)
-        Files.deleteIfExists(second)
+        AgentConfiguration.writeDefaultAccessFilter(AgentConfiguration.getDefaultAccessFilterPath(first))
+        NativeExtension.deleteSessionAgentConfigDirectory(first)
+        assert !Files.exists(first)
+
+        NativeExtension.deleteSessionAgentConfigDirectory(second)
     }
 
     private static Plugin plugin(String artifactId) {


### PR DESCRIPTION
This fixes #874 by adding the default access-filter.json file as the first argument to the agent.

Please let me know if I messed up anything or should add anything else.

`./gradlew test` ran successfully

`./gradlew :native-maven-plugin:inspections` only showed me pre-existing issues
