### PR TITLE
Bump reachability metadata version to 1.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Project versions
 nativeBuildTools = "1.0.1-SNAPSHOT"
-metadataRepository = "1.0-M1"
+metadataRepository = "1.0.0"
 
 # External dependencies
 spock = "2.1-groovy-3.0"


### PR DESCRIPTION
Fixes #878

This updates `metadataRepository` in `gradle/libs.versions.toml` from `1.0-M1` to `1.0.0` so the build uses the released reachability metadata repository version.