### PR TITLE
Document skipNativeBuildForPom for Maven aggregators

### DIFF
--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -64,7 +64,6 @@ The following configuration options are available:
    application modules to build their native images. It does not select the application module
    automatically; configure or run the native build in the module that owns the main class. To
    enable it, add:
-// §maven/FS-maven-native-image-builds.2
 [source,xml, role="multi-language-sample"]
 ----
 <skipNativeBuildForPom>true</skipNativeBuildForPom>

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -55,6 +55,20 @@ The following configuration options are available:
 ----
 <skipNativeBuild>true</skipNativeBuild>
 ----
+`<skipNativeBuildForPom>`::
+   To skip generation of the native image only for Maven projects with `pom` packaging, use
+   `<skipNativeBuildForPom>`. This option defaults to `false` for compatibility. It is useful in
+   multi-module builds where a parent aggregator POM shares the native profile or plugin
+   configuration with child modules but does not contain the application main class. Enabling this
+   option prevents native image generation in the aggregator project while still allowing
+   application modules to build their native images. It does not select the application module
+   automatically; configure or run the native build in the module that owns the main class. To
+   enable it, add:
+// §maven/FS-maven-native-image-builds.2
+[source,xml, role="multi-language-sample"]
+----
+<skipNativeBuildForPom>true</skipNativeBuildForPom>
+----
 `<skipNativeTests>`::
    To skip generation and execution of the native image compiled tests, add:
 [source,xml, role="multi-language-sample"]


### PR DESCRIPTION
Fixes #920

## What changed

This PR documents `<skipNativeBuildForPom>` for Maven aggregator projects.

Before this change, the Maven docs did not clearly explain that `skipNativeBuildForPom` skips native image generation only for projects with `pom` packaging while still allowing one native profile to be shared across aggregator and leaf modules.

After this change, the docs explain the option, its default value, and the multi-module aggregator use case.

## Why

This makes it easier to configure multi-module Maven builds where the aggregator project should not attempt native image generation, but application modules still should.

## Example

Before:

Users configuring one native profile across a parent aggregator POM and application modules had to infer how to prevent the aggregator itself from trying to build a native image.

After:

The docs now show that `<skipNativeBuildForPom>` can be enabled for `pom` packaging while still leaving the actual native build to the module that owns the main class.

## Implementation summary

- Document `<skipNativeBuildForPom>` next to `<skipNativeBuild>` in the Maven plugin docs.
- Explain that it skips native image generation only for Maven projects with `pom` packaging.
- Document the default `false` value for compatibility.
- Cover the multi-module parent aggregator use case and clarify that users still need to run or configure the native build in the application-owning module.

## Validation

- `grund check`
- `grund fmt . --marker --check`
- `git diff --check`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :docs:asciidoctor --rerun-tasks`
