### PR TITLE
Clarify buildArgs option entries

### DIFF
--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -173,6 +173,20 @@ You can also pass **build-time** and **run-time** arguments:
 - `buildArgs.add('<buildArg>')`: Configures the build by passing options directly to `native-image`. You can pass any Native Image build option listed https://www.graalvm.org/reference-manual/native-image/overview/Options/[here].
 - `runtimeArgs.add('<runtimeArg>')`: Specifies runtime arguments consumed by your application.
 
+Each `buildArgs` list entry should contain one Native Image option expression, not a shell command line.
+Put unrelated options in separate entries, but keep values that belong to the option expression together,
+such as `--emit build-report`, `--enable-monitoring=jfr`, or `-H:Name=value`.
+
+[source,kotlin, role="multi-language-sample"]
+----
+buildArgs.addAll(
+    "--static",
+    "--libc=musl",
+    "--emit build-report",
+    "-H:+ReportExceptionStackTraces"
+)
+----
+
 ==== Command Line Options
 
 The preferred way to configure native binaries is through the DSL, so that you can provide reproducible builds which do not depend on obscure CLI invocations.

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -175,15 +175,13 @@ You can also pass **build-time** and **run-time** arguments:
 
 Each `buildArgs` list entry should contain one Native Image option expression, not a shell command line.
 Put unrelated options in separate entries, but keep values that belong to the option expression together,
-such as `--emit build-report`, `--enable-monitoring=jfr`, or `-H:Name=value`.
+such as `--emit build-report` or `--enable-monitoring=jfr`.
 
 [source,kotlin, role="multi-language-sample"]
 ----
 buildArgs.addAll(
-    "--static",
-    "--libc=musl",
     "--emit build-report",
-    "-H:+ReportExceptionStackTraces"
+    "--enable-monitoring=jfr"
 )
 ----
 

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -43,10 +43,16 @@ The following configuration options are available:
    image name is not supplied, the artifact ID of the project will be used by default.
 `<buildArgs>`::
    If you want to pass additional build options to `native-image`, use the `<buildArgs>` tag. You can pass any Native Image build option listed https://www.graalvm.org/reference-manual/native-image/overview/Options/[here].
+   Each `<buildArg>` entry should contain one Native Image option expression, not a shell command line.
+   Put unrelated options in separate `<buildArg>` entries, but keep values that belong to the option expression together,
+   such as `--emit build-report`, `--enable-monitoring=jfr`, or `-H:Name=value`.
 [source,xml, role="multi-language-sample"]
 ----
 <buildArgs>
-    <buildArg>--argument</buildArg>
+    <buildArg>--static</buildArg>
+    <buildArg>--libc=musl</buildArg>
+    <buildArg>--emit build-report</buildArg>
+    <buildArg>-H:+ReportExceptionStackTraces</buildArg>
 </buildArgs>
 ----
 `<skipNativeBuild>`::

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -45,14 +45,12 @@ The following configuration options are available:
    If you want to pass additional build options to `native-image`, use the `<buildArgs>` tag. You can pass any Native Image build option listed https://www.graalvm.org/reference-manual/native-image/overview/Options/[here].
    Each `<buildArg>` entry should contain one Native Image option expression, not a shell command line.
    Put unrelated options in separate `<buildArg>` entries, but keep values that belong to the option expression together,
-   such as `--emit build-report`, `--enable-monitoring=jfr`, or `-H:Name=value`.
+   such as `--emit build-report` or `--enable-monitoring=jfr`.
 [source,xml, role="multi-language-sample"]
 ----
 <buildArgs>
-    <buildArg>--static</buildArg>
-    <buildArg>--libc=musl</buildArg>
     <buildArg>--emit build-report</buildArg>
-    <buildArg>-H:+ReportExceptionStackTraces</buildArg>
+    <buildArg>--enable-monitoring=jfr</buildArg>
 </buildArgs>
 ----
 `<skipNativeBuild>`::


### PR DESCRIPTION
Fixes #930

## What changed

This PR clarifies the docs for Maven and Gradle `buildArgs` entries.

Before this change, users could read the docs and assume a `buildArgs` entry should be written like a shell command line instead of as one native-image option expression per entry.

After this change, the docs make it clear that each Maven `<buildArg>` or Gradle `buildArgs` entry should contain a single native-image option expression, and the examples are updated accordingly.

## Why

This avoids configuration confusion and makes the examples line up with how Native Build Tools actually passes native-image arguments.

## Example

Before:

Users could infer that unrelated options should be combined into one `buildArgs` entry.

After:

The docs show separate entries for unrelated options while preserving valid single-expression forms such as `--emit build-report`, `--enable-monitoring=jfr`, and `-H:Name=value`.

## Implementation summary

- Clarify that each Maven `<buildArg>` entry should contain one native-image option expression.
- Add equivalent Gradle `buildArgs.addAll(...)` guidance.
- Update examples so unrelated options are configured as separate entries while keeping valid same-expression native-image forms.

## Validation

- `grund fmt . --marker --check`
- `git diff --check`
- `env JAVA_HOME=/home/jovan/.mx/jdks/labsjdk-ee-17-jvmci-23.1-b02 PATH=/home/jovan/.mx/jdks/labsjdk-ee-17-jvmci-23.1-b02/bin:$PATH ./gradlew :docs:asciidoctor`
- Confirmed rendered Maven and Gradle HTML contains the new `buildArgs` guidance and examples.
