### PR TITLE
Document Gradle tracing agent default mode

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -248,6 +248,10 @@ The agent can run in multiple modes that dictate how the metadata is collected a
 * `tasksToInstrumentPredicate` - By default, when `-Pagent` is specified, all tasks extending `JavaForkOptions` are instrumented.
 This can be limited to only specific tasks that match this predicate.
 
+When you pass `-Pagent` without an explicit mode, the plugin uses `defaultMode`.
+The default `defaultMode` is `standard`, except projects applying Gradle's `java-library` plugin default to `conditional`.
+Because `conditional` mode requires `userCodeFilterPath`, library projects should either configure a conditional user-code filter or run with an explicit mode, for example `-Pagent=standard`.
+
 [source,groovy,subs="verbatim,attributes", role="multi-language-sample"]
 ----
 agent {

--- a/native-gradle-plugin/docs/functional/tracing-agent.md
+++ b/native-gradle-plugin/docs/functional/tracing-agent.md
@@ -7,7 +7,8 @@ The Gradle plugin exposes the shared tracing-agent workflow from
 
 The agent can be enabled by DSL configuration or with the `-Pagent` Gradle property. When the
 property names a mode, that mode must override the configured default mode for the instrumented
-run.
+run. The default mode convention is `standard`, except projects that apply Gradle's
+`java-library` plugin use `conditional` as the default convention.
 
 ## 2. Instrumented tasks
 


### PR DESCRIPTION
Fixes #554

## What changed

This PR clarifies the Gradle tracing-agent docs around the default agent mode.

Before this change, users could read the docs and still miss an important behavior: bare `-Pagent` uses the configured `defaultMode`, and projects applying Gradle's `java-library` plugin default that mode to `conditional`.

After this change, the docs explain how bare `-Pagent`, `defaultMode`, `java-library`, `conditional`, and `userCodeFilterPath` interact.

## Why

Without this clarification, users can think `-Pagent` always behaves like the standard tracing-agent mode, even in library projects where the default mode is intentionally different.

## Example

Before:

A `java-library` project could run with bare `-Pagent` and unexpectedly get `conditional` mode behavior unless the user already knew about the library default.

After:

The docs now explain that library projects default to `conditional`, and that users can either provide a conditional `userCodeFilterPath` or ask for an explicit mode such as `-Pagent=standard`.

## Implementation summary

- Update the public Gradle plugin docs to explain the interaction between bare `-Pagent`, `defaultMode`, `java-library`, `conditional`, and `userCodeFilterPath`.
- Update the Gradle tracing-agent functional spec docs to ground the existing `java-library` default-mode convention.
- Leave plugin behavior unchanged; this is a documentation clarification only.

## Validation

- `grund fmt . --marker --check`
- `grund check`
- `git diff --check`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal PATH=/home/jovan/.sdkman/candidates/java/17.0.12-graal/bin:$PATH ./gradlew :docs:asciidoctor`
