### PR TITLE
Fix generateTestResourceConfig autodetection paths

### DIFF
--- a/native-maven-plugin/docs/functional/resources-and-metadata.md
+++ b/native-maven-plugin/docs/functional/resources-and-metadata.md
@@ -10,6 +10,10 @@ The plugin must generate resource configuration for main and test classpaths. Ge
 respect existing Native Image resource configuration and the shared classpath scanning behavior in
 [§common/FS-common-libraries.2](../../../common/docs/functional-spec.md#2-resource-configuration).
 
+For `native:generateTestResourceConfig`, autodetection for the current project must use Maven's
+processed test output directory instead of the main output artifact or raw test resource source
+directories.
+
 ## 2. Reachability metadata
 
 `native:add-reachability-metadata` resolves metadata for project dependencies from the configured

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -103,29 +103,38 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractGraalVMMavenFun
         buildSucceeded
 
         and:
-        matches(file("target/native/generated/generateTestResourceConfig/resource-config.json").text, '''{
-  "resources": {
-    "includes": [
-      {
-        "pattern": "\\\\Qmessage.txt\\\\E"
-      },
-      {
-        "pattern": "\\\\Qorg/graalvm/demo/expected.txt\\\\E"
-      }
-    ],
-    "excludes": []
-  },
-  "bundles": []
-}''')
+        // Autodetection scans processed test output, not main output or raw test sources. §FS-resources-and-metadata.1.
+        matches(file("target/native/generated/generateTestResourceConfig/resource-config.json").text, resourceConfigFor(expectedPatterns))
 
         where:
-        detection | includedPatterns                                                               | restrictToModules | detectionExclusionPatterns
-        false     | [Pattern.quote("message.txt"), Pattern.quote("org/graalvm/demo/expected.txt")] | false             | []
-        true      | []                                                                             | false             | ["META-INF/.*", "junit-platform-unique-ids.*"]
-        true      | []                                                                             | true              | ["META-INF/.*", "junit-platform-unique-ids.*"]
+        detection | includedPatterns                                                               | restrictToModules | detectionExclusionPatterns                         || expectedPatterns
+        false     | [Pattern.quote("message.txt"), Pattern.quote("org/graalvm/demo/expected.txt")] | false             | []                                                 || [Pattern.quote("message.txt"), Pattern.quote("org/graalvm/demo/expected.txt")]
+        true      | []                                                                             | false             | ["META-INF/.*", "junit-platform-unique-ids.*"]     || [Pattern.quote("org/graalvm/demo/expected.txt")]
+        true      | []                                                                             | true              | ["META-INF/.*", "junit-platform-unique-ids.*"]     || [Pattern.quote("org/graalvm/demo/expected.txt")]
     }
 
     private static String joinForCliArg(List<String> patterns) {
         patterns.join(",")
+    }
+
+    private static String resourceConfigFor(List<String> patterns) {
+        String includes = patterns.collect { pattern ->
+"""      {
+        "pattern": "${escapeJson(pattern)}"
+      }"""
+        }.join(",\n")
+"""{
+  "resources": {
+    "includes": [
+${includes}
+    ],
+    "excludes": []
+  },
+  "bundles": []
+}"""
+    }
+
+    private static String escapeJson(String value) {
+        value.replace('\\', '\\\\')
     }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractResourceConfigMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractResourceConfigMojo.java
@@ -134,11 +134,15 @@ public abstract class AbstractResourceConfigMojo extends AbstractMojo {
 
     private Set<File> findAllProjectArtifacts() {
         Set<File> all = new LinkedHashSet<>();
-        all.add(mavenProject.getArtifact().getFile());
+        all.addAll(getProjectArtifacts());
         all.addAll(transitiveProjectsArtifacts());
         Collection<? extends File> extraProjectArtifacts = getExtraProjectArtifacts();
         all.addAll(extraProjectArtifacts);
         return all;
+    }
+
+    protected Collection<? extends File> getProjectArtifacts() {
+        return Collections.singleton(mavenProject.getArtifact().getFile());
     }
 
     protected Collection<? extends File> getExtraProjectArtifacts() {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildTestResourceConfigMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildTestResourceConfigMojo.java
@@ -41,14 +41,13 @@
 
 package org.graalvm.buildtools.maven;
 
-import org.apache.maven.model.FileSet;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.io.File;
 import java.util.Collection;
-import java.util.stream.Collectors;
+import java.util.Collections;
 
 /**
  * Scans test resources and generates resource metadata for them.
@@ -66,12 +65,7 @@ public class NativeBuildTestResourceConfigMojo extends AbstractResourceConfigMoj
     }
 
     @Override
-    protected Collection<? extends File> getExtraProjectArtifacts() {
-        return mavenProject.getBuild()
-                .getTestResources()
-                .stream()
-                .map(FileSet::getDirectory)
-                .map(File::new)
-                .collect(Collectors.toList());
+    protected Collection<? extends File> getProjectArtifacts() {
+        return Collections.singleton(new File(mavenProject.getBuild().getTestOutputDirectory()));
     }
 }


### PR DESCRIPTION
Fixes #566

## What changed

This PR fixes Maven `native:generateTestResourceConfig` autodetection so current-project test resources are discovered from processed test output rather than from the main output artifact or raw test resource source directories.

Before this change, current-project autodetection could scan the wrong paths for test resources.

After this change, current-project test resource autodetection uses `target/test-classes` while preserving the existing shared classpath scanning behavior for dependencies.

## Why

Users expect test resource config generation to reflect the processed test output Maven actually builds for the current project. Scanning the wrong paths can either miss resources or pick up the wrong inputs.

## Example

Before:

`native:generateTestResourceConfig` could treat raw `src/test/resources` directories or main output artifacts as the current-project source for autodetection.

After:

The same goal now scans the processed current-project test output under `target/test-classes`, which matches Maven's test resource pipeline.

## Implementation summary

- Add an overridable current-project artifact hook in `AbstractResourceConfigMojo`.
- Update `NativeBuildTestResourceConfigMojo` to use `mavenProject.getBuild().getTestOutputDirectory()` for current-project autodetection.
- Remove raw test resource source directories from the test resource config autodetection path.
- Clarify the Maven resource metadata functional spec.
- Update functional expectations so autodetection-enabled test resource generation follows processed test output resources.

## Validation

- `grund fmt . --marker --check`
- `git diff --check`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal PATH=/home/jovan/.sdkman/candidates/java/17.0.12-graal/bin:$PATH ./gradlew :native-maven-plugin:inspections --no-daemon`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal PATH=/home/jovan/.sdkman/candidates/java/17.0.12-graal/bin:$PATH ./gradlew :native-maven-plugin:functionalTest --no-daemon --fail-fast --tests org.graalvm.buildtools.maven.JavaApplicationWithResourcesFunctionalTest`
