### PR TITLE
Use explicit Gradle project dependency notation and test on Gradle 9.6.1

### DIFF
--- a/build-logic/common-plugins/src/main/groovy/org.graalvm.build.github-actions-helper.gradle
+++ b/build-logic/common-plugins/src/main/groovy/org.graalvm.build.github-actions-helper.gradle
@@ -12,7 +12,7 @@ def latestMatrixDefault = [
 
 // # Following versions are disabled temporarily in order to speed up PR testing  "7.3.3", "7.2", "7.1", "6.8.3",
 def gradleVersions = [
-        "gradle-version": ["current", "8.4", "8.14.2", "9.0.0"],
+        "gradle-version": ["current", "8.4", "8.14.2", "9.0.0", "9.6.1"],
 ]
 
 def gradleCachedVersions = [

--- a/build-logic/gradle-functional-testing/src/main/groovy/org.graalvm.build.functional-testing.gradle
+++ b/build-logic/gradle-functional-testing/src/main/groovy/org.graalvm.build.functional-testing.gradle
@@ -84,7 +84,7 @@ def graalVm = javaToolchains.launcherFor {
 
 def fullFunctionalTest = tasks.register("fullFunctionalTest")
 
-['functionalTest': ["current", "8.4", "8.14.2", "9.0.0"],
+['functionalTest': ["current", "8.4", "8.14.2", "9.0.0", "9.6.1"],
  'configCacheFunctionalTest': ['current', "9.0.0"]
 ].each { baseName, gradleVersions ->
     gradleVersions.each { gradleVersion ->

--- a/docs/spec/requirements.md
+++ b/docs/spec/requirements.md
@@ -40,7 +40,7 @@ metadata lines.
 
 The plugins require Java 17+ to run. Native Image workflows must support JDK 25+, and are tested
 against the two most recent GraalVM LTS versions. The Gradle plugin
-supports Gradle 8.3+ and currently tests `current`, `8.4`, `8.14.2`, and `9.0.0`. The Maven plugin
+supports Gradle 8.3+ and currently tests `current`, `8.4`, `8.14.2`, `9.0.0`, and `9.6.1`. The Maven plugin
 supports Maven 3.9.x and currently tests with `3.9.9`. Metadata defaults must track the latest
 compatible published repository while remaining pinnable by version, URI, or local path.
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -50,6 +50,20 @@ import spock.lang.Requires
 import java.nio.file.Files
 
 class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
+    @Issue("https://github.com/graalvm/native-build-tools/issues/900")
+    def "does not use deprecated Project dependency notation"() {
+        given:
+        withSample("java-application")
+
+        when:
+        run 'help', '--warning-mode=fail'
+
+        then:
+        tasks {
+            succeeded ':help'
+        }
+    }
+
     @Issue("https://github.com/graalvm/native-build-tools/issues/855")
     def "does not resolve runtime classpath during configuration when dependencies change after evaluate"() {
         given:

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -41,6 +41,7 @@
 
 package org.graalvm.buildtools.gradle
 
+import org.gradle.util.GradleVersion
 import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
@@ -51,6 +52,13 @@ import java.nio.file.Files
 
 class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
     @Issue("https://github.com/graalvm/native-build-tools/issues/900")
+    @Requires({
+        def currentVersion = System.getProperty("gradle.test.version", GradleVersion.current().version)
+        if (currentVersion == "current") {
+            currentVersion = GradleVersion.current().version
+        }
+        GradleVersion.version(currentVersion).baseVersion >= GradleVersion.version("9.6")
+    })
     def "does not use deprecated Project dependency notation"() {
         given:
         withSample("java-application")

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -952,6 +952,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                 }
             });
         });
+        // Native-image classpaths must model the current project through Gradle's supported dependency APIs. §gradle/FS-plugin-model.
         compileOnly.getDependencies().add(project.getDependencies().project(Collections.singletonMap("path", project.getPath())));
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -952,7 +952,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                 }
             });
         });
-        compileOnly.getDependencies().add(project.getDependencies().create(project));
+        compileOnly.getDependencies().add(project.getDependencies().project(Collections.singletonMap("path", project.getPath())));
     }
 
     private NativeImageOptions createMainOptions(GraalVMExtension graalExtension, Project project) {


### PR DESCRIPTION
Fixes #900

## What changed

This PR updates the Gradle plugin to stop using deprecated raw `Project` dependency notation when wiring its native compile-only configuration.

It also bumps the Gradle functional-test matrix to include `9.6.1` in the normal `functionalTest` lane so PR CI exercises the regression on a Gradle version that actually emits the deprecation.

Before this change, newer Gradle versions could report a deprecation warning for this dependency notation, and builds that treat warnings as failures could trip over it.

After this change, the plugin uses explicit project path notation instead, and the regression coverage runs on Gradle `9.6.1` with `--warning-mode=fail`.

## Why

This removes a Gradle deprecation path and keeps the plugin compatible with stricter warning handling on newer Gradle versions.

The matrix bump is included because the new regression only becomes meaningful on Gradle `9.6+`; without that lane, reduced PR CI would still run the class on `9.0.0` and would not prove the fix.

## Example

Before:

On Gradle `9.6.1`, running the functional test path with `--warning-mode=fail` could fail on the deprecated dependency notation path.

After:

The same path uses explicit project dependency notation and no longer triggers that deprecation warning.

## Implementation summary

- Replace the deprecated raw `Project` dependency notation with explicit project path notation in the native compile-only configuration.
- Add a Gradle `9.6+` regression test that runs `help --warning-mode=fail`.
- Add `9.6.1` to the normal Gradle functional-test matrix, while leaving the config-cache matrix unchanged.
- Update the declared tested Gradle versions in the support-matrix spec.

## Validation

- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:functionalTest -DgradleVersion=9.6.1 --tests 'org.graalvm.buildtools.gradle.JavaApplicationFunctionalTest.does not use deprecated Project dependency notation'`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal ./gradlew -PmatrixType=gradle :native-gradle-plugin:dumpFunctionalTestList`
