### PR TITLE
Adapt missing metadata issues to title-only coordinates

### DIFF
--- a/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/MissingMetadataCommandSupport.java
+++ b/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/MissingMetadataCommandSupport.java
@@ -88,7 +88,6 @@ public final class MissingMetadataCommandSupport {
 
     private static final String AUTOMATION_NOTE = "_This issue was created by automation._";
     private static final String ISSUE_TEMPLATE = "01_support_new_library.yml";
-    private static final String ISSUE_TEMPLATE_MAVEN_COORDINATES_FIELD = "maven_coordinates";
     private static final Pattern COORDINATES_PATTERN = Pattern.compile("([A-Za-z0-9_.-]+):([A-Za-z0-9_.-]+)(?::([A-Za-z0-9_.-]+))?");
     private static final long GITHUB_CLI_TIMEOUT_SECONDS = 5;
 
@@ -714,7 +713,7 @@ public final class MissingMetadataCommandSupport {
                 }
                 for (int i = 0; i < items.length(); i++) {
                     JSONObject item = items.getJSONObject(i);
-                    if (referencesGroupAndArtifact(item.optString("title"), item.optString("body"), dependency.groupAndArtifact())) {
+                    if (referencesGroupAndArtifact(item.optString("title"), dependency.groupAndArtifact())) {
                         return Optional.of(new IssueReference(
                             IssueStatus.EXISTING_OPEN_ISSUE,
                             item.getString("html_url"),
@@ -740,8 +739,7 @@ public final class MissingMetadataCommandSupport {
 
         private IssueReference newIssueLink(DependencyCoordinate dependency) {
             String issueUrl = htmlBaseUri + "/" + options.targetRepository() + "/issues/new?template=" + encode(ISSUE_TEMPLATE)
-                + "&title=" + encodeReadableQueryValue(issueTitle(dependency))
-                + "&" + ISSUE_TEMPLATE_MAVEN_COORDINATES_FIELD + "=" + encode(dependency.coordinates());
+                + "&title=" + encodeReadableQueryValue(issueTitle(dependency));
             return new IssueReference(IssueStatus.NEW_ISSUE_LINK_GENERATED, issueUrl, null);
         }
 
@@ -749,7 +747,7 @@ public final class MissingMetadataCommandSupport {
             URI uri = URI.create(apiBaseUri + "/repos/" + options.targetRepository() + "/issues");
             JSONObject body = new JSONObject();
             body.put("title", issueTitle(dependency));
-            body.put("body", issueBody(dependency));
+            body.put("body", issueBody());
             JSONArray labels = new JSONArray();
             labels.put("library-new-request");
             body.put("labels", labels);
@@ -802,17 +800,13 @@ public final class MissingMetadataCommandSupport {
         return "Support for " + dependency.coordinates();
     }
 
-    private static String issueBody(DependencyCoordinate dependency) {
-        return "### Full Maven coordinates\n\n"
-            + dependency.coordinates()
-            + "\n\n"
-            + AUTOMATION_NOTE + '\n';
+    private static String issueBody() {
+        return AUTOMATION_NOTE + '\n';
     }
 
-    static boolean referencesGroupAndArtifact(String title, String body, String groupAndArtifact) {
+    static boolean referencesGroupAndArtifact(String title, String groupAndArtifact) {
         Set<String> referencedModules = new LinkedHashSet<>();
         collectGroupAndArtifact(title, referencedModules);
-        collectGroupAndArtifact(body, referencedModules);
         return referencedModules.contains(groupAndArtifact);
     }
 

--- a/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/MissingMetadataCommandSupportTest.java
+++ b/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/MissingMetadataCommandSupportTest.java
@@ -62,20 +62,19 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MissingMetadataCommandSupportTest {
     @Test
-    void detectsCoordinatesInIssueTitleAndBody() {
+    void detectsCoordinatesInIssueTitleOnly() {
         assertTrue(MissingMetadataCommandSupport.referencesGroupAndArtifact(
             "Support for org.example:demo-lib:1.2.3",
-            "",
             "org.example:demo-lib"
         ));
-        assertTrue(MissingMetadataCommandSupport.referencesGroupAndArtifact(
+        assertFalse(MissingMetadataCommandSupport.referencesGroupAndArtifact(
             "Different title",
-            "### Full Maven coordinates\n\norg.example:demo-lib:1.2.3\n",
             "org.example:demo-lib"
         ));
     }
@@ -122,8 +121,8 @@ class MissingMetadataCommandSupportTest {
         assertTrue(missingUrl.contains("/" + MissingMetadataCommandSupport.DEFAULT_TARGET_REPOSITORY + "/issues/new?template="));
         assertTrue(missingUrl.contains("title=Support+for+org.example:missing-lib:2.0.0"),
             "title should keep colons readable, was: " + missingUrl);
-        assertTrue(missingUrl.contains("maven_coordinates=org.example%3Amissing-lib%3A2.0.0"),
-            "maven_coordinates= should prefill the issue form field, was: " + missingUrl);
+        assertFalse(missingUrl.contains("maven_coordinates="),
+            "maven_coordinates= should not be used because coordinates now live in the issue title only, was: " + missingUrl);
         String console = report.renderConsoleOutput();
         assertTrue(console.contains("Missing metadata libraries: 1 of 2 scanned"),
             "console should headline missing/scanned counts, was:\n" + console);
@@ -152,7 +151,7 @@ class MissingMetadataCommandSupportTest {
                       "number": 42,
                       "html_url": "http://localhost:%d/test/repo/issues/42",
                       "title": "Support for org.example:duplicate-lib:1.0.0",
-                      "body": "### Full Maven coordinates\\n\\norg.example:duplicate-lib:1.0.0\\n"
+                      "body": "Coordinates are no longer stored here."
                     }
                   ]
                 }
@@ -195,6 +194,53 @@ class MissingMetadataCommandSupportTest {
             assertTrue(console.contains("- org.example:duplicate-lib:2.0.0  -> existing request [E2]"), console);
             assertTrue(console.contains("[E1] " + issueUrl), console);
             assertTrue(console.contains("[E2] " + issueUrl), console);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void createsIssuesWithCoordinatesInTitleOnly() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        java.util.concurrent.atomic.AtomicReference<JSONObject> createdIssue = new java.util.concurrent.atomic.AtomicReference<>();
+        server.createContext("/api/v3/search/issues", exchange -> writeJson(exchange, "{\"items\":[]}"));
+        server.createContext("/api/v3/repos/test/repo/issues", exchange -> {
+            String requestBody = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            createdIssue.set(new JSONObject(requestBody));
+            writeJson(exchange, """
+                {
+                  "number": 7,
+                  "html_url": "http://localhost:%d/test/repo/issues/7"
+                }
+                """.formatted(server.getAddress().getPort()));
+        });
+        server.start();
+        try {
+            MissingMetadataCommandSupport.Report report = MissingMetadataCommandSupport.run(
+                List.of(new MissingMetadataCommandSupport.DependencyCoordinate("org.example", "missing-lib", "1.0.0")),
+                new TestRepository(Set.of()),
+                Set.of(),
+                java.util.Map.of(),
+                new MissingMetadataCommandSupport.Options(
+                    "gradle",
+                    "demo-app",
+                    "file:///tmp/repo",
+                    true,
+                    "gho_test_token",
+                    "test/repo",
+                    "http://localhost:" + server.getAddress().getPort() + "/api/v3",
+                    Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneOffset.UTC)
+                )
+            );
+
+            JSONObject requestBody = createdIssue.get();
+            assertEquals("Support for org.example:missing-lib:1.0.0", requestBody.getString("title"));
+            assertEquals("_This issue was created by automation._\n", requestBody.getString("body"));
+            assertFalse(requestBody.getString("body").contains("Full Maven coordinates"));
+            assertEquals("library-new-request", requestBody.getJSONArray("labels").getString(0));
+            JSONObject result = new JSONObject(report.toJsonString()).getJSONArray("results").getJSONObject(0);
+            assertEquals("created_issue", result.getString("issueStatus"));
+            assertEquals("http://localhost:" + server.getAddress().getPort() + "/test/repo/issues/7", result.getString("issueUrl"));
         } finally {
             server.stop(0);
         }


### PR DESCRIPTION
Fixes #885

The reachability metadata repository removed the `Full Maven coordinates` issue-form field, so missing metadata requests now need to carry coordinates only in the issue title.

This updates `MissingMetadataCommandSupport` to generate title-only request links, create issues without the removed coordinates body section, and match existing library request issues by title only. Tests cover the new link, issue creation, and reuse behavior.

Tested with:

```
JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal ./gradlew :graalvm-reachability-metadata:test
```