### PR TITLE
Skip metadata requests for artifacts unavailable in Maven Central repository

### DIFF
--- a/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/MissingMetadataCommandSupport.java
+++ b/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/MissingMetadataCommandSupport.java
@@ -89,6 +89,7 @@ public final class MissingMetadataCommandSupport {
     private static final String AUTOMATION_NOTE = "_This issue was created by automation._";
     private static final String ISSUE_TEMPLATE = "01_support_new_library.yml";
     private static final String ISSUE_TEMPLATE_MAVEN_COORDINATES_FIELD = "maven_coordinates";
+    private static final URI MAVEN_CENTRAL_BASE_URI = URI.create("https://repo.maven.apache.org/maven2/");
     private static final Pattern COORDINATES_PATTERN = Pattern.compile("([A-Za-z0-9_.-]+):([A-Za-z0-9_.-]+)(?::([A-Za-z0-9_.-]+))?");
     private static final long GITHUB_CLI_TIMEOUT_SECONDS = 5;
 
@@ -131,9 +132,13 @@ public final class MissingMetadataCommandSupport {
                     results.add(Result.supported(dependency));
                     continue;
                 }
-                IssueReference issue = issueCache.computeIfAbsent(dependency.groupAndArtifact(), ga ->
-                    resolveIssue(issueClient, dependency)
-                );
+                IssueReference issue = issueCache.get(dependency.groupAndArtifact());
+                if (issue == null) {
+                    issue = resolveIssue(issueClient, dependency);
+                    if (!issue.isSkippedIssueCreation()) {
+                        issueCache.put(dependency.groupAndArtifact(), issue);
+                    }
+                }
                 results.add(Result.missing(dependency, issue));
             } catch (Exception ex) {
                 if (options.createIssues()) {
@@ -154,6 +159,9 @@ public final class MissingMetadataCommandSupport {
     }
 
     private static IssueReference resolveIssue(GitHubIssueClient issueClient, DependencyCoordinate dependency) {
+        if (!issueClient.isAvailableInMavenCentral(dependency)) {
+            return IssueReference.skippedIssueCreation();
+        }
         Optional<IssueReference> existing = issueClient.findOpenIssue(dependency);
         if (existing.isPresent()) {
             return existing.get();
@@ -174,6 +182,7 @@ public final class MissingMetadataCommandSupport {
         private final String githubApiUrl;
         private final Clock clock;
         private final GitHubCliTokenSupplier gitHubCliTokenSupplier;
+        private final ArtifactAvailabilityChecker artifactAvailabilityChecker;
         private final Consumer<String> warningSink;
 
         public Options(String buildTool,
@@ -185,7 +194,7 @@ public final class MissingMetadataCommandSupport {
                        String githubApiUrl,
                        Clock clock) {
             this(buildTool, projectName, metadataRepositoryUri, createIssues, githubToken, targetRepository, githubApiUrl, clock,
-                GitHubCliTokenSupplier.DEFAULT, message -> { });
+                GitHubCliTokenSupplier.DEFAULT, ArtifactAvailabilityChecker.DEFAULT, message -> { });
         }
 
         public Options(String buildTool,
@@ -198,7 +207,7 @@ public final class MissingMetadataCommandSupport {
                        Clock clock,
                        Consumer<String> warningSink) {
             this(buildTool, projectName, metadataRepositoryUri, createIssues, githubToken, targetRepository, githubApiUrl, clock,
-                GitHubCliTokenSupplier.DEFAULT, warningSink);
+                GitHubCliTokenSupplier.DEFAULT, ArtifactAvailabilityChecker.DEFAULT, warningSink);
         }
 
         Options(String buildTool,
@@ -211,7 +220,7 @@ public final class MissingMetadataCommandSupport {
                 Clock clock,
                 GitHubCliTokenSupplier gitHubCliTokenSupplier) {
             this(buildTool, projectName, metadataRepositoryUri, createIssues, githubToken, targetRepository, githubApiUrl, clock,
-                gitHubCliTokenSupplier, message -> { });
+                gitHubCliTokenSupplier, ArtifactAvailabilityChecker.DEFAULT, message -> { });
         }
 
         Options(String buildTool,
@@ -223,6 +232,21 @@ public final class MissingMetadataCommandSupport {
                 String githubApiUrl,
                 Clock clock,
                 GitHubCliTokenSupplier gitHubCliTokenSupplier,
+                ArtifactAvailabilityChecker artifactAvailabilityChecker) {
+            this(buildTool, projectName, metadataRepositoryUri, createIssues, githubToken, targetRepository, githubApiUrl, clock,
+                gitHubCliTokenSupplier, artifactAvailabilityChecker, message -> { });
+        }
+
+        Options(String buildTool,
+                String projectName,
+                String metadataRepositoryUri,
+                boolean createIssues,
+                String githubToken,
+                String targetRepository,
+                String githubApiUrl,
+                Clock clock,
+                GitHubCliTokenSupplier gitHubCliTokenSupplier,
+                ArtifactAvailabilityChecker artifactAvailabilityChecker,
                 Consumer<String> warningSink) {
             this.buildTool = Objects.requireNonNull(buildTool, "buildTool");
             this.projectName = Objects.requireNonNull(projectName, "projectName");
@@ -233,6 +257,7 @@ public final class MissingMetadataCommandSupport {
             this.githubApiUrl = blankToNull(githubApiUrl) == null ? DEFAULT_GITHUB_API_URL : stripTrailingSlash(githubApiUrl);
             this.clock = clock == null ? Clock.systemUTC() : clock;
             this.gitHubCliTokenSupplier = Objects.requireNonNull(gitHubCliTokenSupplier, "gitHubCliTokenSupplier");
+            this.artifactAvailabilityChecker = Objects.requireNonNull(artifactAvailabilityChecker, "artifactAvailabilityChecker");
             this.warningSink = warningSink == null ? message -> { } : warningSink;
         }
 
@@ -270,6 +295,10 @@ public final class MissingMetadataCommandSupport {
 
         GitHubCliTokenSupplier gitHubCliTokenSupplier() {
             return gitHubCliTokenSupplier;
+        }
+
+        ArtifactAvailabilityChecker artifactAvailabilityChecker() {
+            return artifactAvailabilityChecker;
         }
 
         Consumer<String> warningSink() {
@@ -323,7 +352,8 @@ public final class MissingMetadataCommandSupport {
     public enum IssueStatus {
         EXISTING_OPEN_ISSUE("existing_open_issue"),
         NEW_ISSUE_LINK_GENERATED("new_issue_link_generated"),
-        CREATED_ISSUE("created_issue");
+        CREATED_ISSUE("created_issue"),
+        SKIPPED_NOT_AVAILABLE_IN_MAVEN_CENTRAL("skipped_not_available_in_maven_central");
 
         private final String jsonValue;
 
@@ -458,8 +488,9 @@ public final class MissingMetadataCommandSupport {
             List<Result> existing = filterByIssueStatus(IssueStatus.EXISTING_OPEN_ISSUE);
             List<Result> created = filterByIssueStatus(IssueStatus.CREATED_ISSUE);
             List<Result> needRequest = filterByIssueStatus(IssueStatus.NEW_ISSUE_LINK_GENERATED);
+            List<Result> skipped = filterByIssueStatus(IssueStatus.SKIPPED_NOT_AVAILABLE_IN_MAVEN_CENTRAL);
             List<Result> errors = results.stream().filter(r -> r.status == Status.ERROR).toList();
-            int missingTotal = existing.size() + created.size() + needRequest.size() + errors.size();
+            int missingTotal = existing.size() + created.size() + needRequest.size() + skipped.size() + errors.size();
             if (missingTotal == 0) {
                 StringBuilder out = new StringBuilder();
                 out.append("All ").append(scanned).append(" direct dependencies are supported by the reachability metadata repository.");
@@ -514,11 +545,11 @@ public final class MissingMetadataCommandSupport {
             if (!needRequest.isEmpty()) {
                 String quantifier;
                 if (needRequest.size() == 1) {
-                    quantifier = !existing.isEmpty() || !created.isEmpty()
+                    quantifier = !existing.isEmpty() || !created.isEmpty() || !skipped.isEmpty()
                         ? "the remaining library"
                         : "this library";
                 } else {
-                    quantifier = !existing.isEmpty() || !created.isEmpty()
+                    quantifier = !existing.isEmpty() || !created.isEmpty() || !skipped.isEmpty()
                         ? "the remaining " + needRequest.size() + " libraries"
                         : "all " + needRequest.size() + " libraries";
                 }
@@ -530,6 +561,14 @@ public final class MissingMetadataCommandSupport {
 
                 out.append("Or request support manually, one library at a time:\n");
                 renderBulletList(out, needRequest, labels, "request support");
+                out.append('\n');
+            }
+
+            if (!skipped.isEmpty()) {
+                out.append("Skipped support requests for ").append(skipped.size())
+                    .append(skipped.size() == 1 ? " library" : " libraries")
+                    .append(" not found in Maven Central:\n");
+                renderSkippedList(out, skipped);
                 out.append('\n');
             }
 
@@ -561,6 +600,14 @@ public final class MissingMetadataCommandSupport {
             return results.stream()
                 .filter(r -> r.status == Status.MISSING && r.issueStatus == issueStatus)
                 .toList();
+        }
+
+        private void renderSkippedList(StringBuilder out, List<Result> entries) {
+            int maxWidth = maxCoordinateWidth(entries);
+            for (Result r : entries) {
+                out.append("  - ").append(padRight(r.dependency.coordinates(), maxWidth))
+                    .append("  support request skipped\n");
+            }
         }
 
         private void renderBulletList(StringBuilder out, List<Result> entries,
@@ -629,6 +676,7 @@ public final class MissingMetadataCommandSupport {
             summary.put("existingOpenIssue", existingIssueCount());
             summary.put("newIssueLinks", newIssueLinkCount());
             summary.put("createdIssues", createdIssueCount());
+            summary.put("skippedIssueCreation", skippedIssueCreationCount());
             summary.put("errors", errorCount());
             json.put("summary", summary);
             JSONArray resultsJson = new JSONArray();
@@ -659,6 +707,10 @@ public final class MissingMetadataCommandSupport {
             return results.stream().filter(result -> result.issueStatus == IssueStatus.CREATED_ISSUE).count();
         }
 
+        private long skippedIssueCreationCount() {
+            return results.stream().filter(result -> result.issueStatus == IssueStatus.SKIPPED_NOT_AVAILABLE_IN_MAVEN_CENTRAL).count();
+        }
+
         private long errorCount() {
             return results.stream().filter(result -> result.status == Status.ERROR).count();
         }
@@ -667,7 +719,17 @@ public final class MissingMetadataCommandSupport {
     private record IssueReference(IssueStatus issueStatus, String issueUrl, Integer issueNumber) {
         private IssueReference {
             Objects.requireNonNull(issueStatus, "issueStatus");
-            Objects.requireNonNull(issueUrl, "issueUrl");
+            if (issueStatus != IssueStatus.SKIPPED_NOT_AVAILABLE_IN_MAVEN_CENTRAL) {
+                Objects.requireNonNull(issueUrl, "issueUrl");
+            }
+        }
+
+        private static IssueReference skippedIssueCreation() {
+            return new IssueReference(IssueStatus.SKIPPED_NOT_AVAILABLE_IN_MAVEN_CENTRAL, null, null);
+        }
+
+        private boolean isSkippedIssueCreation() {
+            return issueStatus == IssueStatus.SKIPPED_NOT_AVAILABLE_IN_MAVEN_CENTRAL;
         }
     }
 
@@ -764,6 +826,10 @@ public final class MissingMetadataCommandSupport {
                 response.getString("html_url"),
                 response.optInt("number")
             );
+        }
+
+        private boolean isAvailableInMavenCentral(DependencyCoordinate dependency) {
+            return options.artifactAvailabilityChecker().isAvailable(dependency);
         }
 
         private HttpRequest.Builder request(URI uri) {
@@ -899,6 +965,59 @@ public final class MissingMetadataCommandSupport {
         return host;
     }
 
+    static URI mavenCentralPomUri(URI baseUri, DependencyCoordinate dependency) {
+        String pomPath = dependency.groupId().replace('.', '/')
+            + "/" + dependency.artifactId()
+            + "/" + dependency.version()
+            + "/" + dependency.artifactId() + "-" + dependency.version() + ".pom";
+        return baseUri.resolve(encodePath(pomPath));
+    }
+
+    private static String encodePath(String path) {
+        String[] segments = path.split("/", -1);
+        StringBuilder encoded = new StringBuilder(path.length());
+        for (int i = 0; i < segments.length; i++) {
+            if (i > 0) {
+                encoded.append('/');
+            }
+            encoded.append(URLEncoder.encode(segments[i], StandardCharsets.UTF_8).replace("+", "%20"));
+        }
+        return encoded.toString();
+    }
+
+    @FunctionalInterface
+    interface ArtifactAvailabilityChecker {
+        ArtifactAvailabilityChecker DEFAULT = dependency -> {
+            HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build();
+            HttpRequest request = HttpRequest.newBuilder(mavenCentralPomUri(MAVEN_CENTRAL_BASE_URI, dependency))
+                .timeout(Duration.ofSeconds(20))
+                .header("User-Agent", "native-build-tools-missing-metadata")
+                .method("HEAD", HttpRequest.BodyPublishers.noBody())
+                .build();
+            try {
+                HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+                int statusCode = response.statusCode();
+                if (statusCode >= 200 && statusCode < 300) {
+                    return true;
+                }
+                if (statusCode == 404) {
+                    return false;
+                }
+                throw new MavenCentralLookupException("Maven Central lookup failed for " + dependency.coordinates() + " with status " + statusCode);
+            } catch (IOException ex) {
+                throw new UncheckedIOException(ex);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(ex);
+            }
+        };
+
+        boolean isAvailable(DependencyCoordinate dependency);
+    }
+
     @FunctionalInterface
     interface GitHubCliTokenSupplier {
         GitHubCliTokenSupplier DEFAULT = hostname -> {
@@ -939,6 +1058,12 @@ public final class MissingMetadataCommandSupport {
 
     private static final class GitHubApiException extends RuntimeException {
         private GitHubApiException(String message) {
+            super(message);
+        }
+    }
+
+    private static final class MavenCentralLookupException extends RuntimeException {
+        private MavenCentralLookupException(String message) {
             super(message);
         }
     }

--- a/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/MissingMetadataCommandSupportTest.java
+++ b/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/MissingMetadataCommandSupportTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Clock;
@@ -81,6 +82,17 @@ class MissingMetadataCommandSupportTest {
     }
 
     @Test
+    void buildsMavenCentralPomUriFromCoordinates() {
+        assertEquals(
+            "https://repo.maven.apache.org/maven2/com/siplec/IncidentApiClient/2.0.0-RELEASE/IncidentApiClient-2.0.0-RELEASE.pom",
+            MissingMetadataCommandSupport.mavenCentralPomUri(
+                URI.create("https://repo.maven.apache.org/maven2/"),
+                new MissingMetadataCommandSupport.DependencyCoordinate("com.siplec", "IncidentApiClient", "2.0.0-RELEASE")
+            ).toString()
+        );
+    }
+
+    @Test
     void reportsSupportedAndMissingDependenciesAndGeneratesPrefilledLinks() {
         MissingMetadataCommandSupport.Report report = MissingMetadataCommandSupport.run(
             List.of(
@@ -98,7 +110,9 @@ class MissingMetadataCommandSupportTest {
                 null,
                 MissingMetadataCommandSupport.DEFAULT_TARGET_REPOSITORY,
                 "http://127.0.0.1:9/api/v3",
-                Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneOffset.UTC)
+                Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneOffset.UTC),
+                hostname -> null,
+                dependency -> true
             )
         );
 
@@ -176,7 +190,9 @@ class MissingMetadataCommandSupportTest {
                     null,
                     "test/repo",
                     "http://localhost:" + server.getAddress().getPort() + "/api/v3",
-                    Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneOffset.UTC)
+                    Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneOffset.UTC),
+                    hostname -> null,
+                    dependency -> true
                 )
             );
 
@@ -195,6 +211,53 @@ class MissingMetadataCommandSupportTest {
             assertTrue(console.contains("- org.example:duplicate-lib:2.0.0  -> existing request [E2]"), console);
             assertTrue(console.contains("[E1] " + issueUrl), console);
             assertTrue(console.contains("[E2] " + issueUrl), console);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void listModeSkipsNewIssueLinkWhenArtifactIsNotAvailableInMavenCentral() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        AtomicInteger searches = new AtomicInteger();
+        server.createContext("/api/v3/search/issues", exchange -> {
+            searches.incrementAndGet();
+            writeJson(exchange, "{\"items\":[]}");
+        });
+        server.start();
+        try {
+            MissingMetadataCommandSupport.Report report = MissingMetadataCommandSupport.run(
+                List.of(new MissingMetadataCommandSupport.DependencyCoordinate("com.siplec", "IncidentApiClient", "2.0.0-RELEASE")),
+                new TestRepository(Set.of()),
+                Set.of(),
+                java.util.Map.of(),
+                new MissingMetadataCommandSupport.Options(
+                    "maven",
+                    "demo-app",
+                    "file:///tmp/repo",
+                    false,
+                    null,
+                    "test/repo",
+                    "http://localhost:" + server.getAddress().getPort() + "/api/v3",
+                    Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneOffset.UTC),
+                    hostname -> null,
+                    dependency -> false
+                )
+            );
+
+            JSONObject json = new JSONObject(report.toJsonString());
+            JSONObject summary = json.getJSONObject("summary");
+            JSONObject skipped = findByCoordinates(json.getJSONArray("results"), "com.siplec:IncidentApiClient:2.0.0-RELEASE");
+            assertEquals(0, searches.get());
+            assertEquals(1, summary.getInt("missing"));
+            assertEquals(0, summary.getInt("newIssueLinks"));
+            assertEquals(1, summary.getInt("skippedIssueCreation"));
+            assertEquals("missing", skipped.getString("status"));
+            assertEquals("skipped_not_available_in_maven_central", skipped.getString("issueStatus"));
+            assertTrue(!skipped.has("issueUrl"), "skipped support-request results should not include an issue URL");
+            String console = report.renderConsoleOutput();
+            assertTrue(console.contains("Skipped support requests for 1 library not found in Maven Central:"), console);
+            assertTrue(!console.contains("issues/new?template="), console);
         } finally {
             server.stop(0);
         }
@@ -257,6 +320,59 @@ class MissingMetadataCommandSupportTest {
     }
 
     @Test
+    void createIssuesModeSkipsIssueCreationWhenArtifactIsNotAvailableInMavenCentral() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        AtomicInteger searches = new AtomicInteger();
+        AtomicInteger creations = new AtomicInteger();
+        server.createContext("/api/v3/search/issues", exchange -> {
+            searches.incrementAndGet();
+            writeJson(exchange, "{\"items\":[]}");
+        });
+        server.createContext("/api/v3/repos/test/repo/issues", exchange -> {
+            creations.incrementAndGet();
+            writeJson(exchange, "{\"html_url\":\"http://localhost/unused\",\"number\":99}");
+        });
+        server.start();
+        try {
+            MissingMetadataCommandSupport.Report report = MissingMetadataCommandSupport.run(
+                List.of(new MissingMetadataCommandSupport.DependencyCoordinate("com.siplec", "IncidentApiClient", "2.0.0-RELEASE")),
+                new TestRepository(Set.of()),
+                Set.of(),
+                java.util.Map.of(),
+                new MissingMetadataCommandSupport.Options(
+                    "gradle",
+                    "demo-app",
+                    "file:///tmp/repo",
+                    true,
+                    "gho_test_token",
+                    "test/repo",
+                    "http://localhost:" + server.getAddress().getPort() + "/api/v3",
+                    Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneOffset.UTC),
+                    hostname -> null,
+                    dependency -> false
+                )
+            );
+
+            JSONObject json = new JSONObject(report.toJsonString());
+            JSONObject summary = json.getJSONObject("summary");
+            JSONObject skipped = findByCoordinates(json.getJSONArray("results"), "com.siplec:IncidentApiClient:2.0.0-RELEASE");
+            assertEquals(0, searches.get());
+            assertEquals(0, creations.get());
+            assertEquals(1, summary.getInt("missing"));
+            assertEquals(0, summary.getInt("createdIssues"));
+            assertEquals(1, summary.getInt("skippedIssueCreation"));
+            assertEquals("missing", skipped.getString("status"));
+            assertEquals("skipped_not_available_in_maven_central", skipped.getString("issueStatus"));
+            assertTrue(!skipped.has("issueUrl"), "skipped support-request results should not include an issue URL");
+            String console = report.renderConsoleOutput();
+            assertTrue(console.contains("Skipped support requests for 1 library not found in Maven Central:"), console);
+            assertTrue(console.contains("com.siplec:IncidentApiClient:2.0.0-RELEASE"), console);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
     void createIssuesModeFailsFastWhenIssueCreationFails() throws Exception {
         HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
         AtomicInteger searches = new AtomicInteger();
@@ -290,7 +406,9 @@ class MissingMetadataCommandSupportTest {
                         "gho_test_token",
                         "test/repo",
                         "http://localhost:" + server.getAddress().getPort() + "/api/v3",
-                        Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneOffset.UTC)
+                        Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneOffset.UTC),
+                        hostname -> null,
+                        dependency -> true
                     )
                 )
             );
@@ -323,7 +441,9 @@ class MissingMetadataCommandSupportTest {
                 null,
                 "test/repo",
                 "http://127.0.0.1:9/api/v3",
-                Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneOffset.UTC)
+                Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneOffset.UTC),
+                hostname -> null,
+                dependency -> true
             )
         );
 

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -862,6 +862,7 @@ The GitHub token used for issue lookup and creation is resolved in this order:
 4. `gh auth token`, when the GitHub CLI is installed and authenticated (subprocess capped at 5 seconds; non-zero exit is treated as no token)
 
 In default list mode the task tolerates a missing token: it can still query public issues, and emits a single warning if the GitHub API rejects the lookup. With `-PcreateIssues=true`, a token is required.
+The task first checks Maven Central and skips GitHub support requests for missing libraries whose POM cannot be found there.
 
 === Including Metadata Repository Files
 

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -879,6 +879,7 @@ The GitHub token used for issue lookup and creation is resolved in this order:
 4. `gh auth token`, when the GitHub CLI is installed and authenticated (subprocess capped at 5 seconds; non-zero exit is treated as no token)
 
 In default list mode the goal tolerates a missing token: it can still query public issues, and emits a single warning if the GitHub API rejects the lookup. With `-DcreateIssues=true`, a token is required.
+The goal first checks Maven Central and skips GitHub support requests for missing libraries whose POM cannot be found there.
 
 === Adding Metadata Repository Files
 

--- a/schemas/list-libraries-missing-metadata-schema-v1.0.0.json
+++ b/schemas/list-libraries-missing-metadata-schema-v1.0.0.json
@@ -96,6 +96,10 @@
           "type": "integer",
           "minimum": 0
         },
+        "skippedIssueCreation": {
+          "type": "integer",
+          "minimum": 0
+        },
         "errors": {
           "type": "integer",
           "minimum": 0
@@ -158,8 +162,7 @@
         "coordinates",
         "scope",
         "status",
-        "issueStatus",
-        "issueUrl"
+        "issueStatus"
       ],
       "properties": {
         "coordinates": {
@@ -175,7 +178,8 @@
           "enum": [
             "existing_open_issue",
             "new_issue_link_generated",
-            "created_issue"
+            "created_issue",
+            "skipped_not_available_in_maven_central"
           ]
         },
         "issueUrl": {
@@ -187,6 +191,24 @@
         }
       },
       "allOf": [
+        {
+          "if": {
+            "properties": {
+              "issueStatus": {
+                "enum": [
+                  "existing_open_issue",
+                  "new_issue_link_generated",
+                  "created_issue"
+                ]
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "issueUrl"
+            ]
+          }
+        },
         {
           "if": {
             "properties": {


### PR DESCRIPTION
## Summary
- check Maven Central before performing any GitHub support-request action for missing metadata dependencies
- skip unsupported private/custom-repository artifacts in both list mode and createIssues mode
- expose skipped support requests in console output and the JSON report schema

Fixes #889

## Testing
- Direct `javac --release 17` compile of the touched main/test classes
- Direct JUnit ConsoleLauncher run for `MissingMetadataCommandSupportTest` (14 tests)
- `jq empty schemas/list-libraries-missing-metadata-schema-v1.0.0.json`
- `git diff --check`

Note: the Gradle wrapper test task is blocked locally by this checkout's Gradle 7.4 build logic under the installed JDKs; JDK 25 fails Kotlin DSL Java-version parsing, and JDK 21 hits `Unsupported class file major version 65` in precompiled Groovy plugin compilation.