### PR TITLE
Fix Maven metadata repository fallback mutation

### DIFF
--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -181,8 +181,6 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
             String metadataUrl = String.format(METADATA_REPO_URL_TEMPLATE, VersionInfo.METADATA_REPO_VERSION);
             try {
                 targetUrl = new URI(metadataUrl).toURL();
-                // TODO investigate if the following line is necessary (Issue: https://github.com/graalvm/native-build-tools/issues/560)
-                metadataRepositoryConfiguration.setUrl(targetUrl);
             } catch (URISyntaxException | MalformedURLException e) {
                 throw new RuntimeException(e);
             }
@@ -214,8 +212,6 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
                     String metadataUrl = String.format(METADATA_REPO_URL_TEMPLATE, version);
                     try {
                         targetUrl = new URI(metadataUrl).toURL();
-                        // TODO investigate if the following line is necessary (Issue: https://github.com/graalvm/native-build-tools/issues/560)
-                        metadataRepositoryConfiguration.setUrl(targetUrl);
                     } catch (URISyntaxException | MalformedURLException e) {
                         throw new RuntimeException(e);
                     }

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeMojoTest.groovy
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.maven
+
+import org.codehaus.plexus.logging.Logger
+import org.graalvm.buildtools.VersionInfo
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static org.graalvm.buildtools.utils.SharedConstants.METADATA_REPO_URL_TEMPLATE
+
+// Protects Maven reachability metadata fallback resolution. §FS-resources-and-metadata.2.
+class AbstractNativeMojoTest extends Specification {
+    @TempDir
+    Path testDirectory
+
+    void "default repository falls back to release URL when Maven artifact cannot be resolved"() {
+        given:
+        def mojo = new MetadataFallbackMojo(testDirectory)
+        mojo.reachabilityMetadataOutputDirectory = testDirectory.resolve("metadata").toFile()
+        mojo.metadataRepositoryConfiguration = null
+        mojo.logger = Mock(Logger)
+
+        when:
+        mojo.configureMetadataRepository()
+
+        then:
+        mojo.downloadedUrl.toString() == String.format(METADATA_REPO_URL_TEMPLATE, VersionInfo.METADATA_REPO_VERSION)
+        mojo.metadataRepository != null
+        mojo.metadataRepositoryConfiguration == null
+    }
+
+    private static class MetadataFallbackMojo extends AbstractNativeMojo {
+        private final Path archive
+
+        URL downloadedUrl
+
+        private MetadataFallbackMojo(Path testDirectory) {
+            archive = Files.createFile(testDirectory.resolve("repo.zip"))
+        }
+
+        @Override
+        void execute() {
+        }
+
+        @Override
+        protected URL resolveDefaultMetadataRepositoryUrl() {
+            null
+        }
+
+        @Override
+        protected Optional<Path> downloadMetadata(URL url, Path destination) {
+            downloadedUrl = url
+            Optional.of(archive)
+        }
+
+        @Override
+        protected Path unzipLocalMetadata(Path localPath, Path destination) {
+            Files.createDirectories(destination.resolve("schemas"))
+            Files.createFile(destination.resolve("schemas/metadata-library-index-schema-v2.0.0.json"))
+            Files.createFile(destination.resolve("schemas/library-and-framework-list-schema-v1.0.0.json"))
+            Files.createFile(destination.resolve("schemas/reachability-metadata-schema-v1.2.0.json"))
+            destination
+        }
+    }
+}


### PR DESCRIPTION
Resolves #913

## What changed

This PR fixes Maven reachability metadata fallback handling so fallback URLs are used for downloading metadata without mutating the configured metadata repository object.

Before this change, the fallback path could rewrite the metadata repository configuration by setting the fallback URL directly onto the repository configuration object.

After this change, fallback downloads use the fallback URL as an execution detail while leaving the configured repository object unchanged.

## Why

Repository fallback behavior should not silently rewrite the user's configured metadata repository state. Keeping the fallback path non-mutating makes repository selection easier to reason about and safer for later logic that reads that configuration.

## Example

Before:

If Maven artifact resolution could not resolve the default metadata artifact, the fallback path could mutate the metadata repository configuration by replacing its URL with the fallback target.

After:

The same fallback download path uses the fallback URL only for the download attempt and leaves the original repository configuration untouched.

## Implementation summary

- Remove the fallback `setUrl(targetUrl)` mutations in `AbstractNativeMojo`.
- Remove the stale TODO comments tied to the older fallback behavior.
- Add focused Spock coverage for the default metadata repository fallback path when Maven artifact resolution cannot resolve the default metadata artifact.

## Validation

- `git diff --check`
- `grund check`
- `grund fmt . --marker --check`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal PATH=/home/jovan/.sdkman/candidates/java/17.0.12-graal/bin:$PATH ./gradlew :native-maven-plugin:test --tests org.graalvm.buildtools.maven.AbstractNativeMojoTest`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/21.0.11-graal PATH=/home/jovan/.sdkman/candidates/java/17.0.12-graal/bin:$PATH ./gradlew :native-maven-plugin:functionalTest --tests "org.graalvm.buildtools.maven.*Metadata*"`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal PATH=/home/jovan/.sdkman/candidates/java/17.0.12-graal/bin:$PATH ./gradlew :native-maven-plugin:inspections`
