### PR TITLE
Make Maven agent execution ID configurable

### DIFF
--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -200,6 +200,9 @@ dependencies, add:
 `<agent>`::
    Configuration of the <<agent-support, native agent>>. See <<agent-support-enabling>>
    and <<agent-support-configuring-options>> for details.
+`<agentExecutionId>`::
+   The `exec-maven-plugin` execution ID used when attaching the agent to a main application run.
+   Defaults to `java-agent`.
 
 For example, to build a native image named `myapp` that uses `org.example.ClassName` as its main class with assertions enabled, the `<configuration>` should look like this:
 
@@ -327,6 +330,9 @@ Then you can execute your application with the agent by running:
 ----
 ./mvnw -Pnative -Dagent=true -DskipTests -DskipNativeBuild=true package exec:exec@java-agent
 ----
+
+If you rename the `exec-maven-plugin` execution, set `<agentExecutionId>` in the
+`native-maven-plugin` configuration to the same ID and invoke `exec:exec@<that-id>`.
 
 Both of the above commands generate configuration files in the _target/native/agent-output/main_ directory.
 If you want to run your native application with those configuration files, you then need to execute the following command:

--- a/native-maven-plugin/docs/functional/tracing-agent.md
+++ b/native-maven-plugin/docs/functional/tracing-agent.md
@@ -21,7 +21,9 @@ they need full control.
 
 Agent output from tests must be stored under `target/native/agent-output/test`; agent output from
 application runs must be stored under `target/native/agent-output/main` unless direct mode changes
-the destination.
+the destination. Application agent runs are attached to the `exec-maven-plugin` execution named by
+the native plugin's `<agentExecutionId>` configuration value; the default execution ID is
+`java-agent` so existing POMs keep working.
 
 ## 4. Merge and copy
 

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
@@ -114,6 +114,21 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
         outputContains "Metadata copy process finished."
     }
 
+    @Issue("https://github.com/graalvm/native-build-tools/issues/555")
+    def "application agent uses configured exec plugin execution id"() {
+        given:
+        withSample("java-application-with-reflection")
+
+        when:
+        // Custom execution IDs must receive main application agent injection. §FS-tracing-agent.3.
+        mvnDebug '-PagentConfigurationWithCustomExecutionId', '-DskipTests', 'package', 'exec:exec@custom-java-agent'
+
+        then:
+        buildSucceeded
+        outputContains '-agentlib:native-image-agent='
+        metadataExistsAt("target/native/agent-output/main/")
+    }
+
     def "test agent with metadata copy task and disabled stages"() {
         given:
         withSample("java-application-with-reflection")

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
@@ -77,6 +77,8 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
     private static final String JUNIT_PLATFORM_LISTENERS_UID_TRACKING_OUTPUT_DIR = "junit.platform.listeners.uid.tracking.output.dir";
     private static final String NATIVEIMAGE_IMAGECODE = "org.graalvm.nativeimage.imagecode";
     private static final String SYSTEM_PROPERTY_VARIABLES = "systemPropertyVariables";
+    private static final String AGENT_EXECUTION_ID = "agentExecutionId";
+    private static final String DEFAULT_AGENT_EXECUTION_ID = "java-agent";
 
     private static Logger logger;
 
@@ -149,9 +151,10 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
 
                 // Main configuration
                 if (agent.isEnabled()) {
+                    String agentExecutionId = mainAgentExecutionId(configurationRoot);
                     withPlugin(build, "exec-maven-plugin", execPlugin ->
                             updatePluginConfiguration(execPlugin, (exec, config) -> {
-                                if ("java-agent".equals(exec.getId())) {
+                                if (agentExecutionId.equals(exec.getId())) {
                                     Xpp3Dom commandlineArgs = findOrAppend(config, "arguments");
                                     Xpp3Dom[] arrayOfChildren = commandlineArgs.getChildren();
                                     for (int i = 0; i < arrayOfChildren.length; i++) {
@@ -174,6 +177,7 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                                     for (Xpp3Dom child : children) {
                                         commandlineArgs.addChild(child);
                                     }
+                                    // Main application agent binding follows the configured execution ID. §FS-tracing-agent.3.
                                     findOrAppend(config, "executable").setValue(getGraalvmJava());
                                 }
                             })
@@ -187,6 +191,16 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                 }
             });
         }
+    }
+
+    static String mainAgentExecutionId(Xpp3Dom configurationRoot) {
+        if (configurationRoot != null) {
+            Xpp3Dom agentExecutionId = configurationRoot.getChild(AGENT_EXECUTION_ID);
+            if (agentExecutionId != null && agentExecutionId.getValue() != null && !agentExecutionId.getValue().trim().isEmpty()) {
+                return agentExecutionId.getValue().trim();
+            }
+        }
+        return DEFAULT_AGENT_EXECUTION_ID;
     }
 
     private static void setupMergeAgentFiles(PluginExecution exec, Xpp3Dom configuration, Context context) {

--- a/samples/java-application-with-reflection/pom.xml
+++ b/samples/java-application-with-reflection/pom.xml
@@ -159,6 +159,55 @@
             </build>
         </profile>
         <profile>
+            <id>agentConfigurationWithCustomExecutionId</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>custom-java-agent</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>java</executable>
+                                    <workingDirectory>${project.build.directory}</workingDirectory>
+                                    <arguments>
+                                        <argument>-classpath</argument>
+                                        <classpath/>
+                                        <argument>${mainClass}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <agentExecutionId>custom-java-agent</agentExecutionId>
+                            <agent>
+                                <enabled>true</enabled>
+                                <defaultMode>Standard</defaultMode>
+                                <options>
+                                    <builtinCallerFilter>true</builtinCallerFilter>
+                                    <builtinHeuristicFilter>true</builtinHeuristicFilter>
+                                    <enableExperimentalPredefinedClasses>true</enableExperimentalPredefinedClasses>
+                                    <enableExperimentalUnsafeAllocationTracing>true</enableExperimentalUnsafeAllocationTracing>
+                                    <trackReflectionMetadata>true</trackReflectionMetadata>
+                                </options>
+                            </agent>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>agentConfigurationWithDisabledStages</id>
             <build>
                 <plugins>


### PR DESCRIPTION
Closes #555

## What changed

This PR makes the Maven tracing-agent exec-maven-plugin execution ID configurable.

Before this change, the main tracing-agent execution was effectively tied to the default `java-agent` execution ID.

After this change, users can configure `<agentExecutionId>` for the main tracing-agent execution while the existing `java-agent` default remains in place for backward compatibility.

## Why

This gives users more flexibility when they rename or reorganize exec-maven-plugin executions without breaking tracing-agent integration.

## Example

Before:

A project that renamed the main tracing-agent execution away from `java-agent` could no longer rely on the plugin's built-in default execution lookup.

After:

The same project can set `<agentExecutionId>` explicitly and keep tracing-agent integration aligned with its chosen exec-maven-plugin execution name.

## Implementation summary

- Add Maven `<agentExecutionId>` configuration for the main tracing-agent exec-maven-plugin execution.
- Preserve `java-agent` as the default value for backward compatibility.
- Document the setting and add functional coverage and sample configuration for a renamed execution.

## Validation

- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-maven-plugin:inspections`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-maven-plugin:test`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-maven-plugin:functionalTest --tests org.graalvm.buildtools.maven.JavaApplicationWithAgentFunctionalTest`
- `git diff --check`
