### PR TITLE
Fix Gradle agent toolchain detection

### DIFF
--- a/native-gradle-plugin/docs/functional/tracing-agent.md
+++ b/native-gradle-plugin/docs/functional/tracing-agent.md
@@ -47,6 +47,10 @@ directories. Command-line options on `metadataCopy` may select task names and de
 directories for ad hoc use, exposing the shared agent post-processing workflow from
 [§root/FS-tracing-agent](../../../docs/spec/functional/tracing-agent.md#fs-tracing-agent-both-plugins-attach-the-native-image-tracing-agent-and-post-process-its-output).
 
+Agent post-processing that invokes `native-image-configure` must discover `native-image` through
+the instrumented task launcher or the `metadataCopy` launcher when such a launcher is configured,
+and otherwise preserve the executable fallbacks from [§FS-native-invocation.1](native-image-invocation.md#1-executable-discovery).
+
 ## 6. Agent example
 
 Agent collection is invoked by running an eligible JVM task with `-Pagent`; post-processing is

--- a/native-gradle-plugin/docs/functional/tracing-agent.md
+++ b/native-gradle-plugin/docs/functional/tracing-agent.md
@@ -47,8 +47,8 @@ directories. Command-line options on `metadataCopy` may select task names and de
 directories for ad hoc use, exposing the shared agent post-processing workflow from
 [§root/FS-tracing-agent](../../../docs/spec/functional/tracing-agent.md#fs-tracing-agent-both-plugins-attach-the-native-image-tracing-agent-and-post-process-its-output).
 
-Agent post-processing that invokes `native-image-configure` must discover `native-image` through
-the instrumented task launcher or the `metadataCopy` launcher when such a launcher is configured,
+Agent post-processing must discover `native-image` through the instrumented task launcher or the
+`metadataCopy` launcher when such a launcher is configured,
 and otherwise preserve the executable fallbacks from [§FS-native-invocation.1](native-image-invocation.md#1-executable-discovery).
 
 ## 6. Agent example

--- a/native-gradle-plugin/docs/functional/tracing-agent.md
+++ b/native-gradle-plugin/docs/functional/tracing-agent.md
@@ -47,8 +47,8 @@ directories. Command-line options on `metadataCopy` may select task names and de
 directories for ad hoc use, exposing the shared agent post-processing workflow from
 [§root/FS-tracing-agent](../../../docs/spec/functional/tracing-agent.md#fs-tracing-agent-both-plugins-attach-the-native-image-tracing-agent-and-post-process-its-output).
 
-Agent post-processing must discover `native-image` through the instrumented task launcher or the
-`metadataCopy` launcher when such a launcher is configured,
+Agent post-processing with `native-image-utils` must discover the corresponding `native-image`
+executable through the instrumented task launcher or the `metadataCopy` launcher when such a launcher is configured,
 and otherwise preserve the executable fallbacks from [§FS-native-invocation.1](native-image-invocation.md#1-executable-discovery).
 
 ## 6. Agent example

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -322,6 +322,15 @@ public class NativeImagePlugin implements Plugin<Project> {
             task.getOutputDirectories().set(graalExtension.getAgent().getMetadataCopy().getOutputDirectories());
             task.getMergeWithExisting().set(graalExtension.getAgent().getMetadataCopy().getMergeWithExisting());
             task.getToolchainDetection().set(graalExtension.getToolchainDetection());
+            JavaToolchainService toolchainService = project.getExtensions().findByType(JavaToolchainService.class);
+            if (toolchainService != null) {
+                task.getJavaLauncher().convention(graalExtension.getToolchainDetection().flatMap(enabled -> {
+                    if (enabled) {
+                        return toolchainService.launcherFor(javaConvention.getToolchain());
+                    }
+                    return null;
+                }));
+            }
         });
 
         project.getTasks().register("collectReachabilityMetadata", CollectReachabilityMetadata.class, task -> {
@@ -1133,10 +1142,11 @@ public class NativeImagePlugin implements Plugin<Project> {
             agentModeProvider,
             project.provider(() -> false),
             project.getObjects(),
+            javaLauncherForAgentMerge(project, taskToInstrument),
             graalvmHomeProvider(project.getProviders()),
             mergeInputDirs,
             mergeOutputDirs,
-            graalExtension.getToolchainDetection(),
+            graalExtension.getToolchainDetection().map(enabled -> !enabled),
             execOperations));
 
         taskToInstrument.doLast(new CleanupAgentFilesAction(mergeInputDirs, fileOperations));
@@ -1172,6 +1182,17 @@ public class NativeImagePlugin implements Plugin<Project> {
         return properties.stringPropertyNames().stream()
                 .anyMatch(propertyName -> propertyName.toUpperCase(Locale.ROOT).contains("GRAALVM")
                         || String.valueOf(properties.getProperty(propertyName)).toLowerCase(Locale.ROOT).contains("graalvm"));
+    }
+
+    private static Property<JavaLauncher> javaLauncherForAgentMerge(Project project, Task task) {
+        Property<JavaLauncher> javaLauncher = project.getObjects().property(JavaLauncher.class);
+        // Agent post-processing uses the instrumented JVM task launcher when Gradle exposes one. §FS-tracing-agent.5.
+        if (task instanceof JavaExec) {
+            javaLauncher.convention(((JavaExec) task).getJavaLauncher());
+        } else if (task instanceof Test) {
+            javaLauncher.convention(((Test) task).getJavaLauncher());
+        }
+        return javaLauncher;
     }
 
     private static void injectTestPluginDependencies(Project project, String binaryName, Property<Boolean> testSupportEnabled) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/MetadataCopyTask.java
@@ -54,8 +54,11 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.ExecOperations;
 
 import javax.inject.Inject;
@@ -102,6 +105,13 @@ public abstract class MetadataCopyTask extends DefaultTask {
 
     @Internal
     public abstract Property<Boolean> getToolchainDetection();
+
+    /**
+     * Launcher used to locate Native Image while merging metadata. §FS-tracing-agent.5.
+     */
+    @Nested
+    @Optional
+    public abstract Property<JavaLauncher> getJavaLauncher();
 
     @Option(option = "task", description = "Executed task previously instrumented with the agent whose metadata should be copied.")
     public void overrideInputTaskNames(List<String> inputTaskNames) {
@@ -158,10 +168,11 @@ public abstract class MetadataCopyTask extends DefaultTask {
                 agentModeProvider,
                 getMergeWithExisting(),
                 objectFactory,
+                getJavaLauncher(),
                 graalvmHomeProvider(providerFactory),
                 () -> inputDirectories,
                 () -> outputDirectories,
-                getToolchainDetection(),
+                getToolchainDetection().map(enabled -> !enabled),
                 execOperations).execute(this);
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesAction.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesAction.java
@@ -72,13 +72,14 @@ public class MergeAgentFilesAction implements Action<Task> {
     private final Supplier<List<String>> inputDirs;
     private final Supplier<List<String>> outputDirs;
     private final Provider<Boolean> disableToolchainDetection;
-    private final Property<JavaLauncher> noLauncherProperty;
+    private final Property<JavaLauncher> javaLauncher;
     private final ExecOperations execOperations;
 
     public MergeAgentFilesAction(Provider<Boolean> isMergingEnabled,
                                  Provider<AgentMode> agentMode,
                                  Provider<Boolean> mergeWithOutputs,
                                  ObjectFactory objectFactory,
+                                 Property<JavaLauncher> javaLauncher,
                                  Provider<String> graalvmHomeProvider,
                                  Supplier<List<String>> inputDirs,
                                  Supplier<List<String>> outputDirs,
@@ -92,7 +93,8 @@ public class MergeAgentFilesAction implements Action<Task> {
         this.outputDirs = outputDirs;
         this.disableToolchainDetection = disableToolchainDetection;
         this.execOperations = execOperations;
-        this.noLauncherProperty = objectFactory.property(JavaLauncher.class);
+        this.javaLauncher = objectFactory.property(JavaLauncher.class);
+        this.javaLauncher.convention(javaLauncher);
     }
 
     private static final Set<String> METADATA_FILES = Set.of("reflect-config.json", "jni-config.json", "proxy-config.json", "resource-config.json", "reachability-metadata.json");
@@ -105,7 +107,8 @@ public class MergeAgentFilesAction implements Action<Task> {
     @Override
     public void execute(Task task) {
         if (isMergingEnabled.get()) {
-            File nativeImage = findNativeImageExecutable(noLauncherProperty, disableToolchainDetection, graalvmHomeProvider, execOperations, GraalVMLogger.of(task.getLogger()), new NativeImageExecutableLocator.Diagnostics());
+            // Preserve Native Image executable discovery for agent post-processing. §FS-native-invocation.1.
+            File nativeImage = findNativeImageExecutable(javaLauncher, disableToolchainDetection, graalvmHomeProvider, execOperations, GraalVMLogger.of(task.getLogger()), new NativeImageExecutableLocator.Diagnostics());
             File workingDir = nativeImage.getParentFile();
             File launcher = new File(workingDir, nativeImageConfigureFileName());
             if (!launcher.exists()) {

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesActionTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/actions/MergeAgentFilesActionTest.groovy
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.buildtools.gradle.tasks.actions
+
+import org.graalvm.buildtools.agent.DisabledAgentMode
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.jvm.toolchain.JavaInstallationMetadata
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.process.ExecOperations
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Path
+
+import static org.graalvm.buildtools.utils.NativeImageUtils.nativeImageConfigureFileName
+import static org.graalvm.buildtools.utils.SharedConstants.NATIVE_IMAGE_EXE
+
+// Protects agent post-processing executable discovery through task launchers. §FS-tracing-agent.5 §FS-native-invocation.1.
+class MergeAgentFilesActionTest extends Specification {
+    @TempDir
+    Path testDirectory
+
+    def "uses configured Java launcher to locate native image before environment fallback"() {
+        given:
+        def project = ProjectBuilder.builder()
+                .withProjectDir(testDirectory.resolve("project").toFile())
+                .build()
+        def fakeGraalVmHome = testDirectory.resolve("fake-graalvm").toFile()
+        def fakeGraalVmBin = new File(fakeGraalVmHome, "bin")
+        assert fakeGraalVmBin.mkdirs()
+        assert new File(fakeGraalVmBin, NATIVE_IMAGE_EXE).createNewFile()
+        assert new File(fakeGraalVmBin, nativeImageConfigureFileName()).createNewFile()
+        def environmentGraalVmHome = testDirectory.resolve("environment-graalvm").toFile()
+        def environmentGraalVmBin = new File(environmentGraalVmHome, "bin")
+        assert environmentGraalVmBin.mkdirs()
+        assert new File(environmentGraalVmBin, NATIVE_IMAGE_EXE).createNewFile()
+
+        def javaLauncher = project.objects.property(JavaLauncher)
+        javaLauncher.set(launcherFor(fakeGraalVmHome))
+        def task = project.tasks.create("mergeAgentFiles")
+        def execOperations = Mock(ExecOperations)
+
+        def action = new MergeAgentFilesAction(
+                project.provider { true },
+                project.provider { new DisabledAgentMode() },
+                project.provider { false },
+                project.objects,
+                javaLauncher,
+                project.providers.provider { environmentGraalVmHome.absolutePath },
+                { [new File(fakeGraalVmHome, "agent-input").absolutePath] },
+                { [new File(fakeGraalVmHome, "agent-output").absolutePath] },
+                project.provider { false },
+                execOperations)
+
+        when:
+        action.execute(task)
+
+        then:
+        noExceptionThrown()
+        0 * execOperations.exec(_)
+    }
+
+    private JavaLauncher launcherFor(File javaHome) {
+        Stub(JavaLauncher) {
+            getMetadata() >> Stub(JavaInstallationMetadata) {
+                getInstallationPath() >> Stub(Directory) {
+                    getAsFile() >> javaHome
+                    file(_ as String) >> { String path ->
+                        Stub(RegularFile) {
+                            getAsFile() >> new File(javaHome, path)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #724
Fixes #400

## What changed

This PR makes Gradle tracing-agent post-processing use the Java launcher or Gradle toolchain already configured for the task when locating `native-image`.

Before this change, builds could still depend on `GRAALVM_HOME` during agent metadata post-processing even when the task already had a Gradle toolchain or `javaLauncher` configured.

After this change, agent post-processing can use the configured launcher or Gradle toolchain first, with the existing environment and path fallbacks kept for builds that do not configure a launcher.

## Why

This removes duplicate configuration and makes tracing-agent workflows behave more consistently in Gradle builds that already use toolchains.

## Example

Before:

```gradle
java {
    toolchain {
        languageVersion = JavaLanguageVersion.of(17)
    }
}
```

A build like this could still require `GRAALVM_HOME` during tracing-agent metadata post-processing.

After:

The same build can use the configured Gradle toolchain or `javaLauncher` to find `native-image` for agent post-processing, without requiring a separate `GRAALVM_HOME` setting when the launcher already points at a GraalVM toolchain.

## Implementation summary

- Pass the configured task launcher through the agent post-processing path so it can resolve `native-image` from the same Gradle toolchain.
- Add support for configuring `MetadataCopyTask` from the project Java toolchain when toolchain detection is enabled.
- Keep the existing environment and path-based fallback behavior for builds that do not configure a launcher.
- Document the launcher-aware post-processing behavior and add regression coverage for launcher priority over environment fallback.

## Validation

- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:test --tests org.graalvm.buildtools.gradle.tasks.actions.MergeAgentFilesActionTest --rerun-tasks`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:checkstyleMain`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:functionalTest --tests "org.graalvm.buildtools.gradle.JavaApplicationWithAgentFunctionalTest.agent instruments run task"`
- `git diff --check`
- Targeted `grund` resolution succeeded for the touched Gradle spec IDs.