### PR TITLE
Add regression tests for Windows args-file paths

### DIFF
--- a/common/utils/build.gradle.kts
+++ b/common/utils/build.gradle.kts
@@ -52,5 +52,6 @@ dependencies {
     implementation(libs.openjson)
     testImplementation(platform(libs.test.junit.bom))
     testImplementation(libs.test.junit.jupiter.core)
+    testImplementation(libs.test.jimfs)
     testRuntimeOnly(libs.test.junit.platform.launcher)
 }

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
@@ -93,16 +93,16 @@ public class NativeImageUtils {
 
     public static List<String> convertToArgsFile(List<String> cliArgs, Path outputDir, Path projectDir) {
         try {
-            boolean ignored = outputDir.toFile().mkdirs();
-            File tmpFile = Files.createTempFile(outputDir, "native-image-", ".args").toFile();
+            Files.createDirectories(outputDir);
+            Path tmpFile = Files.createTempFile(outputDir, "native-image-", ".args");
             // tmpFile.deleteOnExit();
             cliArgs = cliArgs.stream().map(NativeImageUtils::escapeArg).collect(Collectors.toList());
-            Files.write(tmpFile.toPath(), cliArgs, StandardCharsets.UTF_8, StandardOpenOption.CREATE);
+            Files.write(tmpFile, cliArgs, StandardCharsets.UTF_8, StandardOpenOption.CREATE);
 
-            Path resultingPath = tmpFile.toPath().toAbsolutePath();
+            Path resultingPath = tmpFile.toAbsolutePath();
             if (projectDir != null) { // We know where the project dir is, so want to use relative paths
                 Path absProjectDir = projectDir.toAbsolutePath();
-                // Only relativize if both paths are on the same file system (same drive on Windows)
+                // Only relativize if both paths are on the same file system root. §FS-common-libraries.1.
                 if (resultingPath.getRoot() != null && resultingPath.getRoot().equals(absProjectDir.getRoot())) {
                     resultingPath = absProjectDir.relativize(resultingPath);
                 }

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageUtilsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageUtilsTest.java
@@ -40,9 +40,16 @@
  */
 package org.graalvm.buildtools.utils;
 
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.regex.Pattern;
 
 class NativeImageUtilsTest {
@@ -188,6 +195,42 @@ class NativeImageUtilsTest {
         Assertions.assertEquals(Pattern.quote("/foo/bar"), NativeImageUtils.escapeArg(Pattern.quote("/foo/bar")));
         Assertions.assertEquals(Pattern.quote("c:\\foo\\bar"), NativeImageUtils.escapeArg(Pattern.quote("c:\\foo\\bar")));
         Assertions.assertEquals(Pattern.quote("c:\\foo\\bar baz"), NativeImageUtils.escapeArg(Pattern.quote("c:\\foo\\bar baz")));
+    }
+
+    @Test
+    void convertToArgsFileUsesRelativePathWhenOutputAndProjectShareRoot() throws IOException {
+        try (FileSystem fs = newWindowsFileSystem()) {
+            Path projectDir = fs.getPath("D:\\project");
+            Path outputDir = projectDir.resolve("build\\native\\tmp");
+
+            List<String> args = NativeImageUtils.convertToArgsFile(List.of("--initialize-at-build-time=org.test"), outputDir, projectDir);
+
+            Assertions.assertEquals(1, args.size());
+            Path argsFile = fs.getPath(args.get(0).substring(1));
+            Assertions.assertFalse(argsFile.isAbsolute());
+            Assertions.assertTrue(Files.exists(projectDir.resolve(argsFile)));
+        }
+    }
+
+    @Test
+    void convertToArgsFileKeepsAbsolutePathWhenOutputAndProjectHaveDifferentRoots() throws IOException {
+        try (FileSystem fs = newWindowsFileSystem()) {
+            Path outputDir = fs.getPath("C:\\temp");
+            Path projectDir = fs.getPath("D:\\project");
+
+            // Protects cross-drive argument-file conversion from unsafe relativization. §FS-common-libraries.1.
+            List<String> args = NativeImageUtils.convertToArgsFile(List.of("-H:Name=application"), outputDir, projectDir);
+
+            Assertions.assertEquals(1, args.size());
+            Path argsFile = fs.getPath(args.get(0).substring(1));
+            Assertions.assertTrue(argsFile.isAbsolute());
+            Assertions.assertTrue(argsFile.startsWith(outputDir));
+            Assertions.assertTrue(Files.exists(argsFile));
+        }
+    }
+
+    private static FileSystem newWindowsFileSystem() {
+        return Jimfs.newFileSystem(Configuration.windows().toBuilder().setRoots("C:\\", "D:\\").build());
     }
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ graalvm = "23.0.2"
 openjson = "1.0.13"
 junitPlatform = "1.13.0"
 junitJupiter = "5.13.0"
+jimfs = "1.3.0"
 slf4j = "1.7.9"
 groovy = "3.0.11"
 jetty = "11.0.11"
@@ -37,6 +38,7 @@ test-junit-jupiter-core = { module = "org.junit.jupiter:junit-jupiter", version 
 test-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version = "" }
 test-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version = "" }
 test-junit-vintage = { module = "org.junit.vintage:junit-vintage-engine", version = "" }
+test-jimfs = { module = "com.google.jimfs:jimfs", version.ref = "jimfs" }
 test-spock = { module = "org.spockframework:spock-core", version.ref = "spock" }
 
 graalvm-svm = { module = "org.graalvm.nativeimage:svm", version.ref = "graalvm" }


### PR DESCRIPTION
Fixes #754

## What changed

This PR adds regression coverage for Windows args-file path handling in the shared common utilities.

Before this change, the implementation already aimed to avoid relativizing paths across different Windows roots, but there was no focused regression coverage proving that behavior.

After this change, the shared args-file conversion logic is covered by Windows-root regression tests for both same-root and cross-root cases.

## Why

Path handling bugs at this layer affect both Gradle and Maven native-image invocation. Adding regression coverage here protects shared behavior without relying on a Windows machine or a full product-level reproduction.

## Example

Before:

A Windows args-file path on the same drive and one on a different drive were both handled by the same shared utility path logic, but only manual reasoning or ad hoc testing could confirm whether the cross-root case stayed absolute.

After:

The shared utility now has Jimfs-backed Windows regression coverage verifying that same-root paths can be relativized while cross-root paths remain absolute.

## Implementation summary

- Keep `NativeImageUtils.convertToArgsFile` on `Path` and `Files` APIs so it can be exercised with alternate file-system providers.
- Add Jimfs-backed Windows filesystem tests covering same-root relative args-file paths and cross-root absolute args-file paths.
- Add Jimfs as a test-only dependency for the common utilities module.

## Validation

- `grund check`
- `grund fmt . --marker --check`
- `git diff --check`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal ./gradlew :utils:test --tests org.graalvm.buildtools.utils.NativeImageUtilsTest --rerun-tasks`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:test :native-gradle-plugin:inspections`
