### PR TITLE
Fix Gradle system property quoting

### DIFF
--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -210,7 +210,7 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         cliArgs.add(targetOutputPath);
         options.getSystemProperties().get().forEach((n, v) -> {
             if (v != null) {
-                cliArgs.add("-D" + n + "=\"" + v + "\"");
+                cliArgs.add("-D" + n + "=" + v);
             }
         });
 

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -50,6 +50,37 @@ import spock.lang.Issue
 
 // Protects Gradle native-image argument construction for special image modes. §FS-native-invocation.3.
 class NativeImageCommandLineProviderTest extends AbstractPluginTest {
+    @Issue("https://github.com/graalvm/native-build-tools/issues/668")
+    def "does not wrap system property values in quotes"() {
+        given:
+        def project = newProject()
+        project.plugins.apply(ApplicationPlugin)
+        project.plugins.apply(NativeImagePlugin)
+        def options = project.extensions.getByType(GraalVMExtension).binaries.getByName("main")
+        options.systemProperty("propertyName", "value")
+        options.systemProperty("spacedProperty", "value with spaces")
+        options.excludeConfigArgs.set([])
+        options.configurationFileDirectories.setFrom([])
+
+        when:
+        def args = new NativeImageCommandLineProvider(
+                project.provider { options },
+                project.provider { "main" },
+                project.provider { testDirectory.toString() },
+                project.provider { testDirectory.toString() },
+                project.objects.fileProperty(),
+                project.provider { false },
+                project.provider { 25 },
+                project.provider { false }
+        ).asArguments()
+
+        then:
+        args.contains("-DpropertyName=value")
+        args.contains("-DspacedProperty=value with spaces")
+        !args.contains('-DpropertyName="value"')
+        !args.contains('-DspacedProperty="value with spaces"')
+    }
+
     @Issue("https://github.com/graalvm/native-build-tools/issues/892")
     def "does not add classpath for layer-create build with empty classpath"() {
         given:


### PR DESCRIPTION
Fixes #668

## What changed

This PR fixes Gradle native-image system property argument construction so property values are no longer wrapped in literal double quotes.

Before this change, Gradle native-image system property values could be emitted as `-Dname="value"`, which changed the actual value seen by native-image even for ordinary property values and values containing spaces.

After this change, Native Build Tools emits `-Dname=value` without injecting literal quotes, while still keeping the value as a single command-line argument.

## Why

Configured Gradle system properties are user-visible native-image inputs. The command-line builder should preserve the configured property value, not rewrite it.

## Example

Before:

A configured value containing spaces could be emitted with extra literal quotes, so native-image received a different value than the one the user configured.

After:

The same property value is emitted without injected quotes and remains a single command-line argument.

## Implementation summary

- Stop wrapping Gradle native-image system property values in literal double quotes when building `-Dname=value` command-line arguments.
- Add a focused regression test that verifies both ordinary and space-containing values are emitted without injected quotes and remain single arguments.

## Validation

- `grund check`
- `grund fmt . --marker --check`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew --no-daemon :native-gradle-plugin:test --tests org.graalvm.buildtools.gradle.tasks.NativeImageCommandLineProviderTest --rerun-tasks`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew --no-daemon :native-gradle-plugin:functionalTest --tests org.graalvm.buildtools.gradle.NativeImageOptionsTest`
