### PR TITLE
Add Maven plugin inspections to CI

### DIFF
--- a/.github/workflows/test-native-maven-plugin.yml
+++ b/.github/workflows/test-native-maven-plugin.yml
@@ -1,4 +1,4 @@
-# Pull request Maven plugin gate: runs Maven E2E matrices and GraalVM dev-build functional tests.
+# Pull request Maven plugin gate: runs Maven E2E matrices, inspections, and GraalVM dev-build functional tests.
 # §AR-repository-ci.1.4; §maven/E2E-maven-plugin-functional-tests
 name: "Test native-maven-plugin"
 
@@ -21,6 +21,22 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'graalvm/native-build-tools' }}
 
 jobs:
+  inspect-native-maven-plugin:
+    name: "Inspections"
+    runs-on: "ubuntu-22.04"
+    timeout-minutes: 20
+    steps:
+      - name: "☁️ Checkout repository"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "🔧 Prepare environment"
+        uses: ./.github/actions/prepare-environment
+        with:
+          java-version: '17.0.12'
+          graal-java-version: ''
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "❓ Inspections"
+        run: ./gradlew :native-maven-plugin:inspections
+
   populate-matrix:
     name: "Set matrix"
     runs-on: "ubuntu-22.04"

--- a/docs/spec/architecture/ci.md
+++ b/docs/spec/architecture/ci.md
@@ -14,7 +14,7 @@ tests prepare both a build JDK and a GraalVM test JDK through §AR-repository-ci
 | `check-grund-spec.yml` | Spec, code citation, sample, workflow, and build-logic changes that may affect grounded documentation. | The root workspace `grund check` run must resolve every declaration and citation across root, Gradle, and Maven namespaces; `grund fmt . --marker --check` must reject bare citation tokens. §AR-repository-ci.1.1 |
 | `macaron-check-github-actions.yml` | GitHub workflow and composite action changes. | Macaron's `check-github-actions` policy must validate workflow and composite action supply-chain rules for this repository package URL. §AR-repository-ci.1.2 |
 | `test-native-gradle-plugin.yml` | Gradle plugin, samples, common modules, workflow/action changes, and shared version catalog changes. | Gradle functional tests, configuration-cache functional tests, unit tests, and inspections. §AR-repository-ci.1.3 |
-| `test-native-maven-plugin.yml` | Maven plugin, samples, common modules, workflow/action changes, and shared version catalog changes. | Maven functional tests plus GraalVM dev-build functional tests. §AR-repository-ci.1.4 |
+| `test-native-maven-plugin.yml` | Maven plugin, samples, common modules, workflow/action changes, and shared version catalog changes. | Maven functional tests, inspections, and GraalVM dev-build functional tests. §AR-repository-ci.1.4 |
 | `test-graalvm-metadata.yml` | Reachability metadata common module and relevant workflow/action changes. | Checkstyle and unit tests for the metadata repository library. §AR-repository-ci.1.5 |
 | `test-junit-platform-native.yml` | JUnit native support and relevant workflow/action changes. | Checkstyle, JVM tests, and native tests for `common/junit-platform-native`. §AR-repository-ci.1.6 |
 
@@ -45,8 +45,8 @@ functional-test job. It is the PR gate for Gradle-facing end-to-end scenarios in
 ### 1.4 Maven plugin PR workflow
 
 `test-native-maven-plugin.yml` validates the Maven plugin through a generated functional-test
-matrix and a GraalVM dev-build functional-test job. It is the PR gate for Maven-facing
-end-to-end scenarios in §maven/E2E-maven-plugin-functional-tests.
+matrix, inspections, and a GraalVM dev-build functional-test job. It is the PR gate for
+Maven-facing end-to-end scenarios in §maven/E2E-maven-plugin-functional-tests.
 
 ### 1.5 Reachability metadata library PR workflow
 

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -96,8 +96,9 @@ sample project would, rather than reaching into compiled classes directly.
 
 ## 5. CI coverage
 
-`test-native-maven-plugin.yml` runs generated Maven functional-test matrices and GraalVM dev-build
-functional tests on pull requests. The CI workflow is specified by §root/AR-repository-ci.1.4.
+`test-native-maven-plugin.yml` runs generated Maven functional-test matrices, inspections, and
+GraalVM dev-build functional tests on pull requests. The CI workflow is specified by
+§root/AR-repository-ci.1.4.
 
 The CI matrix is the merge gate. Local runs should reproduce the failing class or reproducer first,
 then broaden to the full suite before pushing behavior changes that affect goals, Maven parameter


### PR DESCRIPTION
Fixes https://github.com/graalvm/native-build-tools/issues/658

## Spec-fit summary

Issue #658 asks for CI coverage that detects repository style issues. The change fits the existing CI architecture because the Maven plugin PR gate is the Maven-facing ownership boundary and `:native-maven-plugin:inspections` is the repository's existing style/inspection task for that module.

## Implementation summary

- Added an `inspect-native-maven-plugin` job to `test-native-maven-plugin.yml` that prepares Java 17 and runs `./gradlew :native-maven-plugin:inspections`.
- Updated the grounded CI architecture spec to declare inspections as part of the Maven plugin PR workflow evidence.
- Updated the Maven plugin E2E documentation so its CI coverage summary matches the workflow.

## Validation evidence

Review 2 reran issue-specific checks successfully:

- `git diff --check`
- `grund check`
- `grund fmt . --marker --check`
- `./gradlew :native-maven-plugin:inspections --no-daemon` under Java 17

I also reran `git diff --check` before publishing; it passed.

## Review readiness

The latest local review artifact reports no blocking findings, no non-blocking follow-ups, and `Ready to publish: yes`.

## Remaining human follow-up

Local GitHub Actions semantic/policy validation remains incomplete because `actionlint` and `macaron` are not installed locally. The repository's existing Macaron workflow should validate the workflow policy after publication. Full repository builds/tests were not rerun locally for this narrow workflow/spec change.