### PR TITLE
Document Maven native test output directories

### DIFF
--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -746,6 +746,71 @@ Alternatively, set `<skipTestExecution>` to `true` in the plugin configuration:
 
 This will still build the native test image but skips execution of tests as native code.
 
+==== Isolate native test output directories
+
+The `native:test` goal writes the native test executable to the configured Maven plugin `<outputDirectory>`.
+It also uses that same directory when it executes the `native-tests` executable and writes native test reports.
+By default, the directory is `${project.build.directory}`.
+
+Set `<outputDirectory>` when multiple native test executions or Maven profiles need separate native test images:
+
+[source,xml, role="multi-language-sample"]
+----
+<configuration>
+  <outputDirectory>${project.build.directory}/native-tests-config-a</outputDirectory>
+</configuration>
+----
+
+The same option can be set from the command line with the `outputDir` property:
+
+[source,bash, role="multi-language-sample"]
+----
+./mvnw -Pnative -DoutputDir=target/native-tests-config-a native:test
+----
+
+If your native profile binds `native:test` to the Maven `test` phase, use the same property with the phase invocation:
+
+[source,bash, role="multi-language-sample"]
+----
+./mvnw -Pnative -DoutputDir=target/native-tests-config-a test
+----
+
+For profile-specific native test configurations, give each profile a different output directory value:
+
+[source,xml, role="multi-language-sample"]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.graalvm.buildtools</groupId>
+      <artifactId>native-maven-plugin</artifactId>
+      <configuration>
+        <outputDirectory>${native.tests.outputDirectory}</outputDirectory>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
+
+<profiles>
+  <profile>
+    <id>native-tests-config-a</id>
+    <properties>
+      <native.tests.outputDirectory>${project.build.directory}/native-tests-config-a</native.tests.outputDirectory>
+    </properties>
+  </profile>
+  <profile>
+    <id>native-tests-config-b</id>
+    <properties>
+      <native.tests.outputDirectory>${project.build.directory}/native-tests-config-b</native.tests.outputDirectory>
+    </properties>
+  </profile>
+</profiles>
+----
+
+Do not use `-H:Path` in `<buildArgs>` to isolate native test runs.
+That option can move the file produced by Native Image without changing the Maven plugin directory used to locate and execute `native-tests`.
+Use `<outputDirectory>` or `-DoutputDir=...` instead so the build output, execution path, and native test reports stay in the same directory.
+
 ==== Skip modules without native tests in multi-module builds
 
 In multi-module projects where only some sub-modules contain native tests, you need to skip test execution for any module that does not contain native tests. Any module which should contain tests, but does not, should fail the build.


### PR DESCRIPTION
Fixes #940

## What changed

This PR documents how to give Maven native tests their own output directory.

Before this change, the Maven docs did not clearly explain how `native:test` output should be separated from other native build output, or how to configure that separation.

After this change, the docs explain how to configure dedicated native test output directories, including command-line and profile-based usage.

## Why

This makes it easier to isolate native test artifacts, especially in multi-profile builds or setups where test output should not share the main native build directory.

## Example

Before:

Users had to infer how `native:test` output directories worked or try to control them indirectly with unrelated native-image options.

After:

The docs now show supported configuration such as:

```xml
<outputDirectory>${project.build.directory}/native-tests</outputDirectory>
```

and command-line usage such as `-DoutputDir=...`, along with guidance on why `-H:Path` is not the right tool for this use case.

## Implementation summary

- Add an "Isolate native test output directories" subsection to the Maven plugin docs.
- Document `<outputDirectory>` for `native:test` and the `-DoutputDir=...` command-line form.
- Add profile-specific examples for isolated native test output directories.
- Explain why `-H:Path` in `<buildArgs>` is not recommended for this use case.

## Validation

- `git diff --check` passed.
- Focused documentation review confirmed the changed section covers `<outputDirectory>`, `-DoutputDir=...`, isolated profile output directories, and `-H:Path` guidance.
- Public-doc citation scan passed; no new internal `§...` citations were added to public docs.
