### PR TITLE
Add Maven plugin inspections to CI

### DIFF
--- a/.github/workflows/test-native-maven-plugin.yml
+++ b/.github/workflows/test-native-maven-plugin.yml
@@ -82,7 +82,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "❓ Run inspections"
         run: >
-          ./gradlew :native-maven-plugin:publishAllPublicationsToCommonRepository
+          ./gradlew :graalvm-reachability-metadata:publishAllPublicationsToCommonRepository
+          :native-maven-plugin:publishAllPublicationsToCommonRepository
           :native-maven-plugin:inspections --no-parallel
 
   functional-testing-maven-plugin-dev:

--- a/.github/workflows/test-native-maven-plugin.yml
+++ b/.github/workflows/test-native-maven-plugin.yml
@@ -81,7 +81,9 @@ jobs:
           graal-java-version: ''
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "❓ Run inspections"
-        run: ./gradlew :native-maven-plugin:inspections
+        run: >
+          ./gradlew :native-maven-plugin:publishAllPublicationsToCommonRepository
+          :native-maven-plugin:inspections --no-parallel
 
   functional-testing-maven-plugin-dev:
     name: "Functional testing (GraalVM Dev Build)"

--- a/.github/workflows/test-native-maven-plugin.yml
+++ b/.github/workflows/test-native-maven-plugin.yml
@@ -1,4 +1,4 @@
-# Pull request Maven plugin gate: runs Maven E2E matrices and GraalVM dev-build functional tests.
+# Pull request Maven plugin gate: runs Maven E2E matrices, inspections, and GraalVM dev-build functional tests.
 # §AR-repository-ci.1.4; §maven/E2E-functional-tests
 name: "Test native-maven-plugin"
 
@@ -66,6 +66,22 @@ jobs:
         with:
           name: maven-functional-tests-results-${{ strategy.job-index }}-${{ matrix.os }}-${{ matrix.test }}
           path: native-maven-plugin/build/reports/tests/
+
+  inspect-native-maven-plugin:
+    name: "Inspections"
+    runs-on: "ubuntu-22.04"
+    timeout-minutes: 20
+    steps:
+      - name: "☁️ Checkout repository"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "🔧 Prepare environment"
+        uses: ./.github/actions/prepare-environment
+        with:
+          java-version: '17.0.12'
+          graal-java-version: ''
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "❓ Run inspections"
+        run: ./gradlew :native-maven-plugin:inspections
 
   functional-testing-maven-plugin-dev:
     name: "Functional testing (GraalVM Dev Build)"

--- a/docs/spec/architecture/ci.md
+++ b/docs/spec/architecture/ci.md
@@ -14,7 +14,7 @@ tests prepare both a build JDK and a GraalVM test JDK through [§AR-repository-c
 | `check-grund-spec.yml` | Spec, code citation, sample, workflow, build-logic, and local hook changes that may affect grounded documentation. | The root workspace `grund check` run must resolve every declaration and citation across root, Gradle, and Maven namespaces; `grund fmt . --marker --cross-refs --check` must reject bare citation tokens and unlinked Markdown citations. [§AR-repository-ci.1.1](ci.md#11-grund-validation-workflow) |
 | `macaron-check-github-actions.yml` | GitHub workflow and composite action changes. | Macaron's `check-github-actions` policy must validate workflow and composite action supply-chain rules for this repository package URL. [§AR-repository-ci.1.2](ci.md#12-github-actions-macaron-policy-workflow) |
 | `test-native-gradle-plugin.yml` | Gradle plugin, samples, common modules, workflow/action changes, and shared version catalog changes. | Gradle functional tests, configuration-cache functional tests, unit tests, and inspections. [§AR-repository-ci.1.3](ci.md#13-gradle-plugin-pr-workflow) |
-| `test-native-maven-plugin.yml` | Maven plugin, samples, common modules, workflow/action changes, and shared version catalog changes. | Maven functional tests plus GraalVM dev-build functional tests. [§AR-repository-ci.1.4](ci.md#14-maven-plugin-pr-workflow) |
+| `test-native-maven-plugin.yml` | Maven plugin, samples, common modules, workflow/action changes, and shared version catalog changes. | Maven functional tests, inspections, and GraalVM dev-build functional tests. [§AR-repository-ci.1.4](ci.md#14-maven-plugin-pr-workflow) |
 | `test-graalvm-metadata.yml` | Reachability metadata common module and relevant workflow/action changes. | Checkstyle and unit tests for the metadata repository library. [§AR-repository-ci.1.5](ci.md#15-reachability-metadata-library-pr-workflow) |
 | `test-junit-platform-native.yml` | JUnit native support and relevant workflow/action changes. | Checkstyle, JVM tests, and native tests for `common/junit-platform-native`. [§AR-repository-ci.1.6](ci.md#16-junit-native-support-pr-workflow) |
 
@@ -47,7 +47,7 @@ functional-test job. It is the PR gate for Gradle-facing end-to-end scenarios in
 ### 1.4 Maven plugin PR workflow
 
 `test-native-maven-plugin.yml` validates the Maven plugin through a generated functional-test
-matrix and a GraalVM dev-build functional-test job. It is the PR gate for Maven-facing
+matrix, inspections, and a GraalVM dev-build functional-test job. It is the PR gate for Maven-facing
 end-to-end scenarios in [§maven/E2E-functional-tests](../../../native-maven-plugin/docs/e2e.md#e2e-functional-tests-maven-functional-tests-exercise-real-maven-native-image-builds).
 
 ### 1.5 Reachability metadata library PR workflow

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -96,7 +96,8 @@ sample project would, rather than reaching into compiled classes directly.
 
 ## 5. CI coverage
 
-`test-native-maven-plugin.yml` runs generated Maven functional-test matrices and GraalVM dev-build
+`test-native-maven-plugin.yml` runs generated Maven functional-test matrices, Maven plugin
+inspections, and GraalVM dev-build
 functional tests on pull requests. The CI workflow is specified by [§root/AR-repository-ci.1.4](../../docs/spec/architecture/ci.md#14-maven-plugin-pr-workflow).
 
 The CI matrix is the merge gate. Local runs should reproduce the failing class or reproducer first,


### PR DESCRIPTION
Resolves #909

## What changed

This PR adds Maven plugin inspections to the Native Build Tools CI workflow.

Before this change, `test-native-maven-plugin.yml` covered Maven functional tests and GraalVM dev-build functional tests, but it did not include the Maven plugin inspections task.

After this change, the workflow runs `./gradlew :native-maven-plugin:inspections` as its own CI job.

## Why

This closes a gap in the Maven plugin workflow boundary by making inspection failures visible in the same CI workflow that already owns Maven plugin functional coverage.

## Example

Before:

A change could pass the existing Maven plugin workflow jobs while still breaking `:native-maven-plugin:inspections`, because that task was not part of the workflow.

After:

The same workflow now includes an `inspect-native-maven-plugin` job that fails when Maven plugin inspections fail.

## Implementation summary

- Add an `inspect-native-maven-plugin` job to `.github/workflows/test-native-maven-plugin.yml`.
- Reuse the existing environment-preparation action with Java `17.0.12` and without a separate GraalVM test JDK.
- Update the workflow summary comment and the grounded CI architecture and Maven E2E docs.

## Validation

- `git diff --check`
- `grund check`
- `grund fmt . --marker --check`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal PATH=/home/jovan/.sdkman/candidates/java/17.0.12-graal/bin:$PATH ./gradlew :native-maven-plugin:inspections --no-daemon`
