### PR TITLE
Log selected Maven metadata repository

### DIFF
--- a/native-gradle-plugin/docs/functional/resources-and-metadata.md
+++ b/native-gradle-plugin/docs/functional/resources-and-metadata.md
@@ -27,6 +27,10 @@ metadata repository URI, version, exclusions, and module-to-config-version overr
 directory must be consumable by native compile tasks and must contain only metadata selected for
 the binary's dependency graph. When no URI or version is pinned, the Gradle default should follow
 the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs/spec/goals.md#goal-fresh-metadata-users-can-fetch-the-latest-graalvm-reachability-metadata).
+Normal Gradle output must identify the selected metadata repository version
+or, when a version is not known for a local path or arbitrary URL, the selected repository source.
+This keeps important integration state visible without flooding build logs, as required by
+[§root/GOAL-concise-actionable-output](../../../docs/spec/goals.md#goal-concise-actionable-output-build-output-is-concise-actionable-and-token-efficient).
 
 ## 4. Missing metadata reports
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
@@ -74,6 +74,11 @@ class NativeConfigRepoFunctionalTest extends AbstractFunctionalTest {
         then:
         outputContains "Hello, from reflection!"
 
+        and: "identifies the selected metadata repository source"
+        // Gradle output identifies the selected metadata repository source. §FS-resources-and-metadata.3.
+        outputContains "Using GraalVM reachability metadata repository from " +
+                file("config-directory${extension ? '.' + extension : ''}").toURI().toASCIIString()
+
         and: "doesn't find a configuration directory for the current version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory not found. Trying latest version."
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/OfficialMetadataRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/OfficialMetadataRepoFunctionalTest.groovy
@@ -44,6 +44,8 @@ package org.graalvm.buildtools.gradle
 import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 import org.gradle.api.logging.LogLevel
 
+import static org.graalvm.buildtools.VersionInfo.METADATA_REPO_VERSION
+
 class OfficialMetadataRepoFunctionalTest extends AbstractFunctionalTest {
 
     def "the application runs when using the official metadata repository by default"() {
@@ -58,6 +60,10 @@ class OfficialMetadataRepoFunctionalTest extends AbstractFunctionalTest {
         tasks {
             succeeded ':jar', ':nativeCompile', ':nativeRun'
         }
+
+        and: "identifies the selected official metadata repository version"
+        // Gradle output identifies the selected metadata repository version. §FS-resources-and-metadata.3.
+        outputContains "Using GraalVM reachability metadata repository version ${METADATA_REPO_VERSION}"
 
         and: "the run succeeded and retrieved data from the database"
         outputContains "Customers in the database"
@@ -79,6 +85,10 @@ class OfficialMetadataRepoFunctionalTest extends AbstractFunctionalTest {
         tasks {
             failed ':nativeCompile'
         }
+
+        and: "doesn't identify a repository when metadata is disabled"
+        // Disabled metadata avoids selected-repository noise. §FS-resources-and-metadata.3.
+        outputDoesNotContain "Using GraalVM reachability metadata repository"
     }
 
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -588,6 +588,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                 LogLevel logLevel = determineLogLevel();
                 spec.getMaxParallelUsages().set(1);
                 spec.getParameters().getLogLevel().set(logLevel);
+                spec.getParameters().getEnabled().set(repositoryExtension.getEnabled());
                 spec.getParameters().getUri().set(repositoryExtension.getUri().map(serializableTransformerOf(configuredUri -> computeMetadataRepositoryUri(project, repositoryExtension, m -> logFallbackToDefaultUri(m, logger)))));
                 spec.getParameters().getRepositoryDescription().set(
                     repositoryExtension.getUri().zip(repositoryExtension.getVersion(),

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -589,6 +589,9 @@ public class NativeImagePlugin implements Plugin<Project> {
                 spec.getMaxParallelUsages().set(1);
                 spec.getParameters().getLogLevel().set(logLevel);
                 spec.getParameters().getUri().set(repositoryExtension.getUri().map(serializableTransformerOf(configuredUri -> computeMetadataRepositoryUri(project, repositoryExtension, m -> logFallbackToDefaultUri(m, logger)))));
+                spec.getParameters().getRepositoryDescription().set(
+                    repositoryExtension.getUri().zip(repositoryExtension.getVersion(),
+                        serializableBiFunctionOf(NativeImagePlugin::describeSelectedMetadataRepository)));
                 spec.getParameters().getCacheDir().set(
                     new File(project.getGradle().getGradleUserHomeDir(), "native-build-tools/repositories"));
                 spec.getParameters().getBackoffMaxRetries().convention(
@@ -603,6 +606,20 @@ public class NativeImagePlugin implements Plugin<Project> {
     private static void logFallbackToDefaultUri(URI defaultUri, GraalVMLogger logger) {
         logger.warn("Unable to find the GraalVM reachability metadata repository in Maven repository. " +
                     "Falling back to the default repository at " + defaultUri);
+    }
+
+    static String describeSelectedMetadataRepository(URI configuredUri, String version) {
+        if (version != null) {
+            try {
+                URI versionUri = new URI(String.format(METADATA_REPO_URL_TEMPLATE, version));
+                if (versionUri.equals(configuredUri)) {
+                    return "version " + version;
+                }
+            } catch (URISyntaxException e) {
+                throw new RuntimeException("Unable to convert repository version to URI", e);
+            }
+        }
+        return "from " + configuredUri.toASCIIString();
     }
 
     static URI computeMetadataRepositoryUri(Project project,

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/GraalVMReachabilityMetadataService.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/GraalVMReachabilityMetadataService.java
@@ -90,6 +90,8 @@ public abstract class GraalVMReachabilityMetadataService implements BuildService
     public interface Params extends BuildServiceParameters {
         Property<Integer> getBackoffMaxRetries();
 
+        Property<Boolean> getEnabled();
+
         Property<Integer> getInitialBackoffMillis();
 
         Property<LogLevel> getLogLevel();
@@ -104,8 +106,10 @@ public abstract class GraalVMReachabilityMetadataService implements BuildService
     public GraalVMReachabilityMetadataService() throws URISyntaxException {
         URI uri = getParameters().getUri().get();
         this.repository = newRepository(uri);
-        // Normal Gradle output exposes the repository selection. §FS-resources-and-metadata.3.
-        GraalVMLogger.of(LOGGER).lifecycle("Using GraalVM reachability metadata repository " + getParameters().getRepositoryDescription().get());
+        if (getParameters().getEnabled().get()) {
+            // Normal Gradle output exposes the enabled repository selection. §FS-resources-and-metadata.3.
+            GraalVMLogger.of(LOGGER).lifecycle("Using GraalVM reachability metadata repository " + getParameters().getRepositoryDescription().get());
+        }
     }
 
     private GraalVMReachabilityMetadataRepository newRepository(URI uri) throws URISyntaxException {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/GraalVMReachabilityMetadataService.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/GraalVMReachabilityMetadataService.java
@@ -96,12 +96,16 @@ public abstract class GraalVMReachabilityMetadataService implements BuildService
 
         Property<URI> getUri();
 
+        Property<String> getRepositoryDescription();
+
         DirectoryProperty getCacheDir();
     }
 
     public GraalVMReachabilityMetadataService() throws URISyntaxException {
         URI uri = getParameters().getUri().get();
         this.repository = newRepository(uri);
+        // Normal Gradle output exposes the repository selection. §FS-resources-and-metadata.3.
+        GraalVMLogger.of(LOGGER).lifecycle("Using GraalVM reachability metadata repository " + getParameters().getRepositoryDescription().get());
     }
 
     private GraalVMReachabilityMetadataRepository newRepository(URI uri) throws URISyntaxException {

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -51,6 +51,20 @@ class NativeImagePluginTest extends Specification {
         "https://custom.uri"                 | 'ignored'             | 'https://custom.uri'                                                                                                  | null
     }
 
+    // Protects Gradle's version-versus-source repository description. §FS-resources-and-metadata.3.
+    def "describes the selected metadata repository"() {
+        expect:
+        NativeImagePlugin.describeSelectedMetadataRepository(uri, version) == description
+
+        where:
+        uri                                                                                                                | version               | description
+        new URI(DEFAULT_GITHUB_RELEASES_METADATA_URI)                                                                      | METADATA_REPO_VERSION | "version ${METADATA_REPO_VERSION}"
+        new URI('https://github.com/oracle/graalvm-reachability-metadata/releases/download/155/graalvm-reachability-metadata-155.zip') | '155'                 | 'version 155'
+        new URI('https://custom.uri/repository.zip')                                                                       | METADATA_REPO_VERSION | 'from https://custom.uri/repository.zip'
+        new URI('file:/tmp/repository.zip')                                                                                | METADATA_REPO_VERSION | 'from file:/tmp/repository.zip'
+        new URI('https://custom.uri/repository.zip')                                                                       | null                  | 'from https://custom.uri/repository.zip'
+    }
+
     def "registers descriptions for user-facing tasks"() {
         when:
         project.plugins.apply("java")

--- a/native-maven-plugin/docs/functional/resources-and-metadata.md
+++ b/native-maven-plugin/docs/functional/resources-and-metadata.md
@@ -22,6 +22,10 @@ metadata repository, exclusions, and module-to-config-version overrides. It must
 configuration directory to the native image build without requiring users to manually copy
 repository contents. When no URI, version, or local path is pinned, the Maven default should follow
 the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs/spec/goals.md#goal-fresh-metadata-users-can-fetch-the-latest-graalvm-reachability-metadata).
+Normal Maven output must identify the selected metadata repository version
+or, when a version is not known for a local path or arbitrary URL, the selected repository source.
+This keeps important integration state visible without flooding build logs, as required by
+[§root/GOAL-concise-actionable-output](../../../docs/spec/goals.md#goal-concise-actionable-output-build-output-is-concise-actionable-and-token-efficient).
 
 ## 3. Missing metadata reports
 

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
@@ -67,6 +67,9 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         then:
         buildSucceeded
         outputContains "Hello, from reflection!"
+        // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
+        outputContains "Using GraalVM reachability metadata repository from " +
+                file("config-directory").toURI().toASCIIString()
 
         and: "it doesn't find a configuration directory for the current version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory not found. Trying latest version."
@@ -121,6 +124,9 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         then:
         buildSucceeded
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration is forced to version 2"
+        // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
+        outputContains "Using GraalVM reachability metadata repository from " +
+                file("config-directory").toURI().toASCIIString()
         outputContains "Reflection failed"
     }
 
@@ -134,6 +140,9 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         then:
         buildSucceeded
         outputContains "Hello, from reflection!"
+        // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
+        outputContains "Using GraalVM reachability metadata repository from " +
+                file("target/repo.zip").toURI().toASCIIString()
 
         and: "it doesn't find a configuration directory for the current version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory not found. Trying latest version."
@@ -154,6 +163,9 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         buildSucceeded
         outputContains "Hello, from reflection!"
         outputContains "Downloaded GraalVM reachability metadata repository from http://localhost:${localServerPort}/target/repo.zip"
+        // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
+        outputContains "Using GraalVM reachability metadata repository from " +
+                "http://localhost:${localServerPort}/target/repo.zip"
 
         and: "it doesn't find a configuration directory for the current version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory not found. Trying latest version."

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/OfficialMetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/OfficialMetadataRepositoryFunctionalTest.groovy
@@ -41,6 +41,7 @@
 
 package org.graalvm.buildtools.maven
 
+import org.graalvm.buildtools.VersionInfo
 import spock.lang.IgnoreIf
 
 class OfficialMetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
@@ -55,6 +56,8 @@ class OfficialMetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunct
 
         then:
         buildSucceeded
+        // Maven output identifies the selected metadata repository version. §FS-resources-and-metadata.2.
+        outputContains "Using GraalVM reachability metadata repository version ${VersionInfo.METADATA_REPO_VERSION}"
 
         and: "the run succeeded and retrieved data from the database"
         outputContains "Customers in the database"
@@ -74,6 +77,8 @@ class OfficialMetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunct
 
         then:
         buildSucceeded
+        // Maven output identifies the selected metadata repository version. §FS-resources-and-metadata.2.
+        outputContains "Using GraalVM reachability metadata repository version 1.0-M1"
 
         and: "the run succeeded and retrieved data from the database"
         outputContains "Customers in the database"
@@ -93,6 +98,8 @@ class OfficialMetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunct
 
         then:
         buildSucceeded
+        // Maven output identifies the selected metadata repository version. §FS-resources-and-metadata.2.
+        outputContains "Using GraalVM reachability metadata repository version 1.0-M1"
 
         and: "the run succeeded and retrieved data from the database"
         outputContains "Customers in the database"
@@ -112,5 +119,7 @@ class OfficialMetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunct
 
         then:
         buildFailed
+        // Disabled metadata avoids selected-repository noise. §FS-resources-and-metadata.2.
+        outputDoesNotContain "Using GraalVM reachability metadata repository"
     }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -163,6 +163,7 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
                     "Note: Since the repository is enabled by default, you can disable it manually in your pom.xml file (see this: " +
                     "https://graalvm.github.io/native-build-tools/latest/maven-plugin.html#_configuring_the_metadata_repository)");
         } else {
+            logSelectedMetadataRepository();
             metadataRepository = new FileSystemRepository(repoPath, new FileSystemRepository.Logger() {
                 @Override
                 public void log(String groupId, String artifactId, String version, Supplier<String> message) {
@@ -170,6 +171,26 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
                 }
             });
         }
+    }
+
+    private void logSelectedMetadataRepository() {
+        // Normal Maven output exposes the repository selection. §FS-resources-and-metadata.2.
+        logger.info("Using GraalVM reachability metadata repository " + describeSelectedMetadataRepository());
+    }
+
+    private String describeSelectedMetadataRepository() {
+        if (metadataRepositoryConfiguration != null) {
+            if (metadataRepositoryConfiguration.getVersion() != null) {
+                return "version " + metadataRepositoryConfiguration.getVersion();
+            }
+            if (metadataRepositoryConfiguration.getLocalPath() != null) {
+                return "from " + metadataRepositoryConfiguration.getLocalPath().toURI().toASCIIString();
+            }
+            if (metadataRepositoryConfiguration.getUrl() != null) {
+                return "from " + metadataRepositoryConfiguration.getUrl();
+            }
+        }
+        return "version " + VersionInfo.METADATA_REPO_VERSION;
     }
 
     private Path getDefaultRepo(Path destinationRoot) {


### PR DESCRIPTION
Fixes #444

## What changed

This PR makes the Maven plugin log which reachability metadata repository version or source it selected.

Before this change, metadata repository selection happened silently in normal Maven output. Users could see the effects of metadata selection, but not which repository version or source was actually in use.

After this change, the Maven plugin prints one concise info-level line describing the selected official metadata repository version, or the configured source when a semantic version is not available.

## Why

Metadata repository selection is user-visible integration state. Surfacing it in normal Maven output makes builds easier to understand and troubleshoot.

## Example

Before:

A Maven build could resolve metadata from the default repository, a forced version, a local path, or a custom URL without telling the user which repository source was actually chosen.

After:

The build emits output such as `Using GraalVM reachability metadata repository version <version>` or `Using GraalVM reachability metadata repository from <source>`.

## Implementation summary

- Add one concise info-level Maven log line after metadata repository selection and before dependency metadata lookup.
- Report official repository versions when they are known.
- Report local paths, ZIP paths, and arbitrary URLs as repository sources when a semantic version is not known.
- Keep disabled metadata quiet with respect to the selected-repository line.
- Extend Maven functional coverage across default, explicit, implicit-enable, path, ZIP, URL, forced-version, and disabled metadata cases.

## Validation

- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-maven-plugin:test --no-daemon`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1 ./gradlew :native-maven-plugin:functionalTest --no-daemon --fail-fast --tests org.graalvm.buildtools.maven.MetadataRepositoryFunctionalTest`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1 ./gradlew :native-maven-plugin:functionalTest --no-daemon --fail-fast --tests org.graalvm.buildtools.maven.OfficialMetadataRepositoryFunctionalTest`
- `git diff --check`
- `grund maven/FS-maven-resources-and-metadata.2`
