### PR TITLE
Fix Gradle nativeTest test resource detection

### DIFF
--- a/docs/src/docs/asciidoc/changelog.adoc
+++ b/docs/src/docs/asciidoc/changelog.adoc
@@ -4,6 +4,7 @@
 == Release 1.0.1
 
 - Regenerate the documentation `latest` symlink automatically for releases so GitHub Pages no longer serves stale docs
+- Gradle `nativeTest` now includes test resources without requiring explicit resource configuration
 
 == Release 1.0.0
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -41,6 +41,7 @@
 package org.graalvm.buildtools.gradle
 
 import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
+import spock.lang.Issue
 import spock.lang.Unroll
 
 class JavaApplicationWithResourcesFunctionalTest extends AbstractFunctionalTest {
@@ -134,6 +135,48 @@ graalvmNative {
 """
                                           ]
         ]
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/537")
+    def "native tests include test resources without explicit resource configuration"() {
+        given:
+        withSample("java-application-with-resources")
+        file("src/test/resources/db").mkdirs()
+        file("src/test/resources/db/mysql_conf_override").text = "native-test-resource"
+        file("src/test/java/org/graalvm/demo/Issue537Test.java").text = """
+package org.graalvm.demo;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class Issue537Test {
+    @Test
+    void testResourceDirectoryIsAvailableInNativeTest() throws Exception {
+        // A normal Gradle JUnit setup is enough for nativeTest to include test resources. §FS-native-tests.1.
+        try (InputStream input = Thread.currentThread().getContextClassLoader().getResourceAsStream("db/mysql_conf_override")) {
+            assertNotNull(input);
+            assertEquals("native-test-resource", new String(input.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+}
+"""
+
+        when:
+        run 'nativeTest'
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeTest'
+            doesNotContain ':build', ':run'
+        }
+
+        and:
+        contains(file("build/native/generated/generateTestResourcesConfigFile/resource-config.json").text, '"pattern": "\\\\Qdb/mysql_conf_override\\\\E"')
     }
 
     @Unroll("can run native tests which uses resources using #pattern with JUnit Platform #junitVersion")

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -137,6 +137,7 @@ graalvmNative {
         ]
     }
 
+    // Protects default test-resource wiring for nativeTest. §FS-native-tests.1.
     @Issue("https://github.com/graalvm/native-build-tools/issues/537")
     def "native tests include test resources without explicit resource configuration"() {
         given:
@@ -157,7 +158,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class Issue537Test {
     @Test
     void testResourceDirectoryIsAvailableInNativeTest() throws Exception {
-        // A normal Gradle JUnit setup is enough for nativeTest to include test resources. §FS-native-tests.1.
         try (InputStream input = Thread.currentThread().getContextClassLoader().getResourceAsStream("db/mysql_conf_override")) {
             assertNotNull(input);
             assertEquals("native-test-resource", new String(input.readAllBytes(), StandardCharsets.UTF_8));

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -175,6 +175,7 @@ public class NativeImagePlugin implements Plugin<Project> {
 
     private static final String JUNIT_PLATFORM_LISTENERS_UID_TRACKING_ENABLED = "junit.platform.listeners.uid.tracking.enabled";
     private static final String JUNIT_PLATFORM_LISTENERS_UID_TRACKING_OUTPUT_DIR = "junit.platform.listeners.uid.tracking.output.dir";
+    private static final String JUNIT_PLATFORM_UNIQUE_IDS_RESOURCE_PATTERN = "junit-platform-unique-ids.*";
     private static final String REPOSITORY_COORDINATES = "org.graalvm.buildtools:graalvm-reachability-metadata:" + VersionInfo.NBT_VERSION + ":repository@zip";
     private static final String DEFAULT_URI = String.format(METADATA_REPO_URL_TEMPLATE, VersionInfo.METADATA_REPO_VERSION);
 
@@ -989,6 +990,9 @@ public class NativeImagePlugin implements Plugin<Project> {
         classpath.from(configurations.getByName(imageClasspathConfigurationNameFor(binaryName)));
         classpath.from(sourceSet.getOutput().getClassesDirs());
         classpath.from(sourceSet.getOutput().getResourcesDir());
+        testExtension.getResources().getDetectionOptions().getEnabled().convention(true);
+        // Native tests include test source-set resources by default; omit the generated discovery list. §FS-native-tests.1.
+        testExtension.getResources().getDetectionOptions().getDetectionExclusionPatterns().add(JUNIT_PLATFORM_UNIQUE_IDS_RESOURCE_PATTERN);
 
         return testExtension;
     }


### PR DESCRIPTION
Fixes #537

## What changed

This PR fixes Gradle `nativeTest` so it picks up resources from `src/test/resources` by default.

Before this change, JVM `test` could see test resources while `nativeTest` missed them unless users added extra resource configuration.

After this change, the Gradle native test binary enables resource autodetection by convention and includes test resources without requiring explicit resource configuration.

## Why

Users expect `nativeTest` to follow the same test-resource model as the normal Gradle test path. Without this fix, native tests could fail only because resources present in `src/test/resources` never made it into the native test executable.

## Example

Before:

A file such as `src/test/resources/db/mysql_conf_override` could be visible to JVM tests but missing when the same test suite ran through `nativeTest`.

After:

The same resource is autodetected for the Gradle native test binary, so the native test executable can load it without extra resource configuration.

## Implementation summary

- Enable resource autodetection by convention for the Gradle native test binary.
- Exclude generated `junit-platform-unique-ids.*` discovery-list files from detected test resources.
- Add a focused functional regression that verifies a native test executable can load a resource from `src/test/resources` without explicit configuration.
- Add a changelog entry for the `nativeTest` resource fix.

## Validation

- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/21.0.11-graal ./gradlew :native-gradle-plugin:functionalTest --tests "org.graalvm.buildtools.gradle.JavaApplicationWithResourcesFunctionalTest.native tests include test resources without explicit resource configuration"`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:inspections`
- `git diff --check`
