### PR TITLE
Fix custom native test classpath wiring

### DIFF
--- a/native-gradle-plugin/docs/functional/native-tests.md
+++ b/native-gradle-plugin/docs/functional/native-tests.md
@@ -21,6 +21,13 @@ test {
 }
 ```
 
+### 1.1 Custom test binaries
+
+A custom test binary registered with `registerTestBinary` must derive its classes, resources,
+runtime classpath, test identifiers, and JUnit native support from the source set and `Test` task
+selected by `usingSourceSet` and `forTestTask`. A custom source set must not have to inherit from
+the default `test` source set configurations to build or run as a native test image.
+
 ## 2. Native test execution
 
 `nativeTestCompile` builds the native test image. `nativeTest` runs that image unless the test

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
@@ -46,7 +46,7 @@ import org.graalvm.buildtools.gradle.fixtures.TestResults
 import spock.lang.Issue
 import spock.lang.Unroll
 
-// Protects Gradle native-test task wiring and execution. §FS-native-tests.1 §FS-native-tests.2.
+// Protects Gradle native-test task wiring and execution. §FS-native-tests.1 §FS-native-tests.1.1 §FS-native-tests.2.
 class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
     @Unroll("can execute tests in a native image with JUnit Platform #junitVersion")
     def "can build a native image and run it"() {
@@ -197,6 +197,25 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
             skipped ':nativeTestCompile', ':nativeTest'
             doesNotContain ':build'
         }
+
+        where:
+        junitVersion = System.getProperty('versions.junit')
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/702")
+    @Unroll("custom test image classpath follows custom source set with JUnit Platform #junitVersion")
+    def "custom test image classpath follows custom source set"() {
+        given:
+        withSample("java-application-with-custom-tests")
+
+        when:
+        run 'dependencies', '--configuration', 'nativeImageIntegTestClasspath'
+
+        then:
+        outputContains "project :"
+        outputContains "org.junit.jupiter:junit-jupiter"
+        outputContains "org.junit.platform:junit-platform-launcher"
+        outputContains "org.graalvm.buildtools:junit-platform-native"
 
         where:
         junitVersion = System.getProperty('versions.junit')

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
@@ -213,7 +213,6 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         run 'dependencies', '--configuration', 'nativeImageIntegTestClasspath'
 
         then:
-        outputContains "project :"
         outputContains "org.junit.jupiter:junit-jupiter"
         outputContains "org.junit.platform:junit-platform-launcher"
         outputContains "org.graalvm.buildtools:junit-platform-native"

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithTestsFunctionalTest.groovy
@@ -46,7 +46,7 @@ import org.graalvm.buildtools.gradle.fixtures.TestResults
 import spock.lang.Issue
 import spock.lang.Unroll
 
-// Protects Gradle native-test task wiring and execution. §FS-native-tests.1 §FS-native-tests.1.1 §FS-native-tests.2.
+// Protects Gradle native-test task wiring and execution. §FS-native-tests.1 §FS-native-tests.2.
 class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
     @Unroll("can execute tests in a native image with JUnit Platform #junitVersion")
     def "can build a native image and run it"() {
@@ -202,6 +202,7 @@ class JavaApplicationWithTestsFunctionalTest extends AbstractFunctionalTest {
         junitVersion = System.getProperty('versions.junit')
     }
 
+    // Protects custom native-test source-set classpath wiring. §FS-native-tests.1.1.
     @Issue("https://github.com/graalvm/native-build-tools/issues/702")
     @Unroll("custom test image classpath follows custom source set with JUnit Platform #junitVersion")
     def "custom test image classpath follows custom source set"() {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -978,7 +978,8 @@ public class NativeImagePlugin implements Plugin<Project> {
         createNativeConfigurations(
             project,
             binaryName,
-            JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME
+            // Custom native tests use their selected source set runtime classpath. §FS-native-tests.1.1
+            sourceSet.getRuntimeClasspathConfigurationName()
         );
         var configurations = project.getConfigurations();
         setupExtensionConfigExcludes(testExtension, configurations);

--- a/samples/java-application-with-custom-tests/build.gradle
+++ b/samples/java-application-with-custom-tests/build.gradle
@@ -60,15 +60,10 @@ sourceSets {
     integTest
 }
 
-configurations {
-    integTestImplementation.extendsFrom(testImplementation)
-    integTestRuntimeOnly.extendsFrom(testRuntimeOnly)
-}
-
 dependencies {
-    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
+    integTestImplementation(platform("org.junit:junit-bom:${junitVersion}"))
+    integTestImplementation('org.junit.jupiter:junit-jupiter')
+    integTestRuntimeOnly('org.junit.platform:junit-platform-launcher')
     integTestImplementation project(":")
 }
 


### PR DESCRIPTION
Fixes #702

## What changed

This PR fixes custom Gradle native test binaries so they follow the selected custom source set runtime classpath instead of always falling back to the default `testRuntimeClasspath`.

Before this change, a custom native test binary registered with `registerTestBinary` could accidentally inherit the default test classpath and mask missing dependencies or configuration errors in the custom source set.

After this change, custom native test binaries derive their runtime classpath from the selected source set, while still keeping the expected JUnit native support and generated task wiring.

## Why

Custom native test binaries should behave like the source set they were registered for. Without this fix, users could get passing custom native test setups only because the default test classpath leaked in underneath them.

## Example

Before:

A custom test image such as `integTest` could appear to work even if its own source set dependencies were incomplete, because the default `test` classpath masked the problem.

After:

The same custom test image follows its own source set runtime classpath, so project, JUnit, and plugin-provided native test dependencies come from the intended configuration.

## Implementation summary

- Add `FS-gradle-native-tests.1.1` for custom native test binaries.
- Use the selected source set runtime classpath configuration instead of always using `testRuntimeClasspath`.
- Add functional regression coverage that checks custom test image classpaths include the expected custom source set and plugin-provided dependencies.
- Update the custom-test sample so it no longer inherits dependencies from the default `test` configurations.

## Validation

- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:functionalTest --tests "org.graalvm.buildtools.gradle.JavaApplicationWithTestsFunctionalTest.custom test image classpath follows custom source set"`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:functionalTest --tests "org.graalvm.buildtools.gradle.JavaApplicationWithTestsFunctionalTest.can register a custom test image"`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:test :native-gradle-plugin:inspections`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:configCacheFunctionalTest --tests "org.graalvm.buildtools.gradle.JavaApplicationWithTestsFunctionalTest.custom test image classpath follows custom source set"`
- `git diff --check`
- `grund gradle/FS-gradle-native-tests.1.1 --brief`
