### PR TITLE
Fix optional JUnit dependency resolution in Maven native tests

### DIFF
--- a/native-maven-plugin/docs/functional/native-tests.md
+++ b/native-maven-plugin/docs/functional/native-tests.md
@@ -10,7 +10,9 @@ dependencies needed by the test image. Current-project content must come from Ma
 outputs, including the processed test output directory; raw test resource source directories must
 not be added because doing so bypasses Maven resource filtering and exclusions and duplicates
 resources already present in the processed output. The goal must also add plugin artifacts relevant
-to Native Build Tools and JUnit and inferred `junit-platform-native` dependencies.
+to Native Build Tools and JUnit and inferred `junit-platform-native` dependencies. Optional
+test-scoped JUnit dependencies that Maven resolves for the current project must remain available to
+the native test image, including when their versions come from dependency management.
 
 ## 2. Test discovery preconditions
 

--- a/native-maven-plugin/reproducers/issue-756/pom.xml
+++ b/native-maven-plugin/reproducers/issue-756/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
     The Universal Permissive License (UPL), Version 1.0
@@ -45,15 +45,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.graalvm.buildtools.examples</groupId>
-    <artifactId>seeding-build</artifactId>
+    <artifactId>issue-756</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.jupiter.version>5.8.1</junit.jupiter.version>
-        <graalvm.version>22.0.0</graalvm.version>
-        <mainClass>org.graalvm.demo.Application</mainClass>
+        <java.version>1.8</java.version>
+        <junit.jupiter.version>5.13.4</junit.jupiter.version>
+        <native.maven.plugin.version>1.1.3-SNAPSHOT</native.maven.plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -72,65 +71,56 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
-            <version>${graalvm.version}</version>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 
-    <build>
-        <finalName>${project.artifactId}</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <mainClass>${mainClass}</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>java</goal>
-                        </goals>
+    <profiles>
+        <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>test-native</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
+                        </executions>
                         <configuration>
-                            <mainClass>${mainClass}</mainClass>
+                            <fallback>false</fallback>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.8.1</version>
+                        <configuration>
+                            <source>${java.version}</source>
+                            <target>${java.version}</target>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/native-maven-plugin/reproducers/issue-756/src/test/java/org/graalvm/buildtools/examples/SimpleTest.java
+++ b/native-maven-plugin/reproducers/issue-756/src/test/java/org/graalvm/buildtools/examples/SimpleTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ */
+package org.graalvm.buildtools.examples;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SimpleTest {
+    @Test
+    void succeeds() {
+        assertTrue(true);
+    }
+}

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/issues/OptionalJUnitDependenciesFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/issues/OptionalJUnitDependenciesFunctionalTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.maven.issues
+
+import org.graalvm.buildtools.maven.AbstractGraalVMMavenFunctionalTest
+import spock.lang.Issue
+
+class OptionalJUnitDependenciesFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
+    @Issue("https://github.com/graalvm/native-build-tools/issues/756")
+    def "native tests resolve optional JUnit dependencies with managed versions"() {
+        withReproducer("issue-756")
+
+        when:
+        mvn '-DnativeDryRun', '-DskipTestExecution=true', '-DuseArgFile=false', '-Pnative', 'test'
+
+        then:
+        buildSucceeded
+        // Optional test-scoped JUnit dependencies managed by a BOM are part of native:test's classpath. §FS-native-tests.1
+        outputContains "junit-platform-launcher"
+        outputDoesNotContain "version can neither be null, empty nor blank"
+    }
+}

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/issues/OptionalJUnitDependenciesFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/issues/OptionalJUnitDependenciesFunctionalTest.groovy
@@ -45,6 +45,7 @@ import org.graalvm.buildtools.maven.AbstractGraalVMMavenFunctionalTest
 import spock.lang.Issue
 
 class OptionalJUnitDependenciesFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
