### PR TITLE
Fix invalid Gradle tracing-agent grund citation

### DIFF
--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -229,7 +229,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     private void instrumentTasksWithAgent(Project project, DefaultGraalVmExtension graalExtension) {
         Provider<String> agentMode = agentProperty(project, graalExtension.getAgent());
         if ("disabled".equals(agentMode.get())) {
-            // Disabled agent mode must not instrument eligible JVM tasks. §FS-gradle-tracing-agent.3.
+            // Disabled agent mode must not instrument eligible JVM tasks. §gradle/FS-tracing-agent.3.
             logger.log("Not instrumenting tasks with native-image-agent because the agent is disabled.");
             return;
         }


### PR DESCRIPTION
## Summary
- fix the invalid Gradle tracing-agent grund citation in `NativeImagePlugin`
- point the comment to `§gradle/FS-tracing-agent.3`, which is the matching disabled-mode spec
- restore a clean `grund check` on the branch

Closes #949

## Verification
- `grund check`
