### PR TITLE
Improve missing metadata reporting for newer repository releases

### DIFF
--- a/common/docs/functional-spec.md
+++ b/common/docs/functional-spec.md
@@ -103,6 +103,15 @@ enough coordinate and repository-status information for users or automation to d
 request support, and format issue requests against the configured GitHub repository and API URL
 when issue creation is enabled. Product plugins supply credentials and project identity.
 
+When a direct runtime dependency is not covered by the configured metadata repository, reporting
+must distinguish between dependencies that are truly uncovered and dependencies that are already
+covered by a newer official metadata repository release. Coverage in a newer official release is
+still actionable for the user because the current build cannot consume it yet, but it must be
+reported separately from truly missing libraries and must advise the user to update either the
+configured metadata repository version or Native Build Tools. Issue creation must only target
+dependencies that remain uncovered after checking the newer official release. This refinement
+builds on the repository coverage semantics in [§FS-common-libraries.5.1](functional-spec.md#51-repository-lookup).
+
 Product-specific report entry points are specified by [§gradle/FS-resources-and-metadata.4](../../native-gradle-plugin/docs/functional/resources-and-metadata.md#4-missing-metadata-reports) and
 [§maven/FS-resources-and-metadata.3](../../native-maven-plugin/docs/functional/resources-and-metadata.md#3-missing-metadata-reports).
 

--- a/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/MissingMetadataCommandSupport.java
+++ b/common/graalvm-reachability-metadata/src/main/java/org/graalvm/reachability/MissingMetadataCommandSupport.java
@@ -42,15 +42,21 @@ package org.graalvm.reachability;
 
 import com.github.openjson.JSONArray;
 import com.github.openjson.JSONObject;
+import org.graalvm.buildtools.utils.FileUtils;
+import org.graalvm.buildtools.utils.SharedConstants;
+import org.graalvm.reachability.internal.FileSystemRepository;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -75,19 +81,22 @@ import java.util.regex.Pattern;
 
 /**
  * Shared support used by Gradle and Maven to report direct runtime dependencies
- * that have no reachability metadata in the configured repository.
+ * that have no reachability metadata in the configured repository. Reporting
+ * follows §FS-common-libraries.6 and relies on repository coverage semantics
+ * from §FS-common-libraries.5.1.
  */
 public final class MissingMetadataCommandSupport {
     public static final String COMMAND_NAME = "listLibrariesMissingMetadata";
     public static final String DEFAULT_SCOPE = "direct-runtime";
     public static final String DEFAULT_GITHUB_API_URL = "https://api.github.com";
     public static final String DEFAULT_TARGET_REPOSITORY = "oracle/graalvm-reachability-metadata";
-    static final String REPORT_SCHEMA_FILENAME = "list-libraries-missing-metadata-schema-v1.0.0.json";
+    static final String REPORT_SCHEMA_FILENAME = "list-libraries-missing-metadata-schema-v1.1.0.json";
     static final String REPORT_SCHEMA_URI = "https://raw.githubusercontent.com/graalvm/native-build-tools/master/schemas/"
         + REPORT_SCHEMA_FILENAME;
 
     private static final String AUTOMATION_NOTE = "_This issue was created by automation._";
     private static final String ISSUE_TEMPLATE = "01_support_new_library.yml";
+    private static final String OFFICIAL_METADATA_REPOSITORY = "oracle/graalvm-reachability-metadata";
     private static final URI MAVEN_CENTRAL_BASE_URI = URI.create("https://repo.maven.apache.org/maven2/");
     private static final Pattern COORDINATES_PATTERN = Pattern.compile("([A-Za-z0-9_.-]+):([A-Za-z0-9_.-]+)(?::([A-Za-z0-9_.-]+))?");
     private static final long GITHUB_CLI_TIMEOUT_SECONDS = 5;
@@ -112,23 +121,21 @@ public final class MissingMetadataCommandSupport {
             .distinct()
             .toList();
         GitHubIssueClient issueClient = new GitHubIssueClient(options);
+        NewerMetadataRepositorySupportChecker newerRepositoryChecker = options.newerMetadataRepositorySupportChecker();
         Map<String, IssueReference> issueCache = new LinkedHashMap<>();
         List<Result> results = new ArrayList<>(candidates.size());
         for (DependencyCoordinate dependency : candidates) {
             try {
-                boolean covered = repository.isCoveredByRepository(query -> {
-                    query.forArtifact(artifact -> {
-                        artifact.gav(dependency.coordinates());
-                        String forcedVersion = effectiveForcedVersions.get(dependency.groupAndArtifact());
-                        if (forcedVersion != null) {
-                            artifact.forceConfigVersion(forcedVersion);
-                        } else {
-                            artifact.useLatestConfigWhenVersionIsUntested();
-                        }
-                    });
-                });
+                String forcedVersion = effectiveForcedVersions.get(dependency.groupAndArtifact());
+                boolean covered = isCoveredByRepository(repository, dependency, forcedVersion);
                 if (covered) {
                     results.add(Result.supported(dependency));
+                    continue;
+                }
+                Optional<SupportingMetadataRepository> supportingRepository = newerRepositoryChecker
+                    .findSupportingRepository(dependency, forcedVersion);
+                if (supportingRepository.isPresent()) {
+                    results.add(Result.supportedInNewerMetadataRepository(dependency, supportingRepository.get()));
                     continue;
                 }
                 IssueReference issue = issueCache.get(dependency.groupAndArtifact());
@@ -147,6 +154,21 @@ public final class MissingMetadataCommandSupport {
             }
         }
         return new Report(options, candidates.size(), results);
+    }
+
+    private static boolean isCoveredByRepository(GraalVMReachabilityMetadataRepository repository,
+                                                 DependencyCoordinate dependency,
+                                                 String forcedVersion) {
+        return repository.isCoveredByRepository(query -> {
+            query.forArtifact(artifact -> {
+                artifact.gav(dependency.coordinates());
+                if (forcedVersion != null) {
+                    artifact.forceConfigVersion(forcedVersion);
+                } else {
+                    artifact.useLatestConfigWhenVersionIsUntested();
+                }
+            });
+        });
     }
 
     private static RuntimeException createIssuesFailure(DependencyCoordinate dependency, Exception ex) {
@@ -183,6 +205,7 @@ public final class MissingMetadataCommandSupport {
         private final GitHubCliTokenSupplier gitHubCliTokenSupplier;
         private final ArtifactAvailabilityChecker artifactAvailabilityChecker;
         private final Consumer<String> warningSink;
+        private final NewerMetadataRepositorySupportChecker newerMetadataRepositorySupportChecker;
 
         public Options(String buildTool,
                        String projectName,
@@ -193,7 +216,7 @@ public final class MissingMetadataCommandSupport {
                        String githubApiUrl,
                        Clock clock) {
             this(buildTool, projectName, metadataRepositoryUri, createIssues, githubToken, targetRepository, githubApiUrl, clock,
-                GitHubCliTokenSupplier.DEFAULT, ArtifactAvailabilityChecker.DEFAULT, message -> { });
+                GitHubCliTokenSupplier.DEFAULT, ArtifactAvailabilityChecker.DEFAULT, message -> { }, null);
         }
 
         public Options(String buildTool,
@@ -206,7 +229,7 @@ public final class MissingMetadataCommandSupport {
                        Clock clock,
                        Consumer<String> warningSink) {
             this(buildTool, projectName, metadataRepositoryUri, createIssues, githubToken, targetRepository, githubApiUrl, clock,
-                GitHubCliTokenSupplier.DEFAULT, ArtifactAvailabilityChecker.DEFAULT, warningSink);
+                GitHubCliTokenSupplier.DEFAULT, ArtifactAvailabilityChecker.DEFAULT, warningSink, null);
         }
 
         Options(String buildTool,
@@ -219,7 +242,7 @@ public final class MissingMetadataCommandSupport {
                 Clock clock,
                 GitHubCliTokenSupplier gitHubCliTokenSupplier) {
             this(buildTool, projectName, metadataRepositoryUri, createIssues, githubToken, targetRepository, githubApiUrl, clock,
-                gitHubCliTokenSupplier, ArtifactAvailabilityChecker.DEFAULT, message -> { });
+                gitHubCliTokenSupplier, ArtifactAvailabilityChecker.DEFAULT, message -> { }, null);
         }
 
         Options(String buildTool,
@@ -233,7 +256,7 @@ public final class MissingMetadataCommandSupport {
                 GitHubCliTokenSupplier gitHubCliTokenSupplier,
                 ArtifactAvailabilityChecker artifactAvailabilityChecker) {
             this(buildTool, projectName, metadataRepositoryUri, createIssues, githubToken, targetRepository, githubApiUrl, clock,
-                gitHubCliTokenSupplier, artifactAvailabilityChecker, message -> { });
+                gitHubCliTokenSupplier, artifactAvailabilityChecker, message -> { }, null);
         }
 
         Options(String buildTool,
@@ -246,7 +269,8 @@ public final class MissingMetadataCommandSupport {
                 Clock clock,
                 GitHubCliTokenSupplier gitHubCliTokenSupplier,
                 ArtifactAvailabilityChecker artifactAvailabilityChecker,
-                Consumer<String> warningSink) {
+                Consumer<String> warningSink,
+                NewerMetadataRepositorySupportChecker newerMetadataRepositorySupportChecker) {
             this.buildTool = Objects.requireNonNull(buildTool, "buildTool");
             this.projectName = Objects.requireNonNull(projectName, "projectName");
             this.metadataRepositoryUri = metadataRepositoryUri;
@@ -258,6 +282,9 @@ public final class MissingMetadataCommandSupport {
             this.gitHubCliTokenSupplier = Objects.requireNonNull(gitHubCliTokenSupplier, "gitHubCliTokenSupplier");
             this.artifactAvailabilityChecker = Objects.requireNonNull(artifactAvailabilityChecker, "artifactAvailabilityChecker");
             this.warningSink = warningSink == null ? message -> { } : warningSink;
+            this.newerMetadataRepositorySupportChecker = newerMetadataRepositorySupportChecker == null
+                ? new OfficialMetadataRepositorySupportChecker(this.metadataRepositoryUri, this.warningSink)
+                : newerMetadataRepositorySupportChecker;
         }
 
         public String buildTool() {
@@ -303,6 +330,10 @@ public final class MissingMetadataCommandSupport {
         Consumer<String> warningSink() {
             return warningSink;
         }
+
+        NewerMetadataRepositorySupportChecker newerMetadataRepositorySupportChecker() {
+            return newerMetadataRepositorySupportChecker;
+        }
     }
 
     public record DependencyCoordinate(String groupId, String artifactId, String version)
@@ -334,6 +365,7 @@ public final class MissingMetadataCommandSupport {
 
     public enum Status {
         SUPPORTED("supported"),
+        SUPPORTED_IN_NEWER_METADATA_REPOSITORY("supported_in_newer_metadata_repository"),
         MISSING("missing"),
         ERROR("error");
 
@@ -371,6 +403,8 @@ public final class MissingMetadataCommandSupport {
         private final IssueStatus issueStatus;
         private final String issueUrl;
         private final Integer issueNumber;
+        private final String supportingMetadataRepositoryVersion;
+        private final String supportingMetadataRepositoryUri;
         private final String errorMessage;
 
         private Result(DependencyCoordinate dependency,
@@ -378,17 +412,35 @@ public final class MissingMetadataCommandSupport {
                        IssueStatus issueStatus,
                        String issueUrl,
                        Integer issueNumber,
+                       String supportingMetadataRepositoryVersion,
+                       String supportingMetadataRepositoryUri,
                        String errorMessage) {
             this.dependency = dependency;
             this.status = status;
             this.issueStatus = issueStatus;
             this.issueUrl = issueUrl;
             this.issueNumber = issueNumber;
+            this.supportingMetadataRepositoryVersion = supportingMetadataRepositoryVersion;
+            this.supportingMetadataRepositoryUri = supportingMetadataRepositoryUri;
             this.errorMessage = errorMessage;
         }
 
         public static Result supported(DependencyCoordinate dependency) {
-            return new Result(dependency, Status.SUPPORTED, null, null, null, null);
+            return new Result(dependency, Status.SUPPORTED, null, null, null, null, null, null);
+        }
+
+        public static Result supportedInNewerMetadataRepository(DependencyCoordinate dependency,
+                                                                SupportingMetadataRepository supportingRepository) {
+            return new Result(
+                dependency,
+                Status.SUPPORTED_IN_NEWER_METADATA_REPOSITORY,
+                null,
+                null,
+                null,
+                supportingRepository.version(),
+                supportingRepository.uri(),
+                null
+            );
         }
 
         public static Result missing(DependencyCoordinate dependency, IssueReference issueReference) {
@@ -398,6 +450,8 @@ public final class MissingMetadataCommandSupport {
                 issueReference.issueStatus(),
                 issueReference.issueUrl(),
                 issueReference.issueNumber(),
+                null,
+                null,
                 null
             );
         }
@@ -406,6 +460,8 @@ public final class MissingMetadataCommandSupport {
             return new Result(
                 dependency,
                 Status.ERROR,
+                null,
+                null,
                 null,
                 null,
                 null,
@@ -437,6 +493,14 @@ public final class MissingMetadataCommandSupport {
             return Optional.ofNullable(errorMessage);
         }
 
+        public Optional<String> supportingMetadataRepositoryVersion() {
+            return Optional.ofNullable(supportingMetadataRepositoryVersion);
+        }
+
+        public Optional<String> supportingMetadataRepositoryUri() {
+            return Optional.ofNullable(supportingMetadataRepositoryUri);
+        }
+
         private JSONObject toJson() {
             JSONObject json = new JSONObject();
             json.put("coordinates", dependency.coordinates());
@@ -450,6 +514,12 @@ public final class MissingMetadataCommandSupport {
             }
             if (issueNumber != null) {
                 json.put("issueNumber", issueNumber);
+            }
+            if (supportingMetadataRepositoryVersion != null) {
+                json.put("supportingMetadataRepositoryVersion", supportingMetadataRepositoryVersion);
+            }
+            if (supportingMetadataRepositoryUri != null) {
+                json.put("supportingMetadataRepositoryUri", supportingMetadataRepositoryUri);
             }
             if (errorMessage != null) {
                 json.put("error", errorMessage);
@@ -484,13 +554,17 @@ public final class MissingMetadataCommandSupport {
         }
 
         public String renderConsoleOutput(String reportFilePath) {
+            List<Result> coveredInNewerRepository = results.stream()
+                .filter(r -> r.status == Status.SUPPORTED_IN_NEWER_METADATA_REPOSITORY)
+                .toList();
             List<Result> existing = filterByIssueStatus(IssueStatus.EXISTING_OPEN_ISSUE);
             List<Result> created = filterByIssueStatus(IssueStatus.CREATED_ISSUE);
             List<Result> needRequest = filterByIssueStatus(IssueStatus.NEW_ISSUE_LINK_GENERATED);
             List<Result> skipped = filterByIssueStatus(IssueStatus.SKIPPED_NOT_AVAILABLE_IN_MAVEN_CENTRAL);
             List<Result> errors = results.stream().filter(r -> r.status == Status.ERROR).toList();
-            int missingTotal = existing.size() + created.size() + needRequest.size() + skipped.size() + errors.size();
-            if (missingTotal == 0) {
+            int unresolvedTotal = existing.size() + created.size() + needRequest.size() + skipped.size();
+            int attentionTotal = coveredInNewerRepository.size() + unresolvedTotal + errors.size();
+            if (attentionTotal == 0) {
                 StringBuilder out = new StringBuilder();
                 out.append("All ").append(scanned).append(" direct dependencies are supported by the reachability metadata repository.");
                 if (reportFilePath != null) {
@@ -521,12 +595,27 @@ public final class MissingMetadataCommandSupport {
             }
 
             StringBuilder out = new StringBuilder();
-            out.append("Missing metadata libraries: ").append(missingTotal)
+            out.append("Dependencies needing attention: ").append(attentionTotal)
                 .append(" of ").append(scanned).append(" scanned");
-            if (!existing.isEmpty()) {
+            if (!coveredInNewerRepository.isEmpty()) {
+                out.append(" (").append(coveredInNewerRepository.size())
+                    .append(coveredInNewerRepository.size() == 1
+                        ? " covered in a newer metadata repository release"
+                        : " covered in newer metadata repository releases");
+                if (!existing.isEmpty()) {
+                    out.append(", ").append(existing.size()).append(" already requested");
+                }
+                out.append(")");
+            } else if (!existing.isEmpty()) {
                 out.append(" (").append(existing.size()).append(" already requested)");
             }
             out.append(".\n\n");
+
+            if (!coveredInNewerRepository.isEmpty()) {
+                out.append("Covered in a newer metadata repository release (update metadata repository or Native Build Tools):\n");
+                renderNewerRepositoryList(out, coveredInNewerRepository);
+                out.append('\n');
+            }
 
             if (!existing.isEmpty()) {
                 out.append("Already requested (no action needed):\n");
@@ -609,6 +698,19 @@ public final class MissingMetadataCommandSupport {
             }
         }
 
+        private void renderNewerRepositoryList(StringBuilder out, List<Result> entries) {
+            for (Result r : entries) {
+                String supportedVersion = r.supportingMetadataRepositoryVersion().orElse("a newer release");
+                out.append("  - ").append(r.dependency.coordinates())
+                    .append(" -> supported in ")
+                    .append(supportedVersion)
+                    .append('\n');
+                out.append("      update metadata repository to ")
+                    .append(supportedVersion)
+                    .append(" or upgrade Native Build Tools\n");
+            }
+        }
+
         private void renderBulletList(StringBuilder out, List<Result> entries,
                                       Map<Result, String> labels, String actionWord) {
             int maxWidth = maxCoordinateWidth(entries);
@@ -671,6 +773,7 @@ public final class MissingMetadataCommandSupport {
             JSONObject summary = new JSONObject();
             summary.put("scanned", scanned);
             summary.put("supported", supportedCount());
+            summary.put("supportedInNewerMetadataRepository", supportedInNewerMetadataRepositoryCount());
             summary.put("missing", missingCount());
             summary.put("existingOpenIssue", existingIssueCount());
             summary.put("newIssueLinks", newIssueLinkCount());
@@ -688,6 +791,10 @@ public final class MissingMetadataCommandSupport {
 
         private long supportedCount() {
             return results.stream().filter(result -> result.status == Status.SUPPORTED).count();
+        }
+
+        private long supportedInNewerMetadataRepositoryCount() {
+            return results.stream().filter(result -> result.status == Status.SUPPORTED_IN_NEWER_METADATA_REPOSITORY).count();
         }
 
         private long missingCount() {
@@ -729,6 +836,13 @@ public final class MissingMetadataCommandSupport {
 
         private boolean isSkippedIssueCreation() {
             return issueStatus == IssueStatus.SKIPPED_NOT_AVAILABLE_IN_MAVEN_CENTRAL;
+        }
+    }
+
+    record SupportingMetadataRepository(String version, String uri) {
+        SupportingMetadataRepository {
+            Objects.requireNonNull(version, "version");
+            Objects.requireNonNull(uri, "uri");
         }
     }
 
@@ -1048,6 +1162,120 @@ public final class MissingMetadataCommandSupport {
         };
 
         String get(String hostname);
+    }
+
+    interface NewerMetadataRepositorySupportChecker {
+        Optional<SupportingMetadataRepository> findSupportingRepository(DependencyCoordinate dependency, String forcedVersion);
+    }
+
+    private static final class OfficialMetadataRepositorySupportChecker implements NewerMetadataRepositorySupportChecker {
+        private final String configuredMetadataRepositoryUri;
+        private final Consumer<String> warningSink;
+        private final AtomicBoolean warningEmitted = new AtomicBoolean();
+        private volatile RepositorySnapshot repositorySnapshot;
+        private volatile boolean initialized;
+
+        private OfficialMetadataRepositorySupportChecker(String configuredMetadataRepositoryUri, Consumer<String> warningSink) {
+            this.configuredMetadataRepositoryUri = blankToNull(configuredMetadataRepositoryUri);
+            this.warningSink = warningSink;
+        }
+
+        @Override
+        public Optional<SupportingMetadataRepository> findSupportingRepository(DependencyCoordinate dependency, String forcedVersion) {
+            RepositorySnapshot snapshot = repositorySnapshot();
+            if (snapshot == null || sameRepository(snapshot.repositoryUri())) {
+                return Optional.empty();
+            }
+            return isCoveredByRepository(snapshot.repository(), dependency, forcedVersion)
+                ? Optional.of(new SupportingMetadataRepository(snapshot.version(), snapshot.repositoryUri()))
+                : Optional.empty();
+        }
+
+        private boolean sameRepository(String officialRepositoryUri) {
+            return configuredMetadataRepositoryUri != null
+                && stripTrailingSlash(configuredMetadataRepositoryUri).equals(stripTrailingSlash(officialRepositoryUri));
+        }
+
+        private RepositorySnapshot repositorySnapshot() {
+            if (!initialized) {
+                synchronized (this) {
+                    if (!initialized) {
+                        repositorySnapshot = loadRepositorySnapshot();
+                        initialized = true;
+                    }
+                }
+            }
+            return repositorySnapshot;
+        }
+
+        private RepositorySnapshot loadRepositorySnapshot() {
+            try {
+                HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(10))
+                    .build();
+                HttpRequest request = HttpRequest.newBuilder(URI.create(DEFAULT_GITHUB_API_URL + "/repos/" + OFFICIAL_METADATA_REPOSITORY + "/releases/latest"))
+                    .timeout(Duration.ofSeconds(20))
+                    .header("Accept", "application/vnd.github+json")
+                    .header("User-Agent", "native-build-tools-missing-metadata")
+                    .GET()
+                    .build();
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+                if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                    throw new RuntimeException("GitHub releases lookup failed with status " + response.statusCode());
+                }
+                JSONObject json = new JSONObject(response.body());
+                String version = json.optString("tag_name", "");
+                if (version.isBlank()) {
+                    throw new RuntimeException("GitHub releases lookup did not return a release tag");
+                }
+                String repositoryUri = String.format(SharedConstants.METADATA_REPO_URL_TEMPLATE, version);
+                FileSystemRepository repository = downloadRepository(repositoryUri);
+                return new RepositorySnapshot(version, repositoryUri, repository);
+            } catch (Exception ex) {
+                if (warningEmitted.compareAndSet(false, true)) {
+                    warningSink.accept(
+                        "Lookup of newer official GraalVM reachability metadata releases failed ("
+                            + ex.getMessage()
+                            + "). Dependencies covered only by newer metadata releases will be reported as missing."
+                    );
+                }
+                return null;
+            }
+        }
+
+        private FileSystemRepository downloadRepository(String repositoryUri) throws IOException {
+            Path cacheRoot = Path.of(System.getProperty("java.io.tmpdir"), "native-build-tools", "metadata-release-cache");
+            Files.createDirectories(cacheRoot);
+            String cacheKey = FileUtils.hashFor(URI.create(repositoryUri));
+            Path extractedRepository = cacheRoot.resolve(cacheKey + "-extracted");
+            if (!Files.exists(extractedRepository)) {
+                URL url = URI.create(repositoryUri).toURL();
+                Path downloadDirectory = cacheRoot.resolve(cacheKey);
+                Optional<Path> downloaded = existingDownloadedArchive(downloadDirectory)
+                    .or(() -> FileUtils.download(url, downloadDirectory, message -> { }));
+                if (downloaded.isEmpty()) {
+                    throw new IOException("Unable to download metadata repository " + repositoryUri);
+                }
+                AtomicBoolean extractionFailed = new AtomicBoolean();
+                FileUtils.extract(downloaded.get(), extractedRepository, message -> extractionFailed.set(true));
+                if (extractionFailed.get()) {
+                    throw new IOException("Unable to extract metadata repository " + repositoryUri);
+                }
+            }
+            return new FileSystemRepository(extractedRepository);
+        }
+
+        private Optional<Path> existingDownloadedArchive(Path downloadDirectory) throws IOException {
+            if (!Files.isDirectory(downloadDirectory)) {
+                return Optional.empty();
+            }
+            try (java.util.stream.Stream<Path> paths = Files.list(downloadDirectory)) {
+                return paths.filter(Files::isRegularFile).findFirst();
+            }
+        }
+    }
+
+    private record RepositorySnapshot(String version, String repositoryUri, FileSystemRepository repository) {
     }
 
     private static final class GitHubApiException extends RuntimeException {

--- a/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/MissingMetadataCommandSupportTest.java
+++ b/common/graalvm-reachability-metadata/src/test/java/org/graalvm/reachability/MissingMetadataCommandSupportTest.java
@@ -59,6 +59,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -123,6 +124,7 @@ class MissingMetadataCommandSupportTest {
 
         assertEquals(2, summary.getInt("scanned"));
         assertEquals(1, summary.getInt("supported"));
+        assertEquals(0, summary.getInt("supportedInNewerMetadataRepository"));
         assertEquals(1, summary.getInt("missing"));
         assertEquals(1, summary.getInt("newIssueLinks"));
         assertEquals(0, summary.getInt("errors"));
@@ -140,8 +142,8 @@ class MissingMetadataCommandSupportTest {
         assertFalse(missingUrl.contains("maven_coordinates="),
             "maven_coordinates= should not be used because coordinates now live in the issue title only, was: " + missingUrl);
         String console = report.renderConsoleOutput();
-        assertTrue(console.contains("Missing metadata libraries: 1 of 2 scanned"),
-            "console should headline missing/scanned counts, was:\n" + console);
+        assertTrue(console.contains("Dependencies needing attention: 1 of 2 scanned"),
+            "console should headline attention/scanned counts, was:\n" + console);
         assertTrue(console.contains("To request support for this library automatically, re-run with createIssues=true:"),
             "console should include the createIssues=true call to action, was:\n" + console);
         assertTrue(console.contains("./gradlew listLibrariesMissingMetadata -PcreateIssues=true -PgithubToken=<token>"),
@@ -182,6 +184,73 @@ class MissingMetadataCommandSupportTest {
         assertEquals(1, summary.getInt("supported"));
         assertEquals(0, summary.getInt("missing"));
         assertEquals("supported", result.getString("status"));
+    }
+
+    @Test
+    void reportsLibrariesCoveredInNewerMetadataRepositorySeparatelyAndSkipsIssueCreation() throws Exception {
+        String configuredMetadataVersion = "test-current-release";
+        String supportingMetadataVersion = "test-newer-release";
+        String configuredMetadataRepositoryUri =
+            "https://example.invalid/releases/" + configuredMetadataVersion + "/metadata.zip";
+        String supportingMetadataRepositoryUri =
+            "https://example.invalid/releases/" + supportingMetadataVersion + "/metadata.zip";
+        MissingMetadataCommandSupport.DependencyCoordinate dependency =
+            new MissingMetadataCommandSupport.DependencyCoordinate("org.example", "covered-later", "test-dependency-version");
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        AtomicInteger searches = new AtomicInteger();
+        AtomicInteger creations = new AtomicInteger();
+        server.createContext("/api/v3/search/issues", exchange -> {
+            searches.incrementAndGet();
+            writeJson(exchange, "{\"items\":[]}");
+        });
+        server.createContext("/api/v3/repos/test/repo/issues", exchange -> {
+            creations.incrementAndGet();
+            writeJson(exchange, "{\"html_url\":\"http://localhost/unused\",\"number\":99}");
+        });
+        server.start();
+        try {
+            MissingMetadataCommandSupport.Report report = MissingMetadataCommandSupport.run(
+                List.of(dependency),
+                new TestRepository(Set.of()),
+                Set.of(),
+                java.util.Map.of(),
+                new MissingMetadataCommandSupport.Options(
+                    "gradle",
+                    "demo-app",
+                    configuredMetadataRepositoryUri,
+                    true,
+                    "gho_test_token",
+                    "test/repo",
+                    "http://localhost:" + server.getAddress().getPort() + "/api/v3",
+                    Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneOffset.UTC),
+                    hostname -> null,
+                    coordinate -> true,
+                    message -> { },
+                    (coordinate, forcedVersion) -> Optional.of(new MissingMetadataCommandSupport.SupportingMetadataRepository(
+                        supportingMetadataVersion,
+                        supportingMetadataRepositoryUri
+                    ))
+                )
+            );
+
+            JSONObject json = new JSONObject(report.toJsonString());
+            JSONObject summary = json.getJSONObject("summary");
+            JSONObject result = findByCoordinates(json.getJSONArray("results"), dependency.coordinates());
+            assertEquals(0, searches.get());
+            assertEquals(0, creations.get());
+            assertEquals(0, summary.getInt("supported"));
+            assertEquals(1, summary.getInt("supportedInNewerMetadataRepository"));
+            assertEquals(0, summary.getInt("missing"));
+            assertEquals("supported_in_newer_metadata_repository", result.getString("status"));
+            assertEquals(supportingMetadataVersion, result.getString("supportingMetadataRepositoryVersion"));
+            assertEquals(supportingMetadataRepositoryUri, result.getString("supportingMetadataRepositoryUri"));
+            String console = report.renderConsoleOutput();
+            assertTrue(console.contains("Covered in a newer metadata repository release"), console);
+            assertTrue(console.contains(dependency.coordinates() + " -> supported in " + supportingMetadataVersion), console);
+            assertTrue(console.contains("update metadata repository to " + supportingMetadataVersion + " or upgrade Native Build Tools"), console);
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test
@@ -235,7 +304,7 @@ class MissingMetadataCommandSupportTest {
                 results.getJSONObject(0).getString("issueUrl"));
             String console = report.renderConsoleOutput();
             String issueUrl = "http://localhost:" + server.getAddress().getPort() + "/test/repo/issues/42";
-            assertTrue(console.contains("Missing metadata libraries: 2 of 2 scanned (2 already requested)"),
+            assertTrue(console.contains("Dependencies needing attention: 2 of 2 scanned (2 already requested)"),
                 "headline should mention the existing-request count, was:\n" + console);
             assertTrue(console.contains("Already requested (no action needed):"), console);
             assertTrue(console.contains("- org.example:duplicate-lib:1.0.0  -> existing request [E1]"), console);

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -843,7 +843,7 @@ By default, the task:
 - Prints prefilled issue links when a dependency is missing metadata support
 - Writes a JSON report to _build/reports/native/list-libraries-missing-metadata.json_
 
-The JSON report includes a `$schema` field pointing to _schemas/list-libraries-missing-metadata-schema-v1.0.0.json_ in this repository.
+The JSON report includes a `$schema` field pointing to _schemas/list-libraries-missing-metadata-schema-v1.1.0.json_ in this repository.
 
 To create issues automatically instead of printing links, opt in explicitly:
 

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -860,7 +860,7 @@ By default, the goal:
 - Prints prefilled issue links when a dependency is missing metadata support
 - Writes a JSON report to _target/native/list-libraries-missing-metadata.json_
 
-The JSON report includes a `$schema` field pointing to _schemas/list-libraries-missing-metadata-schema-v1.0.0.json_ in this repository.
+The JSON report includes a `$schema` field pointing to _schemas/list-libraries-missing-metadata-schema-v1.1.0.json_ in this repository.
 
 To create issues automatically instead of printing links, opt in explicitly:
 

--- a/schemas/list-libraries-missing-metadata-schema-v1.1.0.json
+++ b/schemas/list-libraries-missing-metadata-schema-v1.1.0.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/graalvm/native-build-tools/master/schemas/list-libraries-missing-metadata-schema-v1.0.0.json",
+  "$id": "https://raw.githubusercontent.com/graalvm/native-build-tools/master/schemas/list-libraries-missing-metadata-schema-v1.1.0.json",
   "title": "list-libraries-missing-metadata report",
   "type": "object",
   "additionalProperties": false,
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "$schema": {
-      "const": "https://raw.githubusercontent.com/graalvm/native-build-tools/master/schemas/list-libraries-missing-metadata-schema-v1.0.0.json"
+      "const": "https://raw.githubusercontent.com/graalvm/native-build-tools/master/schemas/list-libraries-missing-metadata-schema-v1.1.0.json"
     },
     "command": {
       "const": "listLibrariesMissingMetadata"
@@ -65,6 +65,7 @@
       "required": [
         "scanned",
         "supported",
+        "supportedInNewerMetadataRepository",
         "missing",
         "existingOpenIssue",
         "newIssueLinks",
@@ -77,6 +78,10 @@
           "minimum": 0
         },
         "supported": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "supportedInNewerMetadataRepository": {
           "type": "integer",
           "minimum": 0
         },
@@ -112,6 +117,9 @@
         "oneOf": [
           {
             "$ref": "#/$defs/supportedResult"
+          },
+          {
+            "$ref": "#/$defs/supportedInNewerMetadataRepositoryResult"
           },
           {
             "$ref": "#/$defs/missingResult"
@@ -152,6 +160,36 @@
         },
         "status": {
           "const": "supported"
+        }
+      }
+    },
+    "supportedInNewerMetadataRepositoryResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coordinates",
+        "scope",
+        "status",
+        "supportingMetadataRepositoryVersion",
+        "supportingMetadataRepositoryUri"
+      ],
+      "properties": {
+        "coordinates": {
+          "$ref": "#/$defs/coordinates"
+        },
+        "scope": {
+          "$ref": "#/$defs/scope"
+        },
+        "status": {
+          "const": "supported_in_newer_metadata_repository"
+        },
+        "supportingMetadataRepositoryVersion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "supportingMetadataRepositoryUri": {
+          "type": "string",
+          "format": "uri"
         }
       }
     },


### PR DESCRIPTION
Closes #947

## Summary

This PR improves `listLibrariesMissingMetadata` reporting so Native Build Tools distinguishes between:

- dependencies that are genuinely missing from the reachability metadata repository
- dependencies that are already covered by a newer official metadata repository release than the one currently configured or bundled

Instead of treating both cases as "missing" and offering or creating support requests for all of them, the command now performs a second lookup against the latest official reachability metadata release when the configured repository does not cover a dependency.

If the dependency is found there, the report:

- classifies it separately as `supported_in_newer_metadata_repository`
- does not create or suggest a GitHub issue for that dependency
- tells the user to upgrade the metadata repository version or Native Build Tools

## What Changed

- added a second-pass lookup in `MissingMetadataCommandSupport` against the latest official GraalVM reachability metadata release
- introduced a dedicated `supported_in_newer_metadata_repository` result status in the JSON report
- updated console rendering to show dependencies covered by a newer release in a separate section
- kept issue creation limited to dependencies that remain uncovered after both checks
- added focused tests covering the newer-release path and the no-issue-creation behavior
- updated the functional spec for missing metadata reporting and repository coverage semantics
- replaced the `list-libraries-missing-metadata` schema `v1.0.0` with `v1.1.0`
- updated Gradle and Maven docs to reference the `v1.1.0` schema

## Why

Today, users running an older Native Build Tools build or an older metadata repository can end up opening issues against `oracle/graalvm-reachability-metadata` for libraries that are already covered on the repository, just not in the version they are currently consuming.

This change keeps the output actionable for those users while avoiding false-positive support requests.

## Example Output

Example console output showing the new section in context when a dependency is not covered by the configured metadata repository but is covered by a newer release:

```text
[INFO] Dependencies needing attention: 6 of 18 scanned (1 covered in a newer metadata repository release).

Covered in a newer metadata repository release (update metadata repository or Native Build Tools):
  - org.springframework.boot:spring-boot-starter-webmvc:4.1.0 -> supported in 1.0.3
      update metadata repository to 1.0.3 or upgrade Native Build Tools

To request support for the remaining 5 libraries automatically, re-run with createIssues=true:

    ./mvnw native:list-libraries-missing-metadata -DcreateIssues=true -DgithubToken=<token>

  Token sources tried in order:
    -DgithubToken=...  ->  $GITHUB_TOKEN  ->  $GH_TOKEN  ->  `gh auth token`

Or request support manually, one library at a time:
  - org.springframework.boot:spring-boot-starter-cache:3.5.6      -> request support [1]
  - org.springframework.boot:spring-boot-starter-thymeleaf:3.5.6  -> request support [2]
  - org.webjars.npm:bootstrap:5.3.8                               -> request support [3]
```

In that case, the dependency is surfaced to the user, but it is excluded from issue creation and from the manual support-request list.

## Validation

- `grund check`
- `./gradlew --no-daemon --console=plain :graalvm-reachability-metadata:test --tests org.graalvm.reachability.MissingMetadataCommandSupportTest`
