### PR TITLE
Add plugin descriptions

### DIFF
--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/OfficialMetadataRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/OfficialMetadataRepoFunctionalTest.groovy
@@ -59,10 +59,12 @@ class OfficialMetadataRepoFunctionalTest extends AbstractFunctionalTest {
             succeeded ':jar', ':nativeCompile', ':nativeRun'
         }
 
+        and: "the run succeeded and retrieved data from the database"
+        outputContains "Customers in the database"
+
         and: "finds metadata in the remote repository"
         outputContains "[graalvm reachability metadata repository for com.h2database:h2:"
         outputContains "Configuration directory is com.h2database" + File.separator + "h2" + File.separator
-        outputDoesNotContain "Falling back to the default repository at"
     }
 
     def "the application doesn't run when usage of the official metadata repository is disabled"() {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -290,6 +290,8 @@ public class NativeImagePlugin implements Plugin<Project> {
 
         TaskProvider<BuildNativeImageTask> imageBuilder = tasks.named(NATIVE_COMPILE_TASK_NAME, BuildNativeImageTask.class);
         tasks.register(DEPRECATED_NATIVE_BUILD_TASK, t -> {
+            t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+            t.setDescription("Deprecated alias for nativeCompile.");
             t.dependsOn(imageBuilder);
             t.doFirst("Warn about deprecation", task -> task.getLogger().warn("Task " + DEPRECATED_NATIVE_BUILD_TASK + " is deprecated. Use " + NATIVE_COMPILE_TASK_NAME + " instead."));
         });
@@ -301,7 +303,7 @@ public class NativeImagePlugin implements Plugin<Project> {
 
         project.getTasks().register("metadataCopy", MetadataCopyTask.class, task -> {
             task.setGroup(LifecycleBasePlugin.BUILD_GROUP);
-            task.setDescription("Copies metadata collected from tasks instrumented with the agent into target directories");
+            task.setDescription("Copies and optionally merges metadata collected by agent-instrumented tasks into target directories.");
             task.getInputTaskNames().set(graalExtension.getAgent().getMetadataCopy().getInputTaskNames());
             task.getOutputDirectories().set(graalExtension.getAgent().getMetadataCopy().getOutputDirectories());
             task.getMergeWithExisting().set(graalExtension.getAgent().getMetadataCopy().getMergeWithExisting());
@@ -310,7 +312,7 @@ public class NativeImagePlugin implements Plugin<Project> {
 
         project.getTasks().register("collectReachabilityMetadata", CollectReachabilityMetadata.class, task -> {
             task.setGroup(LifecycleBasePlugin.BUILD_GROUP);
-            task.setDescription("Obtains native reachability metadata for the runtime classpath configuration");
+            task.setDescription("Collects reachability metadata for the runtime classpath.");
             task.setClasspath(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
         });
 
@@ -371,7 +373,7 @@ public class NativeImagePlugin implements Plugin<Project> {
             }
             TaskProvider<BuildNativeImageTask> imageBuilder = tasks.register(compileTaskName,
                 BuildNativeImageTask.class, builder -> {
-                    builder.setDescription("Compiles a native image for the " + options.getName() + " binary");
+                    builder.setDescription("Builds a native executable for the " + options.getName() + " binary.");
                     builder.setGroup(LifecycleBasePlugin.BUILD_GROUP);
                     builder.getOptions().convention(options);
                     builder.getUseArgFile().convention(graalExtension.getUseArgFile());
@@ -401,7 +403,7 @@ public class NativeImagePlugin implements Plugin<Project> {
             }
             tasks.register(runTaskName, NativeRunTask.class, task -> {
                 task.setGroup(LifecycleBasePlugin.BUILD_GROUP);
-                task.setDescription("Executes the " + options.getName() + " native binary");
+                task.setDescription("Runs the " + options.getName() + " native binary.");
                 task.getImage().convention(imageBuilder.flatMap(BuildNativeImageTask::getOutputFile));
                 task.getRuntimeArgs().convention(options.getRuntimeArgs());
                 var useLayers = options.getLayers()
@@ -660,7 +662,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     private void configureClasspathJarFor(TaskContainer tasks, NativeImageOptions options, TaskProvider<BuildNativeImageTask> imageBuilder) {
         String baseName = imageBuilder.getName();
         TaskProvider<Jar> classpathJar = tasks.register(baseName + "ClasspathJar", Jar.class, jar -> {
-            jar.setDescription("Builds a pathing jar for the " + options.getName() + " native binary");
+            jar.setDescription("Builds a pathing JAR for the " + options.getName() + " native binary classpath.");
             jar.from(
                 options.getClasspath()
                     .getElements()
@@ -729,7 +731,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                                                                                   FileCollection transitiveProjectArtifacts,
                                                                                   String name) {
         return tasks.register(name, GenerateResourcesConfigFile.class, task -> {
-            task.setDescription("Generates a GraalVM resource-config.json file");
+            task.setDescription("Scans resources and generates a resource-config.json file for the " + options.getName() + " binary.");
             task.getOptions().convention(options.getResources());
             task.getClasspath().from(options.getClasspath());
             task.getTransitiveProjectArtifacts().from(transitiveProjectArtifacts);
@@ -860,6 +862,8 @@ public class NativeImagePlugin implements Plugin<Project> {
         });
         if (isPrimaryTest) {
             tasks.register(DEPRECATED_NATIVE_TEST_BUILD_TASK, t -> {
+                t.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
+                t.setDescription("Deprecated alias for nativeTestCompile.");
                 t.dependsOn(testImageBuilder);
                 t.doFirst("Warn about deprecation", task -> task.getLogger().warn("Task " + DEPRECATED_NATIVE_TEST_BUILD_TASK + " is deprecated. Use " + NATIVE_TEST_COMPILE_TASK_NAME + " instead."));
             });

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -3,6 +3,7 @@ package org.graalvm.buildtools.gradle
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension
 import org.graalvm.buildtools.gradle.dsl.GraalVMReachabilityMetadataRepositoryExtension
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Issue
 import spock.lang.Specification
@@ -47,6 +48,30 @@ class NativeImagePluginTest extends Specification {
         null                                 | '155'                 | 'https://github.com/oracle/graalvm-reachability-metadata/releases/download/155/graalvm-reachability-metadata-155.zip' | null
         null                                 | METADATA_REPO_VERSION | 'https://lookup.on.maven.central'                                                                                     | DEFAULT_GITHUB_RELEASES_METADATA_URI
         "https://custom.uri"                 | 'ignored'             | 'https://custom.uri'                                                                                                  | null
+    }
+
+    def "registers descriptions for user-facing tasks"() {
+        when:
+        project.plugins.apply("java")
+
+        then:
+        taskDescription("nativeCompile") == "Builds a native executable for the main binary."
+        taskDescription("nativeRun") == "Runs the main native binary."
+        taskDescription("nativeBuild") == "Deprecated alias for nativeCompile."
+        taskDescription("metadataCopy") == "Copies and optionally merges metadata collected by agent-instrumented tasks into target directories."
+        taskDescription("collectReachabilityMetadata") == "Collects reachability metadata for the runtime classpath."
+        taskDescription("nativeCompileClasspathJar") == "Builds a pathing JAR for the main native binary classpath."
+        taskDescription("generateResourcesConfigFile") == "Scans resources and generates a resource-config.json file for the main binary."
+        taskDescription("nativeTestCompile") == "Builds a native executable for the test binary."
+        taskDescription("nativeTest") == "Runs the test native binary."
+        taskDescription("nativeTestBuild") == "Deprecated alias for nativeTestCompile."
+        taskDescription("generateTestResourcesConfigFile") == "Scans resources and generates a resource-config.json file for the test binary."
+    }
+
+    private String taskDescription(String name) {
+        Task task = project.tasks.getByName(name)
+        assert task.description != null
+        task.description
     }
 
     private void repositoryUriFor(String configuredUri, String version) {

--- a/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-plugin.gradle.kts
+++ b/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-plugin.gradle.kts
@@ -59,6 +59,9 @@ val preparePluginDescriptor = tasks.register<Copy>("preparePluginDescriptor") {
     }) {
         rename { "pom.xml" }
     }
+    from(sourceSets.getByName("main").allJava) {
+        into("src/main/java")
+    }
     from(sourceSets.getByName("main").output.classesDirs) {
         into("target/classes")
     }

--- a/native-maven-plugin/build.gradle.kts
+++ b/native-maven-plugin/build.gradle.kts
@@ -40,7 +40,6 @@
  */
 
 import org.graalvm.build.maven.MavenTask
-import org.gradle.util.GFileUtils
 
 plugins {
     `java-library`
@@ -154,7 +153,13 @@ val prepareMavenLocalRepo = tasks.register<MavenTask>("prepareMavenLocalRepo") {
 }
 
 val launcher = javaToolchains.launcherFor {
-    languageVersion.set(JavaLanguageVersion.of(17))
+    languageVersion.set(
+        providers.gradleProperty("mavenFunctionalTestJavaVersion")
+            .orElse(providers.gradleProperty("javaToolchainVersion"))
+            .orElse("17")
+            .map(String::toInt)
+            .map(JavaLanguageVersion::of)
+    )
 }
 
 tasks {

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
@@ -143,4 +143,38 @@ class JavaApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
         outputContains "Args file written to: target" + File.separator + "native-image"
     }
 
+    def "help describe includes goal descriptions"() {
+        withSample("java-application")
+
+        when:
+        mvn 'help:describe', "-Dplugin=org.graalvm.buildtools:native-maven-plugin:${System.getProperty('native.maven.plugin.version')}"
+
+        then:
+        buildSucceeded
+        outputContains "org.graalvm.buildtools:native-maven-plugin:${System.getProperty('native.maven.plugin.version')}"
+        outputContains "native:add-reachability-metadata"
+        outputContains "metadata repository"
+        outputContains "project's output directory"
+        outputContains "native:compile"
+        outputContains "Builds a native executable by forking Maven"
+        outputContains "native:compile-no-fork"
+        outputContains "separate Maven build"
+        outputContains "native:generateDynamicAccessMetadata"
+        outputContains "dynamic access metadata"
+        outputContains "Build Report"
+        outputContains "native:generateResourceConfig"
+        outputContains "resource metadata"
+        outputContains "native:generateTestResourceConfig"
+        outputContains "native:list-libraries-missing-metadata"
+        outputContains "reachability metadata"
+        outputContains "native:merge-agent-files"
+        outputContains "Merges tracing agent output"
+        outputContains "native:metadata-copy"
+        outputContains "META-INF/native-image"
+        outputContains "native:test"
+        outputContains "native executables"
+        outputContains "native:write-args-file"
+        outputContains "args file"
+    }
+
 }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/OfficialMetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/OfficialMetadataRepositoryFunctionalTest.groovy
@@ -62,7 +62,6 @@ class OfficialMetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunct
         and: "finds metadata in the remote repository"
         outputContains "[graalvm reachability metadata repository for com.h2database:h2:"
         outputContains "Configuration directory is com.h2database" + File.separator + "h2" + File.separator
-        outputDoesNotContain "Falling back to the default repository."
     }
 
     @IgnoreIf({ os.windows })

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AddReachabilityMetadataMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AddReachabilityMetadataMojo.java
@@ -57,6 +57,9 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.graalvm.reachability.DirectoryConfiguration;
 
+/**
+ * Adds dependency reachability metadata from the configured metadata repository to the project's output directory.
+ */
 @Mojo(name = "add-reachability-metadata", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, requiresDependencyResolution = ResolutionScope.RUNTIME, requiresDependencyCollection = ResolutionScope.RUNTIME)
 public class AddReachabilityMetadataMojo extends AbstractNativeMojo {
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/DeprecatedNativeBuildMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/DeprecatedNativeBuildMojo.java
@@ -47,8 +47,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
- * Mojo used to invoke native image building by attaching it to a phase.
- * Deprecated in favor of compile-no-fork goal.
+ * Deprecated alias for the {@code native:compile-no-fork} goal for lifecycle-bound native image builds.
  */
 @Deprecated
 @Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE,

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/ListLibrariesMissingMetadataMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/ListLibrariesMissingMetadataMojo.java
@@ -58,6 +58,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Lists direct runtime dependencies that do not have reachability metadata in the configured metadata repository.
+ * Optionally creates reachability metadata repository issues requesting support for libraries with missing metadata.
+ */
 @Mojo(name = "list-libraries-missing-metadata", defaultPhase = LifecyclePhase.NONE,
     requiresDependencyResolution = ResolutionScope.RUNTIME, requiresDependencyCollection = ResolutionScope.RUNTIME)
 public class ListLibrariesMissingMetadataMojo extends AbstractNativeMojo {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MergeAgentFilesMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MergeAgentFilesMojo.java
@@ -59,6 +59,9 @@ import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Merges tracing agent output from one or more sessions into a single metadata directory.
+ */
 @Mojo(name = "merge-agent-files", defaultPhase = LifecyclePhase.TEST)
 public class MergeAgentFilesMojo extends AbstractMergeAgentFilesMojo {
     @Parameter(defaultValue = "${project}", readonly = true, required = true)

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
@@ -62,6 +62,9 @@ import java.util.ArrayList;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+/**
+ * Copies and optionally merges tracing agent metadata into {@code META-INF/native-image} for packaging.
+ */
 @Mojo(name = "metadata-copy", defaultPhase = LifecyclePhase.NONE)
 public class MetadataCopyMojo extends AbstractMergeAgentFilesMojo {
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildDynamicAccessMetadataMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildDynamicAccessMetadataMojo.java
@@ -69,8 +69,9 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Generates a {@code dynamic-access-metadata.json} file used by the dynamic access tab of the native image
- * Build Report. This json file contains the mapping of all classpath entries that exist in the
+ * Generates dynamic access metadata used by the native image Build Report.
+ *
+ * The generated {@code dynamic-access-metadata.json} file contains the mapping of all classpath entries that exist in the
  * {@value #LIBRARY_AND_FRAMEWORK_LIST} to their transitive dependencies.
  * <p>
  * If {@value #LIBRARY_AND_FRAMEWORK_LIST} doesn't exist in the used release of the

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildResourceConfigMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildResourceConfigMojo.java
@@ -45,6 +45,9 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
+/**
+ * Scans main resources and generates resource metadata for them.
+ */
 @Mojo(
         name = "generateResourceConfig",
         defaultPhase = LifecyclePhase.PACKAGE,

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildTestResourceConfigMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildTestResourceConfigMojo.java
@@ -50,6 +50,9 @@ import java.io.File;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+/**
+ * Scans test resources and generates resource metadata for them.
+ */
 @Mojo(
         name = "generateTestResourceConfig",
         defaultPhase = LifecyclePhase.PACKAGE,

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeCompileMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeCompileMojo.java
@@ -48,8 +48,9 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 
 /**
- * This goal builds native images.
- * It should be invoked from the command line as a single goal (`mvn native:compile`).
+ * Builds a native executable by forking Maven to the {@code package} phase before invoking {@code native-image}.
+ *
+ * It should be invoked from the command line as a single goal ({@code mvn native:compile}).
  */
 @Mojo(name = "compile", defaultPhase = LifecyclePhase.PACKAGE,
         requiresDependencyResolution = ResolutionScope.RUNTIME,

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeCompileNoForkMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeCompileNoForkMojo.java
@@ -62,8 +62,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 
 /**
- * This goal runs native builds. It functions the same as the native:compile goal, but it
- * does not fork the build, so it is suitable for attaching to the build lifecycle.
+ * Builds a native executable in the current Maven lifecycle without forking a separate Maven build.
  */
 @Mojo(name = "compile-no-fork", defaultPhase = LifecyclePhase.PACKAGE,
         requiresDependencyResolution = ResolutionScope.RUNTIME,

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -90,7 +90,7 @@ import java.util.stream.Stream;
 import static org.graalvm.buildtools.utils.NativeImageConfigurationUtils.NATIVE_TESTS_EXE;
 
 /**
- * This goal builds and runs native tests.
+ * Builds and runs the project's tests as native executables.
  *
  * @author Sebastien Deleuze
  */

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/WriteArgsFileMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/WriteArgsFileMojo.java
@@ -54,8 +54,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /**
- * Persists the arguments file to be used by the native-image command. This can be useful in situations where
- * Native Build Tools plugin is not available, for example, when running native-image in a Docker container.
+ * Writes the {@code native-image} arguments for this project to an args file that can be reused outside Maven.
  *
  * The path to the args file is stored in the project properties under the key {@code graalvm.native-image.args-file}.
  *

--- a/samples/metadata-repo-integration/pom.xml
+++ b/samples/metadata-repo-integration/pom.xml
@@ -110,6 +110,11 @@
                                 <phase>package</phase>
                             </execution>
                         </executions>
+                        <configuration>
+                            <buildArgs>
+                                <buildArg>--initialize-at-build-time=ch.qos.logback.classic.Logger</buildArg>
+                            </buildArgs>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -133,6 +138,9 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <buildArgs>
+                                <buildArg>--initialize-at-build-time=ch.qos.logback.classic.Logger</buildArg>
+                            </buildArgs>
                             <!-- tag::metadata-versioned[] -->
                             <metadataRepository>
                                 <enabled>true</enabled>
@@ -163,6 +171,9 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <buildArgs>
+                                <buildArg>--initialize-at-build-time=ch.qos.logback.classic.Logger</buildArg>
+                            </buildArgs>
                             <!-- tag::metadata-disable[] -->
                             <metadataRepository>
                                 <enabled>false</enabled>
@@ -192,6 +203,9 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <buildArgs>
+                                <buildArg>--initialize-at-build-time=ch.qos.logback.classic.Logger</buildArg>
+                            </buildArgs>
                             <metadataRepository>
                                 <version>1.0-M1</version>
                             </metadataRepository>

--- a/samples/native-config-integration/pom.xml
+++ b/samples/native-config-integration/pom.xml
@@ -95,6 +95,9 @@
                             <fallback>false</fallback>
                             <quickBuild>true</quickBuild>
                             <useArgFile>false</useArgFile>
+                            <buildArgs>
+                                <buildArg>--initialize-at-build-time=ch.qos.logback.classic.LoggerContext</buildArg>
+                            </buildArgs>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
```
This plugin has 12 goals:

native:add-reachability-metadata
  Description: Adds dependency reachability metadata from the configured
    metadata repository to the project's output directory.

native:build
  Description: Deprecated alias for the {@code native:compile-no-fork} goal
    for lifecycle-bound native image builds.

native:compile
  Description: Builds a native executable by forking Maven to the {@code
    package} phase before invoking {@code native-image}. It should be invoked
    from the command line as a single goal ({@code mvn native:compile}).

native:compile-no-fork
  Description: Builds a native executable in the current Maven lifecycle
    without forking a separate Maven build.

native:generateDynamicAccessMetadata
  Description: Generates dynamic access metadata used by the native image
    Build Report. The generated {@code dynamic-access-metadata.json} file
    contains the mapping of all classpath entries that exist in the {@value
    #LIBRARY_AND_FRAMEWORK_LIST} to their transitive dependencies.
    If {@value #LIBRARY_AND_FRAMEWORK_LIST} doesn't exist in the used release
    of the {@code GraalVM Reachability Metadata} repository, this task does
    nothing.
    
    The format of the generated JSON file conforms the following schema
    <https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/assets/dynamic-access-metadata-schema-v1.0.0.json>.

native:generateResourceConfig
  Description: Scans main resources and generates resource metadata for them.

native:generateTestResourceConfig
  Description: Scans test resources and generates resource metadata for them.

native:list-libraries-missing-metadata
  Description: Lists direct runtime dependencies that do not have
    reachability metadata in the configured metadata repository.
 Optionally creates reachability metadata repository issues requesting 
    support for libraries with missing metadata.

native:merge-agent-files
  Description: Merges tracing agent output from one or more sessions into a
    single metadata directory.

native:metadata-copy
  Description: Copies and optionally merges tracing agent metadata into
    {@code META-INF/native-image} for packaging.

native:test
  Description: Builds and runs the project's tests as native executables.

native:write-args-file
  Description: Writes the {@code native-image} arguments for this project to
    an args file that can be reused outside Maven. The path to the args file is
    stored in the project properties under the key {@code
    graalvm.native-image.args-file}.

For more information, run 'mvn help:describe [...] -Ddetail'
```