### PR TITLE
Avoid disabled agent instrumentation

### DIFF
--- a/native-gradle-plugin/docs/functional/tracing-agent.md
+++ b/native-gradle-plugin/docs/functional/tracing-agent.md
@@ -20,7 +20,8 @@ without failing the build.
 The Gradle DSL must expose standard, conditional, direct, and disabled agent modes using the
 shared agent mode behavior from §common/FS-common-libraries.3. Conditional mode must support
 user-code and extra filters; direct mode must allow users to pass native agent options, including
-`{output_dir}` substitution.
+`{output_dir}` substitution. Disabled mode must leave eligible JVM tasks uninstrumented and must
+not create agent output for those tasks.
 
 ## 4. Agent output layout
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -74,6 +74,57 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         }
     }
 
+    @Issue("https://github.com/graalvm/native-build-tools/issues/847")
+    def "does not make JavaExec tasks up-to-date when the agent is disabled"() {
+        given:
+        withSample("java-application")
+
+        buildFile << """
+            tasks.register("org.graalvm.demo.Application.main()", JavaExec) {
+                classpath = sourceSets.main.runtimeClasspath
+                mainClass = "org.graalvm.demo.Application"
+            }
+        """.stripIndent()
+
+        when:
+        run 'run'
+
+        then:
+        tasks {
+            succeeded ':run'
+        }
+        outputContains "Hello, native!"
+
+        when:
+        run 'run'
+
+        then:
+        tasks {
+            succeeded ':run'
+        }
+        outputContains "Hello, native!"
+        !file("build/native/agent-output/run").exists()
+
+        when:
+        run 'org.graalvm.demo.Application.main()'
+
+        then:
+        tasks {
+            succeeded ':org.graalvm.demo.Application.main()'
+        }
+        outputContains "Hello, native!"
+
+        when:
+        run 'org.graalvm.demo.Application.main()'
+
+        then:
+        tasks {
+            succeeded ':org.graalvm.demo.Application.main()'
+        }
+        outputContains "Hello, native!"
+        !file("build/native/agent-output/org.graalvm.demo.Application.main()").exists()
+    }
+
     def "can build a native image for a simple application"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/java-application")
         debug = true

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -229,6 +229,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     private void instrumentTasksWithAgent(Project project, DefaultGraalVmExtension graalExtension) {
         Provider<String> agentMode = agentProperty(project, graalExtension.getAgent());
         if ("disabled".equals(agentMode.get())) {
+            // Disabled agent mode must not instrument eligible JVM tasks. §FS-gradle-tracing-agent.3.
             logger.log("Not instrumenting tasks with native-image-agent because the agent is disabled.");
             return;
         }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -228,6 +228,10 @@ public class NativeImagePlugin implements Plugin<Project> {
 
     private void instrumentTasksWithAgent(Project project, DefaultGraalVmExtension graalExtension) {
         Provider<String> agentMode = agentProperty(project, graalExtension.getAgent());
+        if ("disabled".equals(agentMode.get())) {
+            logger.log("Not instrumenting tasks with native-image-agent because the agent is disabled.");
+            return;
+        }
         Predicate<? super Task> taskPredicate = graalExtension.getAgent().getTasksToInstrumentPredicate().getOrElse(serializablePredicateOf(t -> true));
         project.getTasks().configureEach(t -> {
             if (isTaskInstrumentableByAgent(t) && taskPredicate.test(t)) {


### PR DESCRIPTION
Fixes #847.
Fixes #743.

## What changed

This PR avoids wiring native-image agent instrumentation into Gradle Java execution tasks when the resolved agent mode is disabled.

Before this change, Gradle `run` and other `JavaExec`-style tasks could still pick up agent-related wiring even when the build was not actually running with the tracing agent. That could interfere with repeated executions and task up-to-date behavior.

After this change, agent wiring is only applied when the resolved agent mode is enabled, while real agent runs still keep their existing output tracking.

## Why

This prevents disabled-agent builds from paying the cost or behavioral side effects of instrumentation wiring, while preserving the expected behavior for builds that do enable the tracing agent.

## Example

Before:

Running a Gradle `run` task, or an IntelliJ-style `JavaExec` task, multiple times without `-Pagent` could still be affected by agent instrumentation wiring even though the agent was disabled.

After:

The same tasks run without agent wiring when `-Pagent` is not enabled, while builds that do enable the agent still keep the expected tracing-agent behavior and output tracking.

## Implementation summary

- Skip agent task wiring when the resolved agent mode is disabled.
- Keep agent output tracking in place for executions that actually run with the agent enabled.
- Add regression coverage for repeated Gradle `run` and IntelliJ-style `JavaExec` executions without `-Pagent`.
- Keep existing agent-enabled `run` and configuration-cache coverage in place to verify the enabled path still behaves correctly.

## Validation

- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:functionalTest --tests 'org.graalvm.buildtools.gradle.JavaApplicationFunctionalTest.does not make JavaExec tasks up-to-date when the agent is disabled'`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/25.0.2-graal ./gradlew :native-gradle-plugin:functionalTest --tests 'org.graalvm.buildtools.gradle.JavaApplicationWithAgentFunctionalTest.agent instruments run task'`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/25.0.2-graal ./gradlew :native-gradle-plugin:functionalTest --tests 'org.graalvm.buildtools.gradle.JavaApplicationWithAgentFunctionalTest.supports configuration cache'`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:checkstyleMain`
