### PR TITLE
Support autodetected Jupiter extensions in native tests

### DIFF
--- a/common/junit-platform-native/gradle/native-image-testing.gradle
+++ b/common/junit-platform-native/gradle/native-image-testing.gradle
@@ -109,6 +109,7 @@ abstract class NativeTestArgumentProvider implements CommandLineArgumentProvider
                 "--no-fallback",
                 "--features=org.graalvm.junit.platform.JUnitPlatformFeature",
                 "-o", "native-image-tests",
+                "-Djunit.jupiter.extensions.autodetection.enabled=true",
                 "-Djunit.platform.listeners.uid.tracking.output.dir=${testIdsDir.get().asFile.absolutePath}"
         ]
 
@@ -159,5 +160,8 @@ tasks.register("nativeTest", Exec) {
     dependsOn nativeTestCompile
     workingDir = "${buildDir}"
     executable = "${buildDir}/native-image-tests"
-    args = ["-Djunit.platform.listeners.uid.tracking.output.dir=${testIdsDir.get().asFile.absolutePath}"]
+    args = [
+            "-Djunit.jupiter.extensions.autodetection.enabled=true",
+            "-Djunit.platform.listeners.uid.tracking.output.dir=${testIdsDir.get().asFile.absolutePath}"
+    ]
 }

--- a/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java
+++ b/common/junit-platform-native/src/main/java/org/graalvm/junit/platform/config/jupiter/JupiterConfigProvider.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.params.aggregator.AggregateWith;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -61,10 +62,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ServiceLoader;
 
 import static org.graalvm.junit.platform.JUnitPlatformFeatureUtils.debug;
 
 public class JupiterConfigProvider extends PluginConfigProvider {
+    private static final String EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME = "junit.jupiter.extensions.autodetection.enabled";
 
     @Override
     public void onLoad() {
@@ -72,6 +75,7 @@ public class JupiterConfigProvider extends PluginConfigProvider {
         JUnitPlatformFeatureUtils.registerAllClassMembersForReflection(Utils.toClasses(
                 "org.junit.jupiter.engine.extension.TimeoutExtension$ExecutorResource",
                 "org.junit.jupiter.engine.extension.TimeoutInvocationFactory$SingleThreadExecutorResource"));
+        registerAutoDetectedExtensionsForReflection();
     }
 
     @Override
@@ -153,6 +157,23 @@ public class JupiterConfigProvider extends PluginConfigProvider {
             }
         }
         return classList.toArray(new Class<?>[0]);
+    }
+
+    private void registerAutoDetectedExtensionsForReflection() {
+        try {
+            if (Boolean.getBoolean(EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME)) {
+                ServiceLoader.load(Extension.class, applicationClassLoader)
+                        .stream()
+                        .map(ServiceLoader.Provider::type)
+                        .forEach(extensionType -> {
+                            // Service-registered Jupiter extensions need runtime reflection metadata in native tests. §root/FS-native-tests.2.
+                            debug("Registering auto-detected Jupiter extension for reflection: %s", extensionType.getName());
+                            JUnitPlatformFeatureUtils.registerAllClassMembersForReflection(extensionType);
+                        });
+            }
+        } catch (NoClassDefFoundError e) {
+            debug("Cannot register auto-detected Jupiter extensions. Please verify that you have dependency that includes 'org.junit.jupiter.api' if you want to use these extensions.");
+        }
     }
 
     public static void handleEnumSource(Method method, EnumSource source) {

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/AutodetectedExtension.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/AutodetectedExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,67 +38,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-plugins {
-    id 'java-library'
-    id 'checkstyle'
-    id 'signing'
-    id 'org.graalvm.build.java'
-    id 'org.graalvm.build.publishing'
-}
 
-maven {
-    name = "JUnit Platform Native"
-    description = 'JUnit Platform support for GraalVM Native Image'
-}
-dependencies {
-    compileOnly libs.graalvm.svm
-    compileOnly(platform(libs.test.junit.bom))
-    compileOnly libs.test.junit.platform.console
-    compileOnly libs.test.junit.platform.launcher
-    compileOnly libs.test.junit.jupiter.core
-    testImplementation libs.test.junit.vintage
+package org.graalvm.junit.jupiter;
 
-    testImplementation libs.test.junit.jupiter.core
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-    testRuntimeOnly(platform(libs.test.junit.bom))
-    testCompileOnly(platform(libs.test.junit.bom))
-    testRuntimeOnly libs.test.junit.platform.console
-    testRuntimeOnly libs.test.junit.platform.launcher
-    testRuntimeOnly libs.test.junit.jupiter.core
-}
+public class AutodetectedExtension implements BeforeEachCallback, BeforeTestExecutionCallback {
 
-apply from: "gradle/native-image-testing.gradle"
-
-tasks.named('test') {
-    doFirst {
-        delete { delete testIdsDir.get().asFile }
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        System.clearProperty(AutodetectedExtensionTests.EXTENSION_PROPERTY);
     }
-    useJUnitPlatform() {
-        systemProperty('junit.jupiter.extensions.autodetection.enabled', true)
-        systemProperty('junit.platform.listeners.uid.tracking.enabled', true)
-        systemProperty('junit.platform.listeners.uid.tracking.output.dir', "${testIdsDir.get().asFile.absolutePath}/test_ids")
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) {
+        System.setProperty(AutodetectedExtensionTests.EXTENSION_PROPERTY, "true");
     }
-}
-
-tasks.withType(Test).configureEach {
-    testLogging {
-        events "standardOut", "passed", "skipped", "failed"
-    }
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-        }
-    }
-}
-
-signing {
-    required { gradle.taskGraph.hasTask("publish") }
-    sign publishing.publications.mavenJava
-}
-
-tasks.withType(Checkstyle).configureEach {
-    setConfigFile(layout.projectDirectory.dir("../../config/checkstyle.xml").asFile)
 }

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/AutodetectedExtensionTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/AutodetectedExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,67 +38,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-plugins {
-    id 'java-library'
-    id 'checkstyle'
-    id 'signing'
-    id 'org.graalvm.build.java'
-    id 'org.graalvm.build.publishing'
-}
 
