### PR TITLE
Fix Gradle metadata repository service scoping

### DIFF
--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
@@ -151,7 +151,7 @@ graalvmNative {
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration is forced to version 2"
     }
 
-    // §FS-resources-and-metadata.3
+    // Multi-project metadata collection must honor each project's configured repository URI. §FS-resources-and-metadata.3.
     def "subprojects can use different metadata repositories"() {
         given:
         settingsFile << """

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
@@ -42,8 +42,12 @@
 package org.graalvm.buildtools.gradle
 
 import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
+import org.graalvm.buildtools.gradle.fixtures.FileUtils
 import org.gradle.api.logging.LogLevel
 import spock.lang.Unroll
+
+import java.nio.file.Files
+import java.nio.file.Path
 
 class NativeConfigRepoFunctionalTest extends AbstractFunctionalTest {
 
@@ -145,6 +149,82 @@ graalvmNative {
 
         and: "looks for specific configuration version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration is forced to version 2"
+    }
+
+    def "subprojects can use different metadata repositories"() {
+        given:
+        settingsFile << """
+rootProject.name = 'multi-project-native-config'
+include 'first', 'second'
+        """
+        Files.createDirectories(path("first"))
+        Files.createDirectories(path("second"))
+        FileUtils.copyDirectory(new File("../samples/native-config-integration/config-directory").toPath(), path("first-repo"))
+        FileUtils.copyDirectory(new File("../samples/native-config-integration/config-directory").toPath(), path("second-repo"))
+        metadataConfig(path("first-repo")).text = metadataConfigFor("org.graalvm.internal.reflect.FirstProjectMessage")
+        metadataConfig(path("second-repo")).text = metadataConfigFor("org.graalvm.internal.reflect.SecondProjectMessage")
+
+        buildFile << """
+plugins {
+    id 'org.graalvm.buildtools.native' apply false
+}
+
+subprojects {
+    apply plugin: 'java'
+    apply plugin: 'org.graalvm.buildtools.native'
+
+    dependencies {
+        implementation("org.graalvm.internal:library-with-reflection:1.5")
+    }
+}
+
+project(':first') {
+    graalvmNative {
+        metadataRepository {
+            uri(rootProject.file("first-repo"))
+        }
+    }
+}
+
+project(':second') {
+    graalvmNative {
+        metadataRepository {
+            uri(rootProject.file("second-repo"))
+        }
+    }
+}
+        """
+
+        when:
+        run ':first:collectReachabilityMetadata', ':second:collectReachabilityMetadata'
+
+        then:
+        tasks {
+            succeeded ':first:collectReachabilityMetadata', ':second:collectReachabilityMetadata'
+        }
+
+        and: "each project copies metadata from its own configured repository"
+        // Multi-project metadata collection must honor each project's configured repository URI. §FS-resources-and-metadata.3.
+        metadataOutput("first").text.contains("org.graalvm.internal.reflect.FirstProjectMessage")
+        metadataOutput("second").text.contains("org.graalvm.internal.reflect.SecondProjectMessage")
+    }
+
+    private static File metadataConfig(Path repository) {
+        repository.resolve("org.graalvm.internal/library-with-reflection/1/reflect-config.json").toFile()
+    }
+
+    private File metadataOutput(String projectName) {
+        file(projectName, "build/native-reachability-metadata/META-INF/native-image/org.graalvm.internal/library-with-reflection/1.5/reflect-config.json")
+    }
+
+    private static String metadataConfigFor(String className) {
+        """[
+  {
+    "name": "$className",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  }
+]"""
     }
 
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
@@ -151,6 +151,7 @@ graalvmNative {
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration is forced to version 2"
     }
 
+    // §FS-resources-and-metadata.3
     def "subprojects can use different metadata repositories"() {
         given:
         settingsFile << """
@@ -204,7 +205,6 @@ project(':second') {
         }
 
         and: "each project copies metadata from its own configured repository"
-        // Multi-project metadata collection must honor each project's configured repository URI. §FS-resources-and-metadata.3.
         metadataOutput("first").text.contains("org.graalvm.internal.reflect.FirstProjectMessage")
         metadataOutput("second").text.contains("org.graalvm.internal.reflect.SecondProjectMessage")
     }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -181,6 +181,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     public static final String CONFIG_REPO_LOGLEVEL = "org.graalvm.internal.gradle.configrepo.logging";
     public static final Attribute<Boolean> JAR_ANALYSIS_ATTRIBUTE = Attribute.of("jar-analysis", Boolean.class);
 
