### PR TITLE
Clarify JUnit launcher alignment for Maven native tests

### DIFF
--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -675,7 +675,6 @@ Running the `./mvnw -Pnative test` will then build and run tests as native code.
 
 This plugin requires the Maven Surefire plugin 3.0.0 or higher to run tests as native code.
 
-// Native test classpath and launcher/feature behavior are specified by §maven/FS-maven-native-tests.1 and §maven/FS-maven-native-tests.3.
 Native test execution also uses the JUnit Platform while building the native test image.
 By default, the plugin builds the test image with `NativeImageJUnitLauncher` and `JUnitPlatformFeature`,
 which discover and register selected tests using the JUnit Platform artifacts on the test classpath.
@@ -720,7 +719,6 @@ If Maven Surefire is using an older version of the JUnit Platform, the build wil
 [ERROR] Test configuration file wasn't found. Make sure that test execution wasn't skipped.
 ----
 
-// Native-image analysis registration is specified by §FS-native-tests.2.
 If the native test classpath contains incompatible JUnit Platform launcher and engine versions,
 native-image analysis can also fail during test discovery with an error similar to the following:
 

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -675,11 +675,25 @@ Running the `./mvnw -Pnative test` will then build and run tests as native code.
 
 This plugin requires the Maven Surefire plugin 3.0.0 or higher to run tests as native code.
 
+// Native test classpath and launcher/feature behavior are specified by §maven/FS-maven-native-tests.1 and §maven/FS-maven-native-tests.3.
+Native test execution also uses the JUnit Platform while building the native test image.
+By default, the plugin builds the test image with `NativeImageJUnitLauncher` and `JUnitPlatformFeature`,
+which discover and register selected tests using the JUnit Platform artifacts on the test classpath.
+For that reason, the `junit-platform-launcher` artifact available to native test execution must be
+compatible with the JUnit Platform engine artifacts, such as JUnit Jupiter or JUnit Vintage.
+
 Each version of the Maven Surefire plugin has a dependency on a particular version of the JUnit Platform.
-You therefore need to ensure that Maven Surefire is using at least version 1.8 of the JUnit Platform.
-Beginning with version 3.0 M4, Maven Surefire automatically aligns the JUnit Platform version used by Surefire with the version needed by the user's configured version of JUnit Jupiter or JUnit Vintage.
-Since the examples here use Maven Surefire 3.0 M5, their maven POMs do not require any special configuration regarding the JUnit Platform version.
-However, if you are using a version of Maven Surefire prior to 3.0 M4, you will need to add an explicit dependency on the `junit-platform-launcher` artifact to the `dependencies` section of your `native` profile configuration. For example:
+Ensure that Maven Surefire and Native Build Tools use compatible JUnit Platform artifacts,
+and that those artifacts are at least version 1.8.
+Beginning with version 3.0 M4, Maven Surefire automatically aligns the JUnit Platform version used by
+Surefire with the version needed by the user's configured version of JUnit Jupiter or JUnit Vintage.
+Since the examples here use Maven Surefire 3.0 M5, their Maven POMs do not require any special configuration regarding the JUnit Platform version.
+However, if you are using a version of Maven Surefire prior to 3.0 M4, or if your native test
+classpath otherwise contains mismatched JUnit Platform artifacts, you will need to add an explicit
+dependency on the `junit-platform-launcher` artifact to the `dependencies` section of your `native`
+profile configuration.
+Choose a `junit-platform-launcher` version managed by your JUnit BOM or one that matches the JUnit Platform version used by your test engines.
+For example:
 
 [source,xml, role="multi-language-sample"]
 ----
@@ -704,6 +718,15 @@ If Maven Surefire is using an older version of the JUnit Platform, the build wil
 
 ----
 [ERROR] Test configuration file wasn't found. Make sure that test execution wasn't skipped.
+----
+
+// Native-image analysis registration is specified by §FS-native-tests.2.
+If the native test classpath contains incompatible JUnit Platform launcher and engine versions,
+native-image analysis can also fail during test discovery with an error similar to the following:
+
+----
+OutputDirectoryProvider not available; probably due to unaligned versions of the junit-platform-engine
+and junit-platform-launcher jars on the classpath/module path.
 ----
 
 [[testing-support-disabling]]


### PR DESCRIPTION
Fixes #706

## What changed

This PR clarifies the Maven native test docs around `junit-platform-launcher` compatibility.

Before this change, the documentation framed `junit-platform-launcher` alignment mainly as a Maven Surefire concern, even though native test image analysis also depends on JUnit Platform artifacts.

After this change, the docs explain that native test execution also requires compatible JUnit Platform launcher and engine artifacts, and that users may need to declare `junit-platform-launcher` explicitly when versions are mismatched.

## Why

Without this clarification, users can end up chasing native-image analysis errors without realizing the mismatch comes from JUnit Platform artifact alignment on the native test classpath rather than only from Surefire.

## Example

Before:

A project could follow the old documentation, align Surefire, and still hit native-image analysis failures such as `OutputDirectoryProvider not available` because the launcher on the native test classpath did not match the JUnit Platform engine artifacts.

After:

The docs now explain that native test image analysis also depends on compatible JUnit Platform artifacts, and they call out when an explicit `junit-platform-launcher` dependency may be needed.

## Implementation summary

- Update the Maven plugin version-compatibility docs to explain the native test impact of `junit-platform-launcher` alignment.
- Clarify that native test execution uses JUnit Platform artifacts while building the native test image, not only during Surefire execution.
- Document when users may need to add an explicit `junit-platform-launcher` dependency.
- Add the `OutputDirectoryProvider not available` mismatch as a concrete example of the failure mode.

## Validation

- `grund fmt . --marker --check`
- `git diff --check`
- `grund maven/FS-maven-native-tests.1`
- `grund maven/FS-maven-native-tests.3`
- `grund FS-native-tests.2`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal PATH=/home/jovan/.sdkman/candidates/java/17.0.12-graal/bin:$PATH ./gradlew --no-daemon :docs:asciidoctor --rerun-tasks`
- Rendered HTML check for the new `junit-platform-launcher` guidance and `OutputDirectoryProvider` example.