-maven {
-    name = "JUnit Platform Native"
-    description = 'JUnit Platform support for GraalVM Native Image'
-}
-dependencies {
-    compileOnly libs.graalvm.svm
-    compileOnly(platform(libs.test.junit.bom))
-    compileOnly libs.test.junit.platform.console
-    compileOnly libs.test.junit.platform.launcher
-    compileOnly libs.test.junit.jupiter.core
-    testImplementation libs.test.junit.vintage
+package org.graalvm.junit.jupiter;
 
-    testImplementation libs.test.junit.jupiter.core
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-    testRuntimeOnly(platform(libs.test.junit.bom))
-    testCompileOnly(platform(libs.test.junit.bom))
-    testRuntimeOnly libs.test.junit.platform.console
-    testRuntimeOnly libs.test.junit.platform.launcher
-    testRuntimeOnly libs.test.junit.jupiter.core
-}
+class AutodetectedExtensionTests {
+    static final String EXTENSION_PROPERTY = "org.graalvm.junit.jupiter.AutodetectedExtension.invoked";
 
-apply from: "gradle/native-image-testing.gradle"
-
-tasks.named('test') {
-    doFirst {
-        delete { delete testIdsDir.get().asFile }
+    @Test
+    void appliesServiceRegisteredExtension() {
+        // Verifies native-test support for Jupiter service-registered extensions. §root/FS-native-tests.2.
+        Assertions.assertEquals("true", System.getProperty(EXTENSION_PROPERTY));
     }
-    useJUnitPlatform() {
-        systemProperty('junit.jupiter.extensions.autodetection.enabled', true)
-        systemProperty('junit.platform.listeners.uid.tracking.enabled', true)
-        systemProperty('junit.platform.listeners.uid.tracking.output.dir', "${testIdsDir.get().asFile.absolutePath}/test_ids")
-    }
-}
-
-tasks.withType(Test).configureEach {
-    testLogging {
-        events "standardOut", "passed", "skipped", "failed"
-    }
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-        }
-    }
-}
-
-signing {
-    required { gradle.taskGraph.hasTask("publish") }
-    sign publishing.publications.mavenJava
-}
-
-tasks.withType(Checkstyle).configureEach {
-    setConfigFile(layout.projectDirectory.dir("../../config/checkstyle.xml").asFile)
 }

--- a/common/junit-platform-native/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/common/junit-platform-native/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.graalvm.junit.jupiter.AutodetectedExtension

--- a/docs/spec/functional/native-tests.md
+++ b/docs/spec/functional/native-tests.md
@@ -56,11 +56,13 @@ following must happen during image build:
 - Provider classes for JUnit Platform, Jupiter, and Vintage must contribute their Native Image
   metadata when the corresponding engine is on the test classpath. New providers may be added
   when the repository supports new JUnit Platform behavior.
+- When Jupiter extension autodetection is enabled, service-registered
+  `org.junit.jupiter.api.extension.Extension` providers must be available to the native test image.
 
 The repository's native-test fixtures cover nested tests, method sources, CSV sources, enum
-sources, converters, aggregators, class ordering, and display-name generation. The shared launcher
-and feature must preserve JUnit Platform semantics for any scenario the repository's fixtures
-exercise.
+sources, converters, aggregators, class ordering, display-name generation, and service-registered
+Jupiter extensions. The shared launcher and feature must preserve JUnit Platform semantics for
+any scenario the repository's fixtures exercise.
 
 ## 3. Native launcher and feature
 


### PR DESCRIPTION
Fixes #652

## What changed

This PR adds support for JUnit Jupiter extensions discovered through `META-INF/services` when `junit.jupiter.extensions.autodetection.enabled=true` is used in native tests.

Before this change, service-registered Jupiter extensions could be present and autodetection could be enabled, but the extension classes were not registered for native-image reflection.

After this change, service-loaded Jupiter extensions are registered for reflection when autodetection is enabled, so they can participate in native test execution.

## Why

Users expect Jupiter extension autodetection to work the same way in native tests as it does in the JVM test path when the required service registration is present.

## Example

Before:

A Jupiter extension registered through `META-INF/services/org.junit.jupiter.api.extension.Extension` could be discovered conceptually, but the native test path would still fail to apply it because the extension class was not prepared for native-image reflection.

After:

The same service-registered extension is reflected into the image and runs successfully when autodetection is enabled.

## Implementation summary

- Register service-loaded `org.junit.jupiter.api.extension.Extension` provider classes for reflection from `JupiterConfigProvider` when Jupiter extension autodetection is enabled.
- Use `ServiceLoader.Provider::type` so user extensions are not instantiated during image setup.
- Enable the autodetection flag for the module's JVM and native test paths.
- Add a service-provider fixture and test proving the auto-detected extension runs.

## Validation

- `grund check`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew --no-daemon :junit-platform-native:checkstyleMain :junit-platform-native:checkstyleTest`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew --no-daemon :junit-platform-native:test`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew --no-daemon :junit-platform-native:nativeTest`
- `git diff --check`
