### PR TITLE
Re-enable layered application functional test

### DIFF
--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -45,7 +45,6 @@ import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 import org.graalvm.buildtools.gradle.fixtures.GraalVMSupport
 import org.graalvm.buildtools.utils.NativeImageUtils
 import spock.lang.Ignore
-import spock.lang.Issue
 import spock.lang.Requires
 import spock.util.concurrent.PollingConditions
 
@@ -58,8 +57,6 @@ import java.nio.charset.StandardCharsets
         { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
 )
 class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
-    @Issue("https://github.com/graalvm/native-build-tools/issues/851")
-    @Ignore("Disable test temporarily because of a problem on GraalVM side")
     def "can build a native image using layers"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
 


### PR DESCRIPTION
## Summary
- Re-enable the issue-linked `LayeredApplicationFunctionalTest` scenario for Java layered images.
- Keep the separate layered Micronaut scenario ignored.

## Why
`can build a native image using layers` was ignored because issue #851 exposed a GraalVM-side failure with the new metadata format: native-image failed while using the dependency layer with `Class initialization info not stable between layers` for `org.slf4j.LoggerFactory`.

The issue-linked scenario now passes with the latest EA native-image build at `/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1`. The run exercised both `-H:LayerCreate` and `-H:LayerUse`, including the rebuild-after-application-source-change path, without reproducing the original failure.

Fixes #851.

## Verification
```bash
export GRAALVM_HOME_LATEST_EA=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1
export GRAALVM_HOME="$GRAALVM_HOME_LATEST_EA"
export JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal
export PATH="$JAVA_HOME/bin:$PATH"
./gradlew :native-gradle-plugin:functionalTest --tests org.graalvm.buildtools.gradle.LayeredApplicationFunctionalTest --rerun-tasks
```

Result: `BUILD SUCCESSFUL in 4m 45s`; `can build a native image using layers PASSED`; `can build a layered Micronaut application SKIPPED`.
