### PR TITLE
Add common utils Checkstyle CI gate

### DIFF
--- a/.github/workflows/test-common-utils.yml
+++ b/.github/workflows/test-common-utils.yml
@@ -1,0 +1,42 @@
+# Pull request common utilities gate: checkstyle for shared Native Image utilities.
+# §AR-repository-ci.1.7; §common/FS-common-libraries.1
+name: "Test common utils"
+
+on:
+  pull_request:
+    paths:
+      - 'common/utils/**'
+      - 'config/checkstyle.xml'
+      - 'build-logic/common-plugins/**'
+      - 'build-logic/utils-plugins/**'
+      - '.github/actions/**'
+      - '.github/workflows/test-common-utils.yml'
+      - 'gradle/libs.versions.toml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'graalvm/native-build-tools' }}
+
+jobs:
+  test-common-utils:
+    name: "Test common utils"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [ 17.0.12 ]
+        os: [ ubuntu-22.04 ]
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Prepare environment"
+        uses: ./.github/actions/prepare-environment
+        with:
+          java-version: ${{ matrix.java-version }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Checkstyle"
+        run: ./gradlew :utils:checkstyleMain :utils:checkstyleTest

--- a/common/docs/e2e.md
+++ b/common/docs/e2e.md
@@ -15,10 +15,11 @@ repository check is:
 ./gradlew check
 ```
 
-For focused common validation, run the relevant included build task, such as `:utils:test`,
-`:graalvm-reachability-metadata:test`, or `:junit-platform-native:test` from the common build
-context. Use the repository CI workflows in §root/AR-repository-ci.1.5 and
-§root/AR-repository-ci.1.6 as the merge-gate equivalents.
+For focused common validation, run the relevant included build task, such as
+`:utils:checkstyleMain`, `:utils:test`, `:graalvm-reachability-metadata:test`, or
+`:junit-platform-native:test` from the common build context. Use the repository CI workflows in
+§root/AR-repository-ci.1.5, §root/AR-repository-ci.1.6, and §root/AR-repository-ci.1.7 as the
+merge-gate equivalents.
 
 ## 2. Scenario Coverage
 
@@ -50,9 +51,10 @@ compatibility-mode support. This protects §root/FS-native-tests.3 and
 
 ## 3. CI coverage
 
+`test-common-utils.yml` validates shared utilities with checkstyle.
 `test-graalvm-metadata.yml` validates the reachability metadata library with checkstyle and unit
 tests. `test-junit-platform-native.yml` validates the JUnit native support module with checkstyle,
 JVM tests, and native tests. Product plugin CI also exercises common behavior through Gradle and
 Maven functional-test matrices. These workflow gates are specified by
-§root/AR-repository-ci.1.5, §root/AR-repository-ci.1.6,
+§root/AR-repository-ci.1.7, §root/AR-repository-ci.1.5, §root/AR-repository-ci.1.6,
 §root/AR-repository-ci.1.3, and §root/AR-repository-ci.1.4.

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/SchemaValidationUtilsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/SchemaValidationUtilsTest.java
@@ -58,7 +58,7 @@ class SchemaValidationUtilsTest {
 
     @Test
     @DisplayName("validateSchemas succeeds when required schemas with exact majors are present")
-    void validateSchemas_successExactMajors(@TempDir Path tempDir) throws IOException {
+    void validateSchemasSuccessExactMajors(@TempDir Path tempDir) throws IOException {
         Path repoRoot = tempDir.resolve("repo-success");
         Path schemas = repoRoot.resolve("schemas");
         Files.createDirectories(schemas);
@@ -73,7 +73,7 @@ class SchemaValidationUtilsTest {
 
     @Test
     @DisplayName("validateSchemas fails when 'schemas' directory is missing")
-    void validateSchemas_missingSchemasDir(@TempDir Path tempDir) {
+    void validateSchemasMissingSchemasDir(@TempDir Path tempDir) {
         Path repoRoot = tempDir.resolve("repo-missing");
         // Do not create 'schemas' directory
         assertThrows(IllegalStateException.class, () -> SchemaValidationUtils.validateSchemas(repoRoot));
@@ -81,7 +81,7 @@ class SchemaValidationUtilsTest {
 
     @Test
     @DisplayName("validateSchemas fails when repository provides an older required major")
-    void validateSchemas_metadataTooOld(@TempDir Path tempDir) throws IOException {
+    void validateSchemasMetadataTooOld(@TempDir Path tempDir) throws IOException {
         Path repoRoot = tempDir.resolve("repo-too-old");
         Path schemas = repoRoot.resolve("schemas");
         Files.createDirectories(schemas);
@@ -95,7 +95,7 @@ class SchemaValidationUtilsTest {
 
     @Test
     @DisplayName("validateSchemas fails when repository provides a newer required major")
-    void validateSchemas_toolsTooOld(@TempDir Path tempDir) throws IOException {
+    void validateSchemasToolsTooOld(@TempDir Path tempDir) throws IOException {
         Path repoRoot = tempDir.resolve("repo-tools-too-old");
         Path schemas = repoRoot.resolve("schemas");
         Files.createDirectories(schemas);
@@ -109,7 +109,7 @@ class SchemaValidationUtilsTest {
 
     @Test
     @DisplayName("validateSchemas fails when more schema files than supported are present (excluding reachability)")
-    void validateSchemas_tooManySchemasExcludingReachability(@TempDir Path tempDir) throws IOException {
+    void validateSchemasTooManySchemasExcludingReachability(@TempDir Path tempDir) throws IOException {
         Path repoRoot = tempDir.resolve("repo-too-many");
         Path schemas = repoRoot.resolve("schemas");
         Files.createDirectories(schemas);
@@ -126,7 +126,7 @@ class SchemaValidationUtilsTest {
 
     @Test
     @DisplayName("validateReachabilityMetadataSchema does nothing when neither side provides the schema")
-    void validateReachabilitySchema_neitherSideProvided(@TempDir Path tempDir) throws IOException {
+    void validateReachabilitySchemaNeitherSideProvided(@TempDir Path tempDir) throws IOException {
         Path repoRoot = tempDir.resolve("repo-none");
         Files.createDirectories(repoRoot.resolve("schemas"));
 
@@ -138,7 +138,7 @@ class SchemaValidationUtilsTest {
 
     @Test
     @DisplayName("validateReachabilityMetadataSchema fails when repository provides schema but GraalVM does not")
-    void validateReachabilitySchema_repoOnly(@TempDir Path tempDir) throws IOException {
+    void validateReachabilitySchemaRepoOnly(@TempDir Path tempDir) throws IOException {
         Path repoRoot = tempDir.resolve("repo-only");
         Path schemas = repoRoot.resolve("schemas");
         Files.createDirectories(schemas);
@@ -180,7 +180,7 @@ class SchemaValidationUtilsTest {
 
     @Test
     @DisplayName("validateReachabilityMetadataSchema warns when GraalVM provides schema but repository does not")
-    void validateReachabilitySchema_graalOnly(@TempDir Path tempDir) throws IOException {
+    void validateReachabilitySchemaGraalOnly(@TempDir Path tempDir) throws IOException {
         Path repoRoot = tempDir.resolve("repo-no-schema");
         Files.createDirectories(repoRoot.resolve("schemas"));
         // No reachability schema file in repo
@@ -193,7 +193,7 @@ class SchemaValidationUtilsTest {
 
     @Test
     @DisplayName("validateReachabilityMetadataSchema succeeds when versions match")
-    void validateReachabilitySchema_match_ok(@TempDir Path tempDir) throws IOException {
+    void validateReachabilitySchemaMatchOk(@TempDir Path tempDir) throws IOException {
         Path repoRoot = tempDir.resolve("repo-match");
         Path schemas = repoRoot.resolve("schemas");
         Files.createDirectories(schemas);
@@ -206,7 +206,7 @@ class SchemaValidationUtilsTest {
 
     @Test
     @DisplayName("validateReachabilityMetadataSchema fails when versions mismatch")
-    void validateReachabilitySchema_mismatch(@TempDir Path tempDir) throws IOException {
+    void validateReachabilitySchemaMismatch(@TempDir Path tempDir) throws IOException {
         Path repoRoot = tempDir.resolve("repo-mismatch");
         Path schemas = repoRoot.resolve("schemas");
         Files.createDirectories(schemas);

--- a/docs/spec/architecture/ci.md
+++ b/docs/spec/architecture/ci.md
@@ -17,6 +17,7 @@ tests prepare both a build JDK and a GraalVM test JDK through §AR-repository-ci
 | `test-native-maven-plugin.yml` | Maven plugin, samples, common modules, workflow/action changes, and shared version catalog changes. | Maven functional tests plus GraalVM dev-build functional tests. §AR-repository-ci.1.4 |
 | `test-graalvm-metadata.yml` | Reachability metadata common module and relevant workflow/action changes. | Checkstyle and unit tests for the metadata repository library. §AR-repository-ci.1.5 |
 | `test-junit-platform-native.yml` | JUnit native support and relevant workflow/action changes. | Checkstyle, JVM tests, and native tests for `common/junit-platform-native`. §AR-repository-ci.1.6 |
+| `test-common-utils.yml` | Native Image utility common module, Checkstyle configuration, and relevant workflow/action or build-logic changes. | Checkstyle for `common/utils`. §AR-repository-ci.1.7 |
 
 ### 1.1 Grund validation workflow
 
@@ -59,6 +60,13 @@ unit tests. It protects the repository query and missing-metadata behavior speci
 `test-junit-platform-native.yml` validates `common/junit-platform-native` with checkstyle, JVM
 tests, and native tests. It protects the shared native-test runtime behavior specified by
 §FS-native-tests.3.
+
+### 1.7 Common utilities PR workflow
+
+`test-common-utils.yml` validates `common/utils` with checkstyle. It protects the shared Native
+Image utility behavior specified by §common/FS-common-libraries.1,
+§common/FS-common-libraries.2, §common/FS-common-libraries.3, §common/FS-common-libraries.4, and
+§common/FS-common-libraries.7.
 
 ## 2. Publication workflows
 


### PR DESCRIPTION
## Issue

Fixes https://github.com/graalvm/native-build-tools/issues/773.

## Spec Fit

Issue 773 fits the repository CI/build-infrastructure specs: common-library validation should have an explicit pull-request gate, and Checkstyle is already centralized through the repository build logic. This change adds the cheapest ownership-boundary gate for `common/utils` instead of broadening unrelated product-plugin workflows.

## Implementation Summary

- Added `.github/workflows/test-common-utils.yml`, triggered for `common/utils`, Checkstyle config, relevant build-logic, workflow/action, and version-catalog changes.
- The new workflow runs `./gradlew :utils:checkstyleMain :utils:checkstyleTest` on Java 17.0.12.
- Updated the repository CI architecture spec with `§AR-repository-ci.1.7`.
- Updated common-library validation documentation to mention the new gate.
- Renamed underscore-separated `SchemaValidationUtilsTest` methods so the new test-source Checkstyle gate passes on the current tree.

## Validation Evidence

- `grund check` passed.
- `grund fmt . --marker --check` passed.
- `git diff --check` passed.
- `./gradlew :utils:checkstyleMain :utils:checkstyleTest` passed under Java 17.0.12.
- `./gradlew :utils:test --tests org.graalvm.buildtools.utils.SchemaValidationUtilsTest` passed under Java 17.0.12.

## Review Readiness

The latest local review reported no blocking findings and `Ready to publish: yes`.

Known validation gaps:

- `actionlint` and local `macaron` were unavailable, so GitHub Actions syntax and Macaron policy validation were not run locally. The repository Macaron workflow should cover the changed workflow in CI.
- Repository-wide checks were not run; validation stayed scoped to the CI Checkstyle fix.
- Full `./gradlew :utils:test` hit an existing network-dependent `FileUtilsTest` failure involving `https://httpbin.org/html`; the touched `SchemaValidationUtilsTest` class passed in isolation.

## Remaining Human Follow-Up

Please review the new workflow scope and confirm the CI-run Macaron/GitHub Actions checks.
