### PR TITLE
Log Gradle agent output directory

### DIFF
--- a/native-gradle-plugin/docs/functional/tracing-agent.md
+++ b/native-gradle-plugin/docs/functional/tracing-agent.md
@@ -35,7 +35,10 @@ not create agent output for those tasks.
 ## 4. Agent output layout
 
 Agent output must be written under `build/native/agent-output/<taskName>` unless users configure a
-direct mode output location. Generated output must be suitable for later merge and copy steps.
+direct mode output location. When a task is instrumented, the Gradle task output must report the
+Gradle-managed agent output directory so users can find collected metadata without verbose logging,
+aligning with §root/GOAL-concise-actionable-output. Generated output must be suitable for later
+merge and copy steps.
 
 ## 5. Metadata copy
 

--- a/native-gradle-plugin/docs/functional/tracing-agent.md
+++ b/native-gradle-plugin/docs/functional/tracing-agent.md
@@ -37,7 +37,7 @@ not create agent output for those tasks.
 Agent output must be written under `build/native/agent-output/<taskName>` unless users configure a
 direct mode output location. When a task is instrumented, the Gradle task output must report the
 Gradle-managed agent output directory so users can find collected metadata without verbose logging,
-aligning with §root/GOAL-concise-actionable-output. Generated output must be suitable for later
+aligning with [§root/GOAL-concise-actionable-output](../../../docs/spec/goals.md#goal-concise-actionable-output-build-output-is-concise-actionable-and-token-efficient). Generated output must be suitable for later
 merge and copy steps.
 
 ## 5. Metadata copy

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -118,7 +118,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
 """.trim()
 
         and:
-        // Instrumented task output reports the Gradle-managed agent output directory. §FS-gradle-tracing-agent.4.
+        // Instrumented task output reports the Gradle-managed agent output directory. §FS-tracing-agent.4.
         outputContains "Instrumenting task with the native-image-agent: test. Agent output: ${file('build/native/agent-output/test').path}"
         assert metadataExistsAt("build/native/agent-output/test")
 
@@ -173,7 +173,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         }
 
         and:
-        // Instrumented task output reports the Gradle-managed agent output directory. §FS-gradle-tracing-agent.4.
+        // Instrumented task output reports the Gradle-managed agent output directory. §FS-tracing-agent.4.
         outputContains "Instrumenting task with the native-image-agent: run. Agent output: ${file('build/native/agent-output/run').path}"
         assert metadataExistsAt("build/native/agent-output/run")
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -118,6 +118,8 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
 """.trim()
 
         and:
+        // Instrumented task output reports the Gradle-managed agent output directory. §FS-gradle-tracing-agent.4.
+        outputContains "Instrumenting task with the native-image-agent: test. Agent output: ${file('build/native/agent-output/test').path}"
         assert metadataExistsAt("build/native/agent-output/test")
 
         when:
@@ -171,6 +173,8 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         }
 
         and:
