### PR TITLE
Fix Maven test agent paths with spaces

### DIFF
--- a/native-maven-plugin/docs/functional/tracing-agent.md
+++ b/native-maven-plugin/docs/functional/tracing-agent.md
@@ -23,7 +23,9 @@ Agent output from tests must be stored under `target/native/agent-output/test`; 
 application runs must be stored under `target/native/agent-output/main` unless direct mode changes
 the destination. Application agent runs are attached to the `exec-maven-plugin` execution named by
 the native plugin's `<agentExecutionId>` configuration value; the default execution ID is
-`java-agent` so existing POMs keep working.
+`java-agent` so existing POMs keep working. Generated test-agent arguments derived from project paths
+must remain a single JVM argument when passed through Maven test runners, including when those paths
+contain spaces.
 
 ## 4. Merge and copy
 

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
@@ -97,6 +97,21 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
         outputDoesNotContain "containers found"
     }
 
+    @Issue("https://github.com/graalvm/native-build-tools/issues/485")
+    def "test agent works from a project directory with spaces"() {
+        given:
+        withSpacesInProjectDir()
+        withSample("java-application-with-reflection")
+
+        when:
+        // The generated Surefire argLine must keep the test-stage agent output path as one JVM argument. §FS-tracing-agent.3.
+        mvn '-Pnative', '-DquickBuild', 'test', '-Dagent=true', '-DskipNativeTests'
+
+        then:
+        buildSucceeded
+        metadataExistsAt("target/native/agent-output/test/")
+    }
+
     def "test agent with metadata copy task"() {
         given:
         withSample("java-application-with-reflection")

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
@@ -97,6 +97,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
         outputDoesNotContain "containers found"
     }
 
+    // Verifies agent output paths with spaces remain one JVM argument through Maven test runners. §FS-tracing-agent.3.
     @Issue("https://github.com/graalvm/native-build-tools/issues/485")
     def "test agent works from a project directory with spaces"() {
         given:
@@ -104,7 +105,6 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
         withSample("java-application-with-reflection")
 
         when:
-        // The generated Surefire argLine must keep the test-stage agent output path as one JVM argument. §FS-tracing-agent.3.
         mvn '-Pnative', '-DquickBuild', 'test', '-Dagent=true', '-DskipNativeTests'
 
         then:

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
@@ -240,7 +240,7 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
             agent.setValue("agent");
             Xpp3Dom argLine = new Xpp3Dom("argLine");
             // Surefire/Failsafe parse argLine as one command-line string.
-            // Keep spaced output paths as one JVM argument. §FS-tracing-agent.1 §FS-tracing-agent.3.
+            // Keep spaced output paths as one JVM argument. §FS-tracing-agent.3.
             argLine.setValue(quoteAgentArgumentForArgLine(agentArgument));
             configuration.addChild(argLine);
             findOrAppend(configuration, "jvm").setValue(getGraalvmJava());

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
@@ -117,6 +117,19 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
         return "-agentlib:native-image-agent=" + String.join(",", options);
     }
 
+    static String quoteAgentArgumentForArgLine(String agentArgument) {
+        if (!agentArgument.contains(" ")) {
+            return agentArgument;
+        }
+        if (!agentArgument.contains("\"")) {
+            return "\"" + agentArgument + "\"";
+        }
+        if (!agentArgument.contains("'")) {
+            return "'" + agentArgument + "'";
+        }
+        return agentArgument;
+    }
+
     static String agentOutputDirectoryFor(String baseDir, Context context) {
         return (baseDir + "/native/agent-output/" + context).replace('/', File.separatorChar);
     }
@@ -226,7 +239,9 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
             Xpp3Dom agent = findOrAppend(systemPropertyVariables, NATIVEIMAGE_IMAGECODE);
             agent.setValue("agent");
             Xpp3Dom argLine = new Xpp3Dom("argLine");
-            argLine.setValue(agentArgument);
+            // Surefire/Failsafe parse argLine as one command-line string.
+            // Keep spaced output paths as one JVM argument. §FS-tracing-agent.1 §FS-tracing-agent.3.
+            argLine.setValue(quoteAgentArgumentForArgLine(agentArgument));
             configuration.addChild(argLine);
             findOrAppend(configuration, "jvm").setValue(getGraalvmJava());
         });

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
@@ -46,9 +46,11 @@ import org.apache.maven.model.Build
 import org.apache.maven.model.Plugin
 import org.apache.maven.model.PluginExecution
 import org.apache.maven.project.MavenProject
+import org.codehaus.plexus.util.cli.CommandLineUtils
 import org.codehaus.plexus.util.xml.Xpp3Dom
 import spock.lang.Specification
 
