### PR TITLE
Make build infrastructure runnable on newer JDKs

### DIFF
--- a/build-logic/aggregator/src/main/kotlin/org.graalvm.build.aggregator.gradle.kts
+++ b/build-logic/aggregator/src/main/kotlin/org.graalvm.build.aggregator.gradle.kts
@@ -93,7 +93,7 @@ listOf(
     // Root publication aggregators coordinate included builds. §FS-build-infrastructure.1.2.
     val (taskPrefix, repo) = entry
     tasks.register("$taskPrefix$repo") {
-        description = "Publishes all artifacts to the ${repo.decapitalize()} repository"
+        description = "Publishes all artifacts to the ${repo.replaceFirstChar { it.lowercase() }} repository"
         group = PublishingPlugin.PUBLISH_TASK_GROUP
         gradle.includedBuilds.forEach {
             if (it.name != "docs" && !it.projectDir.path.contains("build-logic")) {

--- a/build-logic/aggregator/src/main/kotlin/org/graalvm/build/tasks/GitReset.kt
+++ b/build-logic/aggregator/src/main/kotlin/org/graalvm/build/tasks/GitReset.kt
@@ -57,7 +57,7 @@ abstract class GitReset : AbstractGitTask() {
     fun execute() {
         val cmd = arrayListOf("reset")
         if (mode.isPresent) {
-            cmd.add("--${mode.get().toLowerCase()}")
+            cmd.add("--${mode.get().lowercase()}")
         }
         cmd.add(ref.get())
         runGit(cmd)

--- a/build-logic/documentation-plugins/build.gradle.kts
+++ b/build-logic/documentation-plugins/build.gradle.kts
@@ -49,6 +49,6 @@ repositories {
 }
 
 dependencies {
-    implementation("org.asciidoctor:asciidoctor-gradle-jvm:3.3.2")
+    implementation("org.asciidoctor.jvm.convert:org.asciidoctor.jvm.convert.gradle.plugin:4.0.5")
     implementation("org.ajoberstar:gradle-git-publish:3.0.0")
 }

--- a/build-logic/gradle-functional-testing/src/main/groovy/org.graalvm.build.functional-testing.gradle
+++ b/build-logic/gradle-functional-testing/src/main/groovy/org.graalvm.build.functional-testing.gradle
@@ -101,9 +101,11 @@ def fullFunctionalTest = tasks.register("fullFunctionalTest")
             // Any change to samples invalidates functional tests
             inputs.files(files("../samples"))
             inputs.files(configurations.functionalTestCommonRepository)
-            systemProperty('common.repo.url', configurations.functionalTestCommonRepository.incoming.files.files[0])
             systemProperty('gradle.test.version', effectiveVersion)
             systemProperty('versions.junit', libs.versions.junitJupiter.get())
+            doFirst {
+                systemProperty('common.repo.url', configurations.functionalTestCommonRepository.singleFile.absolutePath)
+            }
             environment('GRAALVM_HOME', graalVmHomeProvider.
                     orElse(providers.provider(() -> graalVm.get().metadata.installationPath.asFile.absolutePath))
                     .map {

--- a/common/graalvm-reachability-metadata/gradle/wrapper/gradle-wrapper.properties
+++ b/common/graalvm-reachability-metadata/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/common/graalvm-reachability-metadata/gradle/wrapper/gradle-wrapper.properties
+++ b/common/graalvm-reachability-metadata/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/common/junit-platform-native/build.gradle
+++ b/common/junit-platform-native/build.gradle
@@ -94,7 +94,7 @@ publishing {
 }
 
 signing {
-    required { gradle.taskGraph.hasTask("publish") }
+    required = { gradle.taskGraph.hasTask("publish") }
     sign publishing.publications.mavenJava
 }
 

--- a/common/junit-platform-native/gradle/wrapper/gradle-wrapper.properties
+++ b/common/junit-platform-native/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/common/junit-platform-native/gradle/wrapper/gradle-wrapper.properties
+++ b/common/junit-platform-native/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/agent/AgentConfiguration.java
@@ -71,7 +71,7 @@ public class AgentConfiguration implements Serializable {
     private final AgentMode agentMode;
 
     // This constructor should be used only to specify that we have instance of agent that is disabled (to avoid using null for agent enable check)
-    public AgentConfiguration(AgentMode ...modes) {
+    public AgentConfiguration(AgentMode... modes) {
         this.callerFilterFiles = null;
         this.accessFilterFiles = null;
         this.builtinCallerFilter = null;

--- a/common/utils/src/main/java/org/graalvm/buildtools/model/resources/ClassPathDirectoryAnalyzer.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/model/resources/ClassPathDirectoryAnalyzer.java
@@ -73,7 +73,7 @@ class ClassPathDirectoryAnalyzer extends ClassPathEntryAnalyzer {
         }
     }
 
-    private class DirectoryVisitor extends SimpleFileVisitor<Path> {
+    private final class DirectoryVisitor extends SimpleFileVisitor<Path> {
         List<String> resources = new ArrayList<>();
         boolean hasNativeImageResourceFile;
         boolean inNativeImageDir;

--- a/docs/spec/requirements.md
+++ b/docs/spec/requirements.md
@@ -42,7 +42,9 @@ The plugins require Java 17+ to run. Native Image workflows must support JDK 25+
 against the two most recent GraalVM LTS versions. The Gradle plugin
 supports Gradle 8.3+ and currently tests `current`, `8.4`, `8.14.2`, `9.0.0`, and `9.6.1`. The Maven plugin
 supports Maven 3.9.x and currently tests with `3.9.9`. Metadata defaults must track the latest
-compatible published repository while remaining pinnable by version, URI, or local path.
+compatible published repository while remaining pinnable by version, URI, or local path. Repository
+build infrastructure must run on the supported Java floor and remain runnable on newer JDK lines
+supported by the checked-in Gradle wrapper.
 
 ## 2. Changing support
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ nativeBuildTools = "1.1.4-SNAPSHOT"
 metadataRepository = "1.0.3"
 
 # External dependencies
-spock = "2.1-groovy-3.0"
+spock = "2.4-groovy-4.0"
 maven = "3.9.9"
 mavenAnnotations = "3.6.4"
 mavenEmbedder = "3.9.9"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/native-gradle-plugin/build.gradle
+++ b/native-gradle-plugin/build.gradle
@@ -40,9 +40,8 @@
  */
 
 plugins {
-    id 'java-gradle-plugin'
     id 'checkstyle'
-    id 'com.gradle.plugin-publish' version '0.15.0'
+    id 'com.gradle.plugin-publish' version '2.1.1'
     id 'java-test-fixtures'
     id 'org.graalvm.build.java'
     id 'org.graalvm.build.functional-testing'
@@ -59,20 +58,19 @@ dependencies {
     implementation libs.utils
     implementation libs.jvmReachabilityMetadata
     testImplementation libs.test.spock
+    testRuntimeOnly libs.test.junit.platform.launcher
     testFixturesImplementation libs.test.spock
     testFixturesImplementation gradleTestKit()
     functionalTestCommonRepository(libs.junitPlatformNative)
     functionalTestCommonRepository(libs.jvmReachabilityMetadata)
     functionalTestCommonRepository("org.graalvm.internal:library-with-reflection")
-}
-
-pluginBundle {
-    website = 'https://graalvm.org/'
-    vcsUrl = 'https://github.com/graalvm/native-build-tools'
-    tags = ['native', 'graalvm', 'graal', 'java']
+    functionalTestRuntimeOnly libs.test.junit.platform.launcher
 }
 
 gradlePlugin {
+    website = 'https://graalvm.org/'
+    vcsUrl = 'https://github.com/graalvm/native-build-tools'
+
     // Define the plugin
     plugins {
         nativeImage {
@@ -80,6 +78,7 @@ gradlePlugin {
             implementationClass = 'org.graalvm.buildtools.gradle.NativeImagePlugin'
             displayName = maven.name.get()
             description = maven.description.get()
+            tags.addAll('native', 'graalvm', 'graal', 'java')
         }
     }
 }

--- a/native-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/native-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/native-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/native-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/AbstractPluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/AbstractPluginTest.groovy
@@ -85,29 +85,21 @@ abstract class AbstractPluginTest extends Specification {
 
     protected File newResourcesDirectory() {
         def dir = testDirectory.resolve("exploded${resourceCount++}").toFile()
-        new FileTreeBuilder(dir) {
-            'META-INF' {
-                'INDEX.LIST'('dummy')
-            }
-            'org' {
-                'foo' {
-                    'some' {
-                        'resource.txt'('resource text')
-                    }
-                }
-            }
-        }
+        new File(dir, "META-INF").mkdirs()
+        new File(dir, "META-INF/INDEX.LIST").text = "dummy"
+        new File(dir, "org/foo/some").mkdirs()
+        new File(dir, "org/foo/some/resource.txt").text = "resource text"
         dir
     }
 
     protected File newResourcesJar(Map<String, String> extraResources = [:]) {
         File resourcesDirectory = newResourcesDirectory()
-        extraResources.each { path, contents -> {
+        extraResources.each { path, contents ->
             def resource = new File(resourcesDirectory, path)
             if (resource.getParentFile().directory || resource.getParentFile().mkdirs()) {
                 resource << contents
             }
-        }}
+        }
         File jar = new File(testDirectory.toFile(), "resources-${resourceCount}.jar")
         Path resourcesPath = resourcesDirectory.toPath()
 

--- a/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-functional-testing.gradle.kts
+++ b/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-functional-testing.gradle.kts
@@ -72,7 +72,9 @@ tasks.register<Test>("functionalTest") {
     inputs.files(files("../samples"))
     inputs.files(files("reproducers"))
     inputs.files(functionalTestCommonRepository)
-    systemProperty("common.repo.url", functionalTestCommonRepository.incoming.files.files.first())
+    doFirst {
+        systemProperty("common.repo.url", functionalTestCommonRepository.singleFile.absolutePath)
+    }
     testClassesDirs = functionalTest.output.classesDirs
     classpath = functionalTest.runtimeClasspath
 }

--- a/native-maven-plugin/build.gradle.kts
+++ b/native-maven-plugin/build.gradle.kts
@@ -174,9 +174,12 @@ tasks {
         systemProperty("junit.platform.native.version", libs.versions.nativeBuildTools.get())
         systemProperty("common.repo.uri", repoDirectory.get().asFile.toURI().toASCIIString())
         systemProperty("seed.repo.uri", localRepositoryDir.get().asFile.toURI().toASCIIString())
-        systemProperty("maven.classpath", configurations.mavenEmbedder.get().asPath)
         systemProperty("maven.settings", layout.projectDirectory.file("config/settings.xml").asFile.absolutePath)
         systemProperty("java.executable", javaLauncher.get().executablePath.asFile.absolutePath)
+        inputs.files(configurations.mavenEmbedder)
+        doFirst {
+            systemProperty("maven.classpath", configurations.mavenEmbedder.get().asPath)
+        }
     }
 }
 

--- a/native-maven-plugin/build.gradle.kts
+++ b/native-maven-plugin/build.gradle.kts
@@ -83,6 +83,7 @@ dependencies {
     testImplementation(libs.maven.core)
     testImplementation(libs.maven.artifact)
     testImplementation(libs.jetty.server)
+    testRuntimeOnly(libs.test.junit.platform.launcher)
 
     testFixturesImplementation(libs.test.spock)
     testFixturesImplementation(libs.jetty.server)
@@ -93,6 +94,7 @@ dependencies {
     functionalTestCommonRepository("org.graalvm.internal:library-with-reflection")
 
     functionalTestImplementation(libs.test.spock)
+    functionalTestRuntimeOnly(libs.test.junit.platform.launcher)
     functionalTestRuntimeOnly(libs.slf4j.simple)
 }
 

--- a/native-maven-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/native-maven-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/native-maven-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/native-maven-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

Fixes #927.

This updates repository build infrastructure so normal maintainer Gradle commands can run when `JAVA_HOME` points at newer JDK lines such as JDK 21 or JDK 25, while preserving the Java 17 toolchain target for produced artifacts and leaving the existing CI JDK matrix unchanged.

Changes include:

- bumping all checked-in Gradle wrappers to Gradle 9.6.1, matching the current tested Gradle line
- updating build plugins that were incompatible with Gradle 9
- moving the Gradle Plugin Publish metadata to the current DSL shape
- updating Spock/JUnit Platform test runtime dependencies for Gradle 9
- fixing small Kotlin/Groovy compatibility issues in build logic and tests
- fixing a latent nested-closure no-op in the resource-jar test fixture so requested extra resources are actually written and the native-image resource-config test exercises its intended path
- fixing two existing `common-utils` Checkstyle violations exposed by the Gradle upgrade

The final item belongs in this PR because Checkstyle is not version-pinned: Gradle 8.3 used Checkstyle 9.3, while the updated Gradle wrapper uses a newer Checkstyle version that reports these pre-existing violations. Fixing them keeps the common-utils CI gate green with the upgraded wrapper.

## Testing

- `./gradlew :native-gradle-plugin:test --tests org.graalvm.buildtools.gradle.tasks.GenerateResourcesConfigFileTest --no-daemon` on Gradle 9.6.1 — 9 tests passed
- `./gradlew :docs:asciidoctor --no-daemon` on Gradle 9.6.1 — documentation rendered successfully
- `grund check`
- `./gradlew :utils:checkstyleMain :utils:checkstyleTest` on Gradle 9.5.1 before aligning the wrapper with the tested 9.6.1 line
- Earlier local validation also covered the same sanity path on JDK 17 and JDK 21 before moving the patch onto the direct repo branch.