+    // Optional test-scoped JUnit dependencies managed by a BOM are part of native:test's classpath. §FS-native-tests.1
     @Issue("https://github.com/graalvm/native-build-tools/issues/756")
     def "native tests resolve optional JUnit dependencies with managed versions"() {
         withReproducer("issue-756")
@@ -54,7 +55,6 @@ class OptionalJUnitDependenciesFunctionalTest extends AbstractGraalVMMavenFuncti
 
         then:
         buildSucceeded
-        // Optional test-scoped JUnit dependencies managed by a BOM are part of native:test's classpath. §FS-native-tests.1
         outputContains "junit-platform-launcher"
         outputDoesNotContain "version can neither be null, empty nor blank"
     }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -74,8 +74,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -406,27 +407,9 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
     }
 
     private void addMissingDependencies(CollectRequest collectRequest) {
-        // it's a chicken-and-egg problem, we need to resolve the dependencies first, in order
-        // to have the list of dependencies which are present and infer the ones which are missing
-        var current = resolveDependencies(request -> {
-            for (var dependency : project.getDependencies()) {
-                if (!dependency.isOptional()) {
-                    request.addDependency(new Dependency(
-                        new DefaultArtifact(
-                            dependency.getGroupId(),
-                            dependency.getArtifactId(),
-                            dependency.getClassifier(),
-                            "jar",
-                            dependency.getVersion()
-                        ),
-                        "runtime"
-                    ));
-                }
-            }
-        });
-        var currentClasspath = current.getArtifactResults().stream()
-            .map(ArtifactResult::getArtifact)
-            .filter(Objects::nonNull)
+        // Use Maven's resolved test graph so optional direct dependencies and managed versions are honored. §FS-native-tests.1
+        var currentClasspath = project.getArtifacts().stream()
+            .filter(artifact -> getDependencyScopes().contains(artifact.getScope()))
             .map(artifact -> new JUnitPlatformNativeDependenciesHelper.DependencyNotation(
                 artifact.getGroupId(),
                 artifact.getArtifactId(),
@@ -434,15 +417,45 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
             )).toList();
         var deps = JUnitPlatformNativeDependenciesHelper.inferMissingDependenciesForTestRuntime(currentClasspath);
         for (var missing : deps) {
+            var version = resolveMissingDependencyVersion(missing);
+            if (version.isEmpty()) {
+                logger.debug("Skipping inferred dependency " + missing.groupId() + ":" + missing.artifactId() +
+                    " because no JUnit Platform version was available.");
+                continue;
+            }
             var missingDependency = new Dependency(new DefaultArtifact(
                 missing.groupId(),
                 missing.artifactId(),
                 null,
                 null,
-                missing.version()
+                version.get()
             ), "runtime");
             collectRequest.addDependency(missingDependency);
         }
+    }
+
+    private Optional<String> resolveMissingDependencyVersion(JUnitPlatformNativeDependenciesHelper.DependencyNotation dependency) {
+        if (!isBlank(dependency.version())) {
+            return Optional.of(dependency.version());
+        }
+        return getManagedDependencyVersion(dependency.groupId(), dependency.artifactId());
+    }
+
+    private Optional<String> getManagedDependencyVersion(String groupId, String artifactId) {
+        var dependencyManagement = project.getDependencyManagement();
+        if (dependencyManagement == null) {
+            return Optional.empty();
+        }
+        return dependencyManagement.getDependencies().stream()
+            .filter(dependency -> Objects.equals(groupId, dependency.getGroupId()))
+            .filter(dependency -> Objects.equals(artifactId, dependency.getArtifactId()))
+            .map(org.apache.maven.model.Dependency::getVersion)
+            .filter(version -> !isBlank(version))
+            .findFirst();
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
     }
 
     private static final class Module {


### PR DESCRIPTION
Fixes #756

## What changed

This PR fixes Maven native test dependency inference for optional JUnit dependencies.

Before this change, optional test-scoped JUnit dependencies resolved by Maven could be dropped when Native Build Tools inferred missing JUnit Platform dependencies for `native:test`, especially when versions came from dependency management. That could lead to versionless-artifact failures or missing launcher support on the native test classpath.

After this change, Native Build Tools infers missing JUnit Platform dependencies from Maven's resolved test graph and preserves optional test-scoped dependencies that Maven already resolved for the current project.

## Why

Users expect `native:test` to follow Maven's resolved test dependency graph. Without this fix, valid Maven setups with optional JUnit dependencies and BOM-managed versions could fail even though Maven had already resolved the right test classpath.

## Example

Before:

A project with optional `junit-jupiter` and `junit-platform-launcher` dependencies managed by the JUnit BOM could hit a versionless-artifact failure while Native Build Tools reconstructed dependencies from raw model entries.

After:

The same setup uses Maven's resolved test graph, keeps the optional dependencies that were actually resolved, and includes `junit-platform-launcher` on the dry-run native test classpath.

## Implementation summary

- Infer missing JUnit Platform dependencies from Maven's resolved test graph instead of reconstructing them from raw project model entries.
- Preserve optional direct test dependencies that Maven resolved for the current project.
- Fall back to Maven dependency management when an inferred dependency needs a version.
- Add an issue reproducer and functional regression coverage for optional JUnit dependencies managed by the JUnit BOM.
- Update the Maven functional-test seeding build to include the BOM shape used by the reproducer.

## Validation

- `grund fmt . --marker --check`
- `git diff --check`
- `grund maven/FS-maven-native-tests --toc`
- `grund refs maven/FS-maven-native-tests --summary`
- Citation grep over the spec, `NativeTestMojo.java`, and the new functional test.
- `./gradlew :native-maven-plugin:inspections --no-daemon`
- `./gradlew :native-maven-plugin:test --no-daemon`
- `./gradlew :native-maven-plugin:functionalTest --no-daemon --fail-fast --tests org.graalvm.buildtools.maven.issues.OptionalJUnitDependenciesFunctionalTest`
