### PR TITLE
Fix custom Gradle binary classpath wiring

### DIFF
--- a/native-gradle-plugin/docs/functional/native-image-tasks.md
+++ b/native-gradle-plugin/docs/functional/native-image-tasks.md
@@ -16,8 +16,9 @@ It uses compiled test classes, test resources, the test runtime classpath, JUnit
 selected test identifiers, and the `test` binary options.
 
 Every custom binary must receive a derived `native<Binary>Compile` task. All compile tasks must
-declare Gradle inputs and outputs for the selected options and generated files so Gradle can skip,
-cache, or rerun them consistently.
+declare Gradle inputs and outputs for the selected options and generated files, including the
+binary's classpath and reachability-metadata exclusions, so Gradle can skip, cache, or rerun them
+consistently.
 
 ## 2. Run tasks
 

--- a/native-gradle-plugin/docs/functional/plugin-model.md
+++ b/native-gradle-plugin/docs/functional/plugin-model.md
@@ -60,7 +60,9 @@ set so `nativeTest` can build and run native JUnit tests without a separate bina
 Users may add entries to the `binaries` container for extra source sets or entry points. Each entry
 must create matching compile and run tasks with predictable task names derived from the binary
 name. Custom binaries apply [§root/FS-native-builds](../../../docs/spec/functional/native-image-builds.md#fs-native-builds-both-plugins-build-native-images-from-build-tool-project-state) without forcing users outside the
-plugin's option model.
+plugin's option model. Custom application binaries default to the main runtime classpath unless a
+specialized registration or image mode, such as a native test binary or layer-create binary,
+provides a source-set-specific or intentionally empty classpath.
 
 ## 5. Activation examples
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
@@ -43,6 +43,7 @@ package org.graalvm.buildtools.gradle
 
 import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 import org.gradle.api.logging.LogLevel
+import spock.lang.Issue
 import spock.lang.Unroll
 
 class NativeConfigRepoFunctionalTest extends AbstractFunctionalTest {
@@ -91,6 +92,40 @@ class NativeConfigRepoFunctionalTest extends AbstractFunctionalTest {
         'zip'    | 'zip file'
         'tar.gz' | 'tar.gz file'
         'tar.bz2' | 'tar.bz2 file'
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/478")
+    // Protects custom binary runtime classpath and metadata exclusions. §FS-plugin-model.4
+    // §FS-native-tasks.1 §FS-resources-and-metadata.6
+    def "custom binary uses runtime classpath and metadata exclusions"() {
+        given:
+        withSample("native-config-integration")
+
+        buildFile << """
+graalvmNative {
+    useArgFile = false
+    binaries {
+        qa {
+            imageName = 'native-config-integration-qa'
+            mainClass = 'org.graalvm.example.Application'
+            verbose = true
+        }
+    }
+}
+        """
+
+        when:
+        run 'nativeQaRun', "-D${NativeImagePlugin.CONFIG_REPO_LOGLEVEL}=${LogLevel.LIFECYCLE}", '--info'
+
+        then:
+        tasks {
+            succeeded ':jar', ':nativeQaCompile', ':nativeQaRun'
+        }
+
+        and:
+        outputContains "Hello, from reflection!"
+        outputContains "--exclude-config"
+        outputContains "library-with-reflection-1.5.jar"
     }
 
     def "can exclude a dependency from native configuration"() {

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
@@ -94,9 +94,9 @@ class NativeConfigRepoFunctionalTest extends AbstractFunctionalTest {
         'tar.bz2' | 'tar.bz2 file'
     }
 
-    @Issue("https://github.com/graalvm/native-build-tools/issues/478")
     // Protects custom binary runtime classpath and metadata exclusions. §FS-plugin-model.4
     // §FS-native-tasks.1 §FS-resources-and-metadata.6
+    @Issue("https://github.com/graalvm/native-build-tools/issues/478")
     def "custom binary uses runtime classpath and metadata exclusions"() {
         given:
         withSample("native-config-integration")

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -59,6 +59,7 @@ import org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator;
 import org.graalvm.buildtools.gradle.internal.agent.AgentConfigurationFactory;
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask;
 import org.graalvm.buildtools.gradle.tasks.CollectReachabilityMetadata;
+import org.graalvm.buildtools.gradle.tasks.CreateLayerOptions;
 import org.graalvm.buildtools.gradle.tasks.GenerateDynamicAccessMetadata;
 import org.graalvm.buildtools.gradle.tasks.GenerateResourcesConfigFile;
 import org.graalvm.buildtools.gradle.tasks.ListLibrariesMissingMetadata;
@@ -380,6 +381,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                                                 TaskContainer tasks,
                                                 SourceSetContainer sourceSets) {
         graalExtension.getBinaries().configureEach(options -> {
+            configureCustomApplicationBinary(project, options);
             String binaryName = options.getName();
             String compileTaskName = deriveTaskName(binaryName, "native", "Compile");
             if (NATIVE_MAIN_EXTENSION.equals(binaryName)) {
@@ -485,6 +487,23 @@ public class NativeImagePlugin implements Plugin<Project> {
             configureJvmReachabilityConfigurationDirectories(project, graalExtension, options, sourceSet);
             configureJvmReachabilityExcludeConfigArgs(project, graalExtension, options, sourceSet);
         });
+    }
+
+    private void configureCustomApplicationBinary(Project project, NativeImageOptions options) {
+        ConfigurationContainer configurations = project.getConfigurations();
+        String binaryName = options.getName();
+        if (configurations.findByName(imageClasspathConfigurationNameFor(binaryName)) != null) {
+            return;
+        }
+        // Custom application binaries share the main runtime classpath and option model. §FS-plugin-model.4
+        createNativeConfigurations(project, binaryName, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+        setupExtensionConfigExcludes(options, configurations);
+        Configuration imageClasspath = configurations.getByName(imageClasspathConfigurationNameFor(binaryName));
+        options.getClasspath().from(project.provider(() -> createsLayer(options) ? Collections.emptyList() : Collections.singletonList(imageClasspath)));
+    }
+
+    private static boolean createsLayer(NativeImageOptions options) {
+        return options.getLayers().stream().anyMatch(CreateLayerOptions.class::isInstance);
     }
 
     private static boolean emitsBuildReport(String buildArg) {
@@ -1002,13 +1021,13 @@ public class NativeImagePlugin implements Plugin<Project> {
                                                  Project project,
                                                  NativeImageOptions mainExtension,
                                                  SourceSet sourceSet) {
-        NativeImageOptions testExtension = graalExtension.getBinaries().create(binaryName);
         createNativeConfigurations(
             project,
             binaryName,
             // Custom native tests use their selected source set runtime classpath. §FS-native-tests.1.1
             sourceSet.getRuntimeClasspathConfigurationName()
         );
+        NativeImageOptions testExtension = graalExtension.getBinaries().create(binaryName);
         var configurations = project.getConfigurations();
         setupExtensionConfigExcludes(testExtension, configurations);
 

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -8,6 +8,8 @@ import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Issue
 import spock.lang.Specification
 
+import java.util.regex.Pattern
+
 import static org.graalvm.buildtools.VersionInfo.METADATA_REPO_VERSION
 
 class NativeImagePluginTest extends Specification {
@@ -81,6 +83,31 @@ class NativeImagePluginTest extends Specification {
         taskDescription("nativeTest") == "Runs the test native binary."
         taskDescription("nativeTestBuild") == "Deprecated alias for nativeTestCompile."
         taskDescription("generateTestResourcesConfigFile") == "Scans resources and generates a resource-config.json file for the test binary."
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/478")
+    // Protects custom binary classpath wiring and exclusion args. §FS-plugin-model.4
+    // §FS-native-tasks.1 §FS-resources-and-metadata.6
+    def "custom application binaries use native image classpath configuration"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def testJar = project.file("test.jar")
+
+        when:
+        def qa = extension.binaries.create("qa")
+        def classpathConfiguration = project.configurations.getByName("nativeImageQaClasspath")
+        qa.excludeConfig.put(testJar, ["META-INF/*"])
+
+        then:
+        taskDescription("nativeQaCompile") == "Builds a native executable for the qa binary."
+        taskDescription("nativeQaRun") == "Runs the qa native binary."
+        qa.classpath.files.containsAll(classpathConfiguration.files)
+        qa.excludeConfigArgs.get() == [
+                "--exclude-config",
+                Pattern.quote(testJar.toPath().toAbsolutePath().toString()),
+                "META-INF/*"
+        ]
     }
 
     private String taskDescription(String name) {

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -85,9 +85,9 @@ class NativeImagePluginTest extends Specification {
         taskDescription("generateTestResourcesConfigFile") == "Scans resources and generates a resource-config.json file for the test binary."
     }
 
-    @Issue("https://github.com/graalvm/native-build-tools/issues/478")
     // Protects custom binary classpath wiring and exclusion args. §FS-plugin-model.4
     // §FS-native-tasks.1 §FS-resources-and-metadata.6
+    @Issue("https://github.com/graalvm/native-build-tools/issues/478")
     def "custom application binaries use native image classpath configuration"() {
         given:
         project.plugins.apply("java")


### PR DESCRIPTION
Fixes #478

## What changed

This PR fixes custom Gradle application binaries so they inherit the expected runtime classpath and metadata exclusion wiring.

Before this change, custom binaries created through `graalvmNative.binaries` could miss the main runtime classpath by default and could also miss reachability metadata exclusion handling.

After this change, custom application binaries follow the main runtime classpath model unless a more specific source set or image mode says otherwise, and metadata exclusions continue to flow into the generated native-image command line.

## Why

Custom binaries should behave like first-class Gradle Native Build Tools binaries. Without this fix, users could get confusing classpath differences or missing metadata exclusion behavior when defining extra application binaries.

## Example

Before:

A custom binary such as `qa` could be created successfully, but its generated compile/run tasks might not see the expected runtime classpath or metadata exclusions that the main binary would get.

After:

A custom application binary such as `qa` uses the expected runtime classpath model and carries metadata exclusions through to the generated native-image invocation.

## Implementation summary

- Initialize custom application binaries from the main runtime classpath model when no explicit native-image classpath configuration already exists.
- Carry the existing metadata exclusion argument provider into those custom binaries.
- Keep test binaries and `createLayer` binaries on their specialized classpath paths.
- Add unit and functional regression coverage for custom binary classpath and metadata exclusion behavior.
- Update the Gradle functional specs for custom binary classpath and compile-task input behavior.

## Validation

- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:test --tests org.graalvm.buildtools.gradle.NativeImagePluginTest`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:inspections`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/21.0.10-graal ./gradlew :native-gradle-plugin:functionalTest --tests "org.graalvm.buildtools.gradle.NativeConfigRepoFunctionalTest.custom binary uses runtime classpath and metadata exclusions" --info`
- `/home/jovan/.local/bin/grund fmt native-gradle-plugin --marker --check`
- `git diff --check`