+    private static final String NATIVE_CONFIGURATION_SERVICE_NAME = "nativeConfigurationService";
     private static final String JUNIT_PLATFORM_LISTENERS_UID_TRACKING_ENABLED = "junit.platform.listeners.uid.tracking.enabled";
     private static final String JUNIT_PLATFORM_LISTENERS_UID_TRACKING_OUTPUT_DIR = "junit.platform.listeners.uid.tracking.output.dir";
     private static final String JUNIT_PLATFORM_UNIQUE_IDS_RESOURCE_PATTERN = "junit-platform-unique-ids.*";
@@ -590,9 +591,10 @@ public class NativeImagePlugin implements Plugin<Project> {
 
     private Provider<GraalVMReachabilityMetadataService> graalVMReachabilityMetadataService(Project project,
                                                                                             GraalVMReachabilityMetadataRepositoryExtension repositoryExtension) {
+        // Keep metadata repository service parameters project-local. §FS-resources-and-metadata.3.
         return project.getGradle()
             .getSharedServices()
-            .registerIfAbsent("nativeConfigurationService", GraalVMReachabilityMetadataService.class, spec -> {
+            .registerIfAbsent(NATIVE_CONFIGURATION_SERVICE_NAME + project.getPath(), GraalVMReachabilityMetadataService.class, spec -> {
                 LogLevel logLevel = determineLogLevel();
                 spec.getMaxParallelUsages().set(1);
                 spec.getParameters().getLogLevel().set(logLevel);


### PR DESCRIPTION
Fixes #415

## What changed

This PR fixes multi-module Gradle builds where different subprojects configure different reachability metadata repositories.

Before this change, Native Build Tools could reuse repository settings from the first subproject that initialized the shared metadata service. That meant later subprojects could silently use the wrong metadata repository.

After this change, each subproject uses its own configured metadata repository.

## Why

Multi-project builds can now safely use different metadata repositories per subproject without cross-project leakage.

## Example

Before:

```gradle
project(":app1") {
    graalvmNative {
        metadataRepository {
            uri = uri("file:///tmp/metadata-repo-a")
        }
    }
}

project(":app2") {
    graalvmNative {
        metadataRepository {
            uri = uri("file:///tmp/metadata-repo-b")
        }
    }
}
```

In some builds, `app2` could still end up using the repository configuration from `app1`.

After:

`app1` uses `metadata-repo-a` and `app2` uses `metadata-repo-b`, matching each subproject's own configuration.

## Implementation summary

- Scope the shared Gradle metadata service per subproject so one project's repository settings do not leak into another.
- Keep service reuse within a single project while allowing different subprojects to carry different metadata repository parameters.
- Add a multi-project regression that verifies each subproject resolves metadata from its own configured repository.

## Validation

Run from the issue worktree with `JAVA_HOME` and `GRAALVM_HOME` set to the installed GraalVM 17 runtime:

- `./gradlew :native-gradle-plugin:functionalTest --tests "org.graalvm.buildtools.gradle.NativeConfigRepoFunctionalTest.subprojects can use different metadata repositories"` passed.
- `./gradlew :native-gradle-plugin:test :native-gradle-plugin:inspections` passed.
- `./gradlew :native-gradle-plugin:configCacheFunctionalTest --tests "org.graalvm.buildtools.gradle.NativeConfigRepoFunctionalTest.subprojects can use different metadata repositories"` passed.
- `grund fmt . --marker --check` passed.
- Targeted grounding checks resolved and found the changed `FS-gradle-resources-and-metadata.3` citations.