### PR TITLE
Bump reachability metadata repository to 1.0.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Project versions
 nativeBuildTools = "1.1.1-SNAPSHOT"
-metadataRepository = "1.0.0"
+metadataRepository = "1.0.2"
 
 # External dependencies
 spock = "2.1-groovy-3.0"


### PR DESCRIPTION
Fixes #896.

Updates the reachability metadata repository version from 1.0.0 to 1.0.2.