+        // Instrumented task output reports the Gradle-managed agent output directory. §FS-gradle-tracing-agent.4.
+        outputContains "Instrumenting task with the native-image-agent: run. Agent output: ${file('build/native/agent-output/run').path}"
         assert metadataExistsAt("build/native/agent-output/run")
 
         when:

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -1082,6 +1082,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                                 Task taskToInstrument,
                                 JavaForkOptions javaForkOptions) {
         Provider<AgentConfiguration> agentConfiguration = AgentConfigurationFactory.getAgentConfiguration(agentMode, graalExtension.getAgent());
+        Provider<Directory> outputDir = AgentConfigurationFactory.getAgentOutputDirectoryForTask(project.getLayout(), taskToInstrument.getName());
         Provider<JavaLauncher> javaLauncherForAgent = javaLauncherForAgent(project.getProviders());
         // Agent runs prefer an available GraalVM Java without replacing task configuration with a regular JAVA_HOME. §FS-tracing-agent.2.1
         if (agentConfiguration.get().isEnabled()) {
@@ -1101,7 +1102,11 @@ public class NativeImagePlugin implements Plugin<Project> {
             @Override
             public void execute(@Nonnull Task task) {
                 if (agentConfiguration.get().isEnabled()) {
-                    logger.logOnce("Instrumenting task with the native-image-agent: " + task.getName());
+                    // Report where users can find generated tracing-agent metadata. §FS-gradle-tracing-agent.4.
+                    logger.logOnce("Instrumenting task with the native-image-agent: "
+                            + task.getName()
+                            + ". Agent output: "
+                            + outputDir.get().getAsFile().getAbsolutePath());
                     JavaLauncher javaLauncher = javaLauncherForAgent.getOrNull();
                     if (javaLauncher != null && !(task instanceof Test) && !(task instanceof JavaExec)) {
                         javaForkOptions.setExecutable(javaLauncher.getExecutablePath().getAsFile().getAbsolutePath());
@@ -1115,7 +1120,6 @@ public class NativeImagePlugin implements Plugin<Project> {
         cliProvider.getFilterableEntries().set(graalExtension.getAgent().getFilterableEntries());
         cliProvider.getAgentMode().set(agentMode);
 
-        Provider<Directory> outputDir = AgentConfigurationFactory.getAgentOutputDirectoryForTask(project.getLayout(), taskToInstrument.getName());
         Provider<Boolean> isMergingEnabled = agentConfiguration.map(serializableTransformerOf(AgentConfiguration::isEnabled));
         Provider<AgentMode> agentModeProvider = agentConfiguration.map(serializableTransformerOf(AgentConfiguration::getAgentMode));
         Supplier<List<String>> mergeInputDirs = serializableSupplierOf(() -> outputDir.map(serializableTransformerOf(NativeImagePlugin::agentSessionDirectories)).get());

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -1102,8 +1102,8 @@ public class NativeImagePlugin implements Plugin<Project> {
             @Override
             public void execute(@Nonnull Task task) {
                 if (agentConfiguration.get().isEnabled()) {
-                    // Report where users can find generated tracing-agent metadata. §FS-gradle-tracing-agent.4.
-                    logger.logOnce("Instrumenting task with the native-image-agent: "
+                    // Report where users can find generated tracing-agent metadata. §FS-tracing-agent.4.
+                    logger.lifecycle("Instrumenting task with the native-image-agent: "
                             + task.getName()
                             + ". Agent output: "
                             + outputDir.get().getAsFile().getAbsolutePath());

--- a/native-maven-plugin/docs/functional/tracing-agent.md
+++ b/native-maven-plugin/docs/functional/tracing-agent.md
@@ -26,6 +26,10 @@ the native plugin's `<agentExecutionId>` configuration value; the default execut
 `java-agent` so existing POMs keep working. Generated test-agent arguments derived from project paths
 must remain a single JVM argument when passed through Maven test runners, including when those paths
 contain spaces.
+When Maven configures an instrumented test or application execution, normal build
+output must report the Maven-managed agent output directory so users can find collected metadata
+without debug logging, aligning with
+[§root/GOAL-concise-actionable-output](../../../docs/spec/goals.md#goal-concise-actionable-output-build-output-is-concise-actionable-and-token-efficient).
 
 ## 4. Merge and copy
 

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
@@ -80,6 +80,10 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
         // Agent is used with Surefire
         outputContains '-agentlib:native-image-agent='
 
+        and:
+        // Instrumented execution output reports the Maven-managed agent output directory. §FS-tracing-agent.3.
+        outputContains "Instrumenting Maven test execution with the native-image-agent. Agent output: " +
+                file('target/native/agent-output/test').absolutePath
 
         and:
         // Agent generates files
@@ -115,7 +119,17 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
     def "test agent with metadata copy task"() {
         given:
         withSample("java-application-with-reflection")
+
+        when:
         mvn'-Pnative', '-DquickBuild', '-DskipNativeBuild=true', 'package', '-Dagent=true', 'exec:exec@java-agent'
+
+        then:
+        buildSucceeded
+
+        and:
+        // Instrumented execution output reports the Maven-managed agent output directory. §FS-tracing-agent.3.
+        outputContains "Instrumenting Maven application execution with the native-image-agent. Agent output: " +
+                file('target/native/agent-output/main').absolutePath
 
         when:
         mvn'-Pnative', '-DquickBuild', '-DskipNativeTests', '-Dagent=true', 'native:metadata-copy'

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
@@ -59,7 +59,9 @@ import org.graalvm.buildtools.utils.SharedConstants;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -149,6 +151,7 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
+                Set<Context> instrumentedContexts = EnumSet.noneOf(Context.class);
 
                 // Test configuration
                 List<String> plugins = List.of("maven-surefire-plugin", "maven-failsafe-plugin");
@@ -157,7 +160,9 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                         configureJunitListener(plugin, testIdsDir);
                         if (agent.isEnabled()) {
                             List<String> agentOptions = agent.getAgentCommandLine();
-                            configureAgentForPlugin(plugin, buildAgentArgument(target, Context.test, agentOptions));
+                            if (configureAgentForPlugin(plugin, buildAgentArgument(target, Context.test, agentOptions))) {
+                                instrumentedContexts.add(Context.test);
+                            }
                         }
                     });
                 }
@@ -168,6 +173,7 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                     withPlugin(build, "exec-maven-plugin", execPlugin ->
                             updatePluginConfiguration(execPlugin, (exec, config) -> {
                                 if (agentExecutionId.equals(exec.getId())) {
+                                    instrumentedContexts.add(Context.main);
                                     Xpp3Dom commandlineArgs = findOrAppend(config, "arguments");
                                     Xpp3Dom[] arrayOfChildren = commandlineArgs.getChildren();
                                     for (int i = 0; i < arrayOfChildren.length; i++) {
@@ -201,6 +207,7 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                         agentResourceDirectory.setValue(agentOutputDirectoryFor(target, context));
                         setupMergeAgentFiles(exec, configuration, context);
                     });
+                    instrumentedContexts.forEach(context -> logAgentOutput(target, context));
                 }
             });
         }
@@ -233,7 +240,10 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
                 .ifPresent(consumer);
     }
 
-    private static void configureAgentForPlugin(Plugin plugin, String agentArgument) {
+    private static boolean configureAgentForPlugin(Plugin plugin, String agentArgument) {
+        if (plugin.getExecutions().isEmpty()) {
+            return false;
+        }
         updatePluginConfiguration(plugin, (exec, configuration) -> {
             Xpp3Dom systemPropertyVariables = findOrAppend(configuration, SYSTEM_PROPERTY_VARIABLES);
             Xpp3Dom agent = findOrAppend(systemPropertyVariables, NATIVEIMAGE_IMAGECODE);
@@ -245,6 +255,14 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
             configuration.addChild(argLine);
             findOrAppend(configuration, "jvm").setValue(getGraalvmJava());
         });
+        return true;
+    }
+
+    private static void logAgentOutput(String baseDir, Context context) {
+        String execution = context == Context.test ? "test" : "application";
+        String outputDirectory = new File(agentOutputDirectoryFor(baseDir, context)).getAbsolutePath();
+        // Report where users can find generated tracing-agent metadata. §FS-tracing-agent.3.
+        logger.info("Instrumenting Maven " + execution + " execution with the native-image-agent. Agent output: " + outputDirectory);
     }
 
     private static void configureJunitListener(Plugin surefirePlugin, String testIdsDir) {


### PR DESCRIPTION
Fixes #443
## What changed

This PR makes Gradle agent runs print the agent output directory in normal build output.

Before this change, users had to know the default output layout or inspect the filesystem to find the generated tracing-agent metadata.

After this change, the build tells you exactly where the metadata was written.

## Why

Users can immediately find generated tracing-agent metadata without turning on extra logging or guessing the output path.

## Example

Before:

```text
[native-image-plugin] Instrumenting task with the native-image-agent: test
```

After:

```text
[native-image-plugin] Instrumenting task with the native-image-agent: test. Agent output: build/native/agent-output/test
```

The same applies to `run`, where the output now points at `build/native/agent-output/run`.

## Implementation summary

- Document the new visible agent-output message in the Gradle tracing-agent docs.
- Extend the plugin log line for instrumented tasks so it prints the resolved agent output directory.
- Add regression coverage for both `test` and `run` agent flows.

## Validation

- `grund fmt . --marker --check`: passed.
- `git diff --check`: passed.
- `JAVA_HOME=/home/jovan/.mx/jdks/labsjdk-ee-17-jvmci-23.1-b02 ./gradlew :native-gradle-plugin:test :native-gradle-plugin:inspections`: passed.
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:functionalTest --tests 'org.graalvm.buildtools.gradle.JavaApplicationWithAgentFunctionalTest.agent is passed*' --tests 'org.graalvm.buildtools.gradle.JavaApplicationWithAgentFunctionalTest.agent instruments run task*'`: passed.

The focused functional run emitted the expected destination-directory messages for both touched scenarios:

```text
[native-image-plugin] Instrumenting task with the native-image-agent: test. Agent output: /tmp/.../build/native/agent-output/test
[native-image-plugin] Instrumenting task with the native-image-agent: run. Agent output: /tmp/.../build/native/agent-output/run
```