+// Protects Maven tracing-agent argLine transport for output paths computed from project directories. §FS-tracing-agent.1 §FS-tracing-agent.3.
 class NativeExtensionTest extends Specification {
     private static final String JUNIT_TRACKING_ENABLED = "junit.platform.listeners.uid.tracking.enabled"
     private static final String JUNIT_TRACKING_OUTPUT_DIR = "junit.platform.listeners.uid.tracking.output.dir"
@@ -84,6 +86,34 @@ class NativeExtensionTest extends Specification {
             assert systemPropertyVariables.getChild(JUNIT_TRACKING_ENABLED).value == "true"
             assert systemPropertyVariables.getChild(JUNIT_TRACKING_OUTPUT_DIR).value == NativeExtension.testIdsDirectory("target")
         }
+    }
+
+    void "test agent argument is quoted for Surefire argLine when output path contains spaces"() {
+        given:
+        def agentArgument = NativeExtension.buildAgentArgument(
+                "/tmp/path with spaces/target",
+                NativeExtension.Context.test,
+                ["config-output-dir={output_dir}"]
+        )
+
+        when:
+        def quotedAgentArgument = NativeExtension.quoteAgentArgumentForArgLine(agentArgument)
+
+        then:
+        quotedAgentArgument == "\"${agentArgument}\""
+        CommandLineUtils.translateCommandline(quotedAgentArgument).toList() == [agentArgument]
+    }
+
+    void "test agent argument is unchanged for Surefire argLine when output path has no spaces"() {
+        given:
+        def agentArgument = NativeExtension.buildAgentArgument(
+                "/tmp/path-without-spaces/target",
+                NativeExtension.Context.test,
+                ["config-output-dir={output_dir}"]
+        )
+
+        expect:
+        NativeExtension.quoteAgentArgumentForArgLine(agentArgument) == agentArgument
     }
 
     private static Plugin plugin(String artifactId) {

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
@@ -50,7 +50,7 @@ import org.codehaus.plexus.util.cli.CommandLineUtils
 import org.codehaus.plexus.util.xml.Xpp3Dom
 import spock.lang.Specification
 
-// Protects Maven tracing-agent argLine transport for output paths computed from project directories. §FS-tracing-agent.1 §FS-tracing-agent.3.
+// Protects Maven tracing-agent argLine transport for output paths computed from project directories. §FS-tracing-agent.3.
 class NativeExtensionTest extends Specification {
     private static final String JUNIT_TRACKING_ENABLED = "junit.platform.listeners.uid.tracking.enabled"
     private static final String JUNIT_TRACKING_OUTPUT_DIR = "junit.platform.listeners.uid.tracking.output.dir"

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
@@ -50,7 +50,6 @@ import org.codehaus.plexus.util.cli.CommandLineUtils
 import org.codehaus.plexus.util.xml.Xpp3Dom
 import spock.lang.Specification
 
-// Protects Maven tracing-agent argLine transport for output paths computed from project directories. §FS-tracing-agent.3.
 class NativeExtensionTest extends Specification {
     private static final String JUNIT_TRACKING_ENABLED = "junit.platform.listeners.uid.tracking.enabled"
     private static final String JUNIT_TRACKING_OUTPUT_DIR = "junit.platform.listeners.uid.tracking.output.dir"
@@ -88,6 +87,7 @@ class NativeExtensionTest extends Specification {
         }
     }
 
+    // Protects Maven tracing-agent argLine transport for output paths computed from project directories. §FS-tracing-agent.3.
     void "test agent argument is quoted for Surefire argLine when output path contains spaces"() {
         given:
         def agentArgument = NativeExtension.buildAgentArgument(

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
@@ -87,7 +87,6 @@ class NativeExtensionTest extends Specification {
         }
     }
 
-    // Protects Maven tracing-agent argLine transport for output paths computed from project directories. §FS-tracing-agent.3.
     void "test agent argument is quoted for Surefire argLine when output path contains spaces"() {
         given:
         def agentArgument = NativeExtension.buildAgentArgument(


### PR DESCRIPTION
Fixes #485

## What changed

This PR fixes Maven tracing-agent test runs from project directories whose paths contain spaces.

Before this change, generated `-agentlib:native-image-agent=...` values could break when passed through Surefire or Failsafe `argLine` from a project directory with spaces in its path.

After this change, the generated agent argument is quoted only when needed, so valid project paths with spaces continue to work while paths without spaces keep their existing behavior.

## Why

Users should be able to run Maven tracing-agent test workflows from ordinary project locations, including directories with spaces, without breaking agent argument parsing.

## Example

Before:

Running the existing reflection sample from a directory such as `with spaces` with `mvn -Pnative -DquickBuild test -Dagent=true -DskipNativeTests` could fail because the agent argument was split incorrectly.

After:

The same project path is preserved as a single JVM argument through Surefire or Failsafe, and agent output is still written to the expected test metadata directory.

## Implementation summary

- Quote generated `-agentlib:native-image-agent=...` values only when the computed argument contains spaces before injecting it into Surefire or Failsafe `argLine`.
- Preserve unchanged output for agent arguments that do not contain spaces.
- Add unit coverage proving Plexus command-line parsing keeps a quoted spaced agent argument as one JVM argument.
- Add a Maven functional regression that runs the existing reflection sample from a project directory named `with spaces`.

## Validation

- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-maven-plugin:test --tests org.graalvm.buildtools.maven.NativeExtensionTest`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-maven-plugin:functionalTest --no-daemon --fail-fast --tests org.graalvm.buildtools.maven.JavaApplicationWithAgentFunctionalTest.'test agent works from a project directory with spaces'`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-maven-plugin:checkstyleMain :native-maven-plugin:checkstyleTest :native-maven-plugin:checkstyleFunctionalTest`
- `grund fmt . --marker --check`
