### PR TITLE
Allow empty classpath for layer-create builds

### DIFF
--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.gradle.tasks
+
+import org.graalvm.buildtools.gradle.NativeImagePlugin
+import org.graalvm.buildtools.gradle.dsl.GraalVMExtension
+import org.graalvm.buildtools.gradle.internal.NativeImageCommandLineProvider
+import org.graalvm.buildtools.model.resources.NativeImageFlags
+import org.gradle.api.plugins.ApplicationPlugin
+import spock.lang.Issue
+
+class NativeImageCommandLineProviderTest extends AbstractPluginTest {
+    @Issue("https://github.com/graalvm/native-build-tools/issues/892")
+    def "does not add classpath for layer-create build with empty classpath"() {
+        given:
+        def project = newProject()
+        project.plugins.apply(ApplicationPlugin)
+        project.plugins.apply(NativeImagePlugin)
+        def options = project.extensions.getByType(GraalVMExtension).binaries.create("libbase")
+        options.createLayer {
+            it.modules.add("java.base")
+        }
+        options.excludeConfigArgs.set([])
+        options.configurationFileDirectories.setFrom([])
+
+        when:
+        def args = new NativeImageCommandLineProvider(
+                project.provider { options },
+                project.provider { "libbase" },
+                project.provider { testDirectory.toString() },
+                project.provider { testDirectory.toString() },
+                project.objects.fileProperty(),
+                project.provider { false },
+                project.provider { 25 },
+                project.provider { false }
+        ).asArguments()
+
+        then:
+        !args.contains("-cp")
+        args.contains(NativeImageFlags.UNLOCK_EXPERIMENTAL_VMOPTIONS)
+        args.any { it.startsWith("${NativeImageFlags.LAYER_CREATE}=libbase.nil") && it.contains("module=java.base") }
+    }
+}

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -53,6 +53,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.logging.Logger;
 import org.graalvm.buildtools.maven.config.ExcludeConfigConfiguration;
+import org.graalvm.buildtools.model.resources.NativeImageFlags;
 import org.graalvm.buildtools.utils.NativeImageConfigurationUtils;
 import org.graalvm.buildtools.utils.NativeImageUtils;
 import org.graalvm.buildtools.utils.SchemaValidationUtils;
@@ -96,6 +97,8 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     protected static final String NATIVE_IMAGE_META_INF = "META-INF/native-image";
     protected static final String NATIVE_IMAGE_PROPERTIES_FILENAME = "native-image.properties";
     protected static final String NATIVE_IMAGE_DRY_RUN = "nativeDryRun";
+    private static final Pattern LAYER_CREATE_ARG = Pattern.compile(
+            Pattern.quote(NativeImageFlags.LAYER_CREATE) + "(@[^=]*)?=.+");
     private static String nativeImageVersionInformation = null;
 
     @Parameter(defaultValue = "${plugin}", readonly = true) // Maven 3 only
@@ -211,8 +214,11 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
             });
         }
 
-        cliArgs.add("-cp");
-        cliArgs.add(getClasspath());
+        String imageClasspath = getClasspath();
+        if (!imageClasspath.isEmpty()) {
+            cliArgs.add("-cp");
+            cliArgs.add(imageClasspath);
+        }
 
         if (debug) {
             cliArgs.add("-g");
@@ -495,12 +501,21 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
             populateClasspath();
         }
         if (imageClasspath.isEmpty()) {
+            if (isLayerCreateBuild()) {
+                return "";
+            }
             throw new MojoExecutionException("Image classpath is empty. " +
                     "Check if your classpath configuration is correct.");
         }
         return imageClasspath.stream()
                 .map(Path::toString)
                 .collect(Collectors.joining(File.pathSeparator));
+    }
+
+    private boolean isLayerCreateBuild() {
+        return buildArgs != null && buildArgs.stream()
+                .filter(Objects::nonNull)
+                .anyMatch(arg -> LAYER_CREATE_ARG.matcher(arg.trim()).matches());
     }
 
     protected void buildImage() throws MojoExecutionException {

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
@@ -1,8 +1,14 @@
 package org.graalvm.buildtools.maven
 
+import org.apache.maven.plugin.MojoExecutionException
 import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Path
 
 class AbstractNativeImageMojoTest extends Specification {
+    @TempDir
+    Path testDirectory
 
     void "it can process build args"() {
         given:
@@ -26,5 +32,61 @@ class AbstractNativeImageMojoTest extends Specification {
                 "C:\\Users\\Lahoucine EL ADDALI\\Desktop\\outdir\\target/java-application-with-custom-packaging-0.1.jar",
                 "-H:ConfigurationFileDirectories=C:\\Users\\Lahoucine EL ADDALI\\Downloads\\4.5.0.0_kubernetes_kubernetes-demo-java-maven\\api\\target\\native\\generated\\generateResourceConfig"
         ]
+    }
+
+    void "it allows empty classpath for layer-create builds"() {
+        given:
+        def mojo = newMojo([layerCreateArg])
+
+        when:
+        def args = mojo.getBuildArgs()
+
+        then:
+        !args.contains("-cp")
+        args.contains(layerCreateArg)
+
+        where:
+        layerCreateArg << [
+                "-H:LayerCreate=libbase.nil,module=java.base",
+                "-H:LayerCreate@user=libbase.nil,module=java.base"
+        ]
+    }
+
+    void "it still rejects empty classpath for regular builds"() {
+        given:
+        def mojo = newMojo([])
+
+        when:
+        mojo.getBuildArgs()
+
+        then:
+        def e = thrown(MojoExecutionException)
+        e.message.contains("Image classpath is empty")
+    }
+
+    private TestNativeImageMojo newMojo(List<String> buildArgs) {
+        def mojo = new TestNativeImageMojo()
+        mojo.outputDirectory = testDirectory.resolve("target").toFile()
+        mojo.resourcesConfigDirectory = testDirectory.resolve("target/native/generated").toFile()
+        mojo.imageName = "libbase"
+        mojo.buildArgs = buildArgs
+        mojo.configFiles = []
+        mojo.useArgFile = false
+        mojo
+    }
+
+    private static class TestNativeImageMojo extends AbstractNativeImageMojo {
+        @Override
+        void execute() {
+        }
+
+        @Override
+        protected List<String> getDependencyScopes() {
+            Collections.emptyList()
+        }
+
+        @Override
+        protected void populateClasspath() {
+        }
     }
 }


### PR DESCRIPTION
Fixes #892

## Summary
- allow Maven layer-create builds to omit `-cp` when the computed image classpath is empty
- detect the hosted layer-create flag emitted by native-build-tools: `-H:LayerCreate...`
- add Maven coverage for empty classpath layer-create builds and regular empty classpath failures
- add Gradle regression coverage showing existing no-`-cp` behavior for empty classpath layer-create builds

## Testing
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-maven-plugin:test --tests org.graalvm.buildtools.maven.AbstractNativeImageMojoTest`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:test --tests org.graalvm.buildtools.gradle.tasks.NativeImageCommandLineProviderTest`

Note: `:native-maven-plugin:checkstyleMain` currently fails on pre-existing unused imports in `NativeTestMojo.java`, unrelated to this change.