### PR TITLE
Skip JDK 25 metadata schema check on macOS x64

### DIFF
--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/SchemaValidationUtils.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/SchemaValidationUtils.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.nio.file.DirectoryStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import java.io.IOException;
@@ -184,6 +185,15 @@ public final class SchemaValidationUtils {
      * guidance in error messages.
      */
     public static void validateReachabilityMetadataSchema(Path repoRoot, int majorJDKVersion, Path nativeImageExecutable) {
+        validateReachabilityMetadataSchema(repoRoot, majorJDKVersion, nativeImageExecutable, System.getProperty("os.name"), System.getProperty("os.arch"));
+    }
+
+    static void validateReachabilityMetadataSchema(Path repoRoot, int majorJDKVersion, Path nativeImageExecutable, String osName, String osArch) {
+        // GraalVM JDK 25 never shipped a macOS x64 release containing this schema.
+        if (shouldSkipReachabilityMetadataSchemaValidation(majorJDKVersion, osName, osArch)) {
+            return;
+        }
+
         Path schemasDir = repoRoot.resolve("schemas");
         if (!Files.isDirectory(schemasDir)) {
             String message = "The configured GraalVM reachability metadata repository at "
@@ -284,6 +294,20 @@ public final class SchemaValidationUtils {
                 }
             }
         }
+    }
+
+    private static boolean shouldSkipReachabilityMetadataSchemaValidation(int majorJDKVersion, String osName, String osArch) {
+        return majorJDKVersion == 25 && isMacOsX64(osName, osArch);
+    }
+
+    private static boolean isMacOsX64(String osName, String osArch) {
+        if (osName == null || osArch == null) {
+            return false;
+        }
+        String normalizedOsName = osName.toLowerCase(Locale.ROOT);
+        String normalizedOsArch = osArch.toLowerCase(Locale.ROOT);
+        return normalizedOsName.contains("mac")
+                && ("x86_64".equals(normalizedOsArch) || "amd64".equals(normalizedOsArch));
     }
 
     /**

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/SchemaValidationUtilsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/SchemaValidationUtilsTest.java
@@ -151,6 +151,33 @@ class SchemaValidationUtilsTest {
     }
 
     @Test
+    @DisplayName("validateReachabilityMetadataSchema skips when JDK 25 runs on macOS x64")
+    void validateReachabilitySchemaRepoOnlyOnMacOsX64Jdk25(@TempDir Path tempDir) throws IOException {
+        Path repoRoot = tempDir.resolve("repo-only-macos-x64");
+        Path schemas = repoRoot.resolve("schemas");
+        Files.createDirectories(schemas);
+        writeJson(schemas.resolve("reachability-metadata-schema-v1.2.0.json"), schemaJson("1.2.0"));
+
+        Path nativeImage = createFakeGraalVMHome(tempDir.resolve("graal-no-schema-macos-x64"), null);
+
+        assertDoesNotThrow(() -> SchemaValidationUtils.validateReachabilityMetadataSchema(repoRoot, 25, nativeImage, "Mac OS X", "x86_64"));
+        assertDoesNotThrow(() -> SchemaValidationUtils.validateReachabilityMetadataSchema(repoRoot, 25, nativeImage, "Mac OS X", "amd64"));
+    }
+
+    @Test
+    @DisplayName("validateReachabilityMetadataSchema still fails for JDK 21 on macOS x64")
+    void validateReachabilitySchemaRepoOnlyOnMacOsX64Jdk21(@TempDir Path tempDir) throws IOException {
+        Path repoRoot = tempDir.resolve("repo-only-macos-x64-jdk21");
+        Path schemas = repoRoot.resolve("schemas");
+        Files.createDirectories(schemas);
+        writeJson(schemas.resolve("reachability-metadata-schema-v1.2.0.json"), schemaJson("1.2.0"));
+
+        Path nativeImage = createFakeGraalVMHome(tempDir.resolve("graal-no-schema-macos-x64-jdk21"), null);
+
+        assertThrows(IllegalStateException.class, () -> SchemaValidationUtils.validateReachabilityMetadataSchema(repoRoot, 21, nativeImage, "Mac OS X", "x86_64"));
+    }
+
+    @Test
     @DisplayName("validateReachabilityMetadataSchema warns when GraalVM provides schema but repository does not")
     void validateReachabilitySchema_graalOnly(@TempDir Path tempDir) throws IOException {
         Path repoRoot = tempDir.resolve("repo-no-schema");


### PR DESCRIPTION
## Summary

Fixes #887.

Native Build Tools 1.0.0+ validates the reachability metadata schema against the schema bundled in GraalVM. GraalVM JDK 25.0.0 and 25.0.1 do not bundle that schema, and macOS x64 users cannot move to 25.0.2+ because that platform is no longer shipped for JDK 25.

This keeps repository schema validation unchanged, but skips the GraalVM/repository reachability metadata schema cross-check when running with JDK 25 on macOS x64.

## Testing

- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew -p common/utils test`
- Local Linux diagnostic check with `GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/25.0.1-graal ./.github/workflows/test-jdk25-reachability-schema.sh` fails with the expected missing GraalVM reachability schema error.

## Notes

The final commit is a temporary `[TEST]` workflow for PR validation. It runs the same JDK 25.0.1 schema check on macOS x64 and Linux; macOS x64 should pass through the compatibility bypass, while Linux should fail on the JDK 25.0.1 schema mismatch.