### PR TITLE
Fix layered image configuration cache test

### DIFF
--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -26,6 +26,10 @@ configuration directories, generated resources, reachability metadata, layer opt
 conversion must come from common utilities rather than Gradle-only string handling, keeping Gradle
 aligned with [§root/FS-option-precedence](../../../docs/spec/functional/option-precedence.md#fs-option-precedence-command-line-input-and-durable-configuration-produce-one-option-state).
 
+For a layer created from declared JARs, the command line must use those JARs as its classpath so
+the layer input remains limited to the declaration. A layer created from packages must instead
+retain the binary classpath, which supplies the classes selected by those package names.
+
 ## 4. Argument files
 
 The plugin must support Native Image argument files for command lines that should not be passed as

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -46,7 +46,6 @@ import org.graalvm.buildtools.gradle.fixtures.GraalVMSupport
 import org.graalvm.buildtools.utils.NativeImageUtils
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
-import spock.lang.Issue
 import spock.lang.Requires
 import spock.util.concurrent.PollingConditions
 
@@ -59,37 +58,67 @@ import java.nio.charset.StandardCharsets
         { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
 )
 class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
-    // Layers are disabled for configuration-cache coverage pending #957 and on JDK 25.0.x Darwin and Windows CI platforms. §E2E-functional-tests.
-    @Issue("https://github.com/graalvm/native-build-tools/issues/957")
-    @IgnoreIf({ Boolean.getBoolean("config.cache") || os.windows || os.macOs })
+    // Layers are disabled on JDK 25.0.x Darwin and Windows CI platforms. §E2E-functional-tests.3.6.
+    @IgnoreIf({ os.windows || os.macOs })
     def "can build a native image using layers"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
 
         given:
         withSample("layered-java-application")
+        buildFile << """
+            // Layered-image configuration-cache coverage isolates layer task inputs.
+            // §E2E-functional-tests.3.6, §E2E-functional-tests.4.
+            graalvmNative.metadataRepository.enabled = false
+        """.stripIndent()
 
         when:
-        run 'nativeLibdependenciesCompile'
+        runAndReloadConfigurationCache 'nativeLibdependenciesCompile'
 
         then:
-        tasks {
-            succeeded ':nativeLibdependenciesCompile'
+        if (hasConfigurationCache) {
+            configurationCacheStoreTasks {
+                succeeded ':nativeLibdependenciesCompile'
+            }
+            tasks {
+                upToDate ':nativeLibdependenciesCompile'
+            }
+        } else {
+            tasks {
+                succeeded ':nativeLibdependenciesCompile'
+            }
         }
-        outputContains "'-H:LayerCreate' (origin(s): command line)"
+        if (hasConfigurationCache) {
+            configurationCacheStoreOutputContains "'-H:LayerCreate' (origin(s): command line)"
+        } else {
+            outputContains "'-H:LayerCreate' (origin(s): command line)"
+        }
 
         when:
-        run 'nativeRun', '-Pmessage="Hello, layered images!"'
+        runAndReloadConfigurationCache 'nativeRun', '-Pmessage="Hello, layered images!"'
 
         then:
-        tasks {
-            upToDate ':nativeLibdependenciesCompile'
-            succeeded ':nativeCompile'
+        if (hasConfigurationCache) {
+            configurationCacheStoreTasks {
+                upToDate ':nativeLibdependenciesCompile'
+                succeeded ':nativeCompile'
+            }
+            tasks {
+                upToDate ':nativeLibdependenciesCompile', ':nativeCompile'
+            }
+        } else {
+            tasks {
+                upToDate ':nativeLibdependenciesCompile'
+                succeeded ':nativeCompile'
+            }
         }
         nativeApp.exists()
 
         and:
-        outputContains "- '-H:LayerUse' (origin(s): command line)"
-        outputContains "Hello, layered images!"
+        if (hasConfigurationCache) {
+            configurationCacheStoreOutputContains "- '-H:LayerUse' (origin(s): command line)"
+        } else {
+            outputContains "- '-H:LayerUse' (origin(s): command line)"
+        }
 
         when: "Updating the application without changing the dependencies"
         file("src/main/java/org/graalvm/demo/Application.java").text = """
@@ -108,18 +137,33 @@ public class Application {
 }
 
 """
-        run 'nativeRun', '-Pmessage="Hello, layered images!"'
+        runAndReloadConfigurationCache 'nativeRun', '-Pmessage="Hello, layered images!"'
 
         then:
-        tasks {
-            // Base layer is not rebuilt
-            upToDate ':nativeLibdependenciesCompile'
-            // Application layer is recompiled
-            succeeded ':nativeCompile'
+        if (hasConfigurationCache) {
+            configurationCacheStoreTasks {
+                // Base layer is not rebuilt
+                upToDate ':nativeLibdependenciesCompile'
+                // Application layer is recompiled
+                succeeded ':nativeCompile'
+            }
+            tasks {
+                upToDate ':nativeLibdependenciesCompile', ':nativeCompile'
+            }
+        } else {
+            tasks {
+                // Base layer is not rebuilt
+                upToDate ':nativeLibdependenciesCompile'
+                // Application layer is recompiled
+                succeeded ':nativeCompile'
+            }
         }
 
-        outputContains "- '-H:LayerUse' (origin(s): command line)"
-        outputContains "Hello, layered images!"
+        if (hasConfigurationCache) {
+            configurationCacheStoreOutputContains "- '-H:LayerUse' (origin(s): command line)"
+        } else {
+            outputContains "- '-H:LayerUse' (origin(s): command line)"
+        }
     }
 
     @Ignore("Disable test temporarily because of a problem on GraalVM side")

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -446,6 +446,8 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         }
         layer.getLayerName().convention(binaryName);
         spec.execute(layer);
+        // Layer creation uses the layer declaration as its classpath model so compile task inputs stay selective. §FS-native-tasks.1.
+        getClasspath().setFrom();
         layers(options -> options.add(layer));
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -446,8 +446,6 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         }
         layer.getLayerName().convention(binaryName);
         spec.execute(layer);
-        // Layer creation uses the layer declaration as its classpath model so compile task inputs stay selective. §FS-native-tasks.1.
-        getClasspath().setFrom();
         layers(options -> options.add(layer));
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -179,15 +179,13 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         }
         cliArgs.addAll(options.getExcludeConfigArgs().get());
         String classpathString = buildClasspathString(options).trim();
-        if (!classpathString.isEmpty()) {
-            cliArgs.add("-cp");
-            cliArgs.add(classpathString);
-        } else if (jarsClasspath != null && !jarsClasspath.isEmpty()) {
-            // This is a shortcut in case of the creation of a layer using the "jars" mode (e.g, not package, nor modules)
-            // in which case the classpath must replicate the jars so we want to avoid that the user has to configure
-            // things twice
+        if (jarsClasspath != null && !jarsClasspath.isEmpty()) {
+            // JAR-defined layers intentionally exclude the binary classpath from the layer build. §FS-native-invocation.3.
             cliArgs.add("-cp");
             cliArgs.add(jarsClasspath.getAsPath());
+        } else if (!classpathString.isEmpty()) {
+            cliArgs.add("-cp");
+            cliArgs.add(classpathString);
         }
         appendBooleanOption(cliArgs, options.getDebug(), "-g");
         appendBooleanOption(cliArgs, options.getFallback().map(NEGATE), NativeImageFlags.NO_FALLBACK);

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -112,6 +112,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
         args.any { it.startsWith("${NativeImageFlags.LAYER_CREATE}=libbase.nil") && it.contains("module=java.base") }
     }
 
+    // Uses declared layer JARs instead of the inherited binary classpath. §FS-native-invocation.3.
     @Issue("https://github.com/graalvm/native-build-tools/issues/957")
     def "uses layer jars instead of inherited binary classpath for layer-create build"() {
         given:

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -144,10 +144,45 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
         ).asArguments()
 
         then:
-        !options.classpath.files.contains(appJar)
+        options.classpath.files.contains(appJar)
         !args.contains(appJar.absolutePath)
         args.any { it.startsWith("${NativeImageFlags.LAYER_CREATE}=libdependencies.nil") && it.contains("path=${dependencyJar}") }
         args.contains("-cp")
         args.contains(dependencyJar.absolutePath)
+    }
+
+    def "retains binary classpath for package-based layer-create build"() {
+        given:
+        def project = newProject()
+        project.plugins.apply(ApplicationPlugin)
+        project.plugins.apply(NativeImagePlugin)
+        def appJar = testDirectory.resolve("app.jar").toFile()
+        appJar.text = "application"
+        def options = project.extensions.getByType(GraalVMExtension).binaries.create("libpackages")
+        options.classpath.from(appJar)
+        options.createLayer {
+            it.modules.add("java.base")
+            it.packages.add("org.graalvm.demo")
+        }
+        options.excludeConfigArgs.set([])
+        options.configurationFileDirectories.setFrom([])
+
+        when:
+        def args = new NativeImageCommandLineProvider(
+                project.provider { options },
+                project.provider { "libpackages" },
+                project.provider { testDirectory.toString() },
+                project.provider { testDirectory.toString() },
+                project.objects.fileProperty(),
+                project.provider { false },
+                project.provider { 25 },
+                project.provider { false }
+        ).asArguments()
+
+        then:
+        options.classpath.files.contains(appJar)
+        args.any { it.startsWith("${NativeImageFlags.LAYER_CREATE}=libpackages.nil") && it.contains("package=org.graalvm.demo") }
+        args.contains("-cp")
+        args.contains(appJar.absolutePath)
     }
 }

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -111,4 +111,43 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
         args.contains(NativeImageFlags.UNLOCK_EXPERIMENTAL_VMOPTIONS)
         args.any { it.startsWith("${NativeImageFlags.LAYER_CREATE}=libbase.nil") && it.contains("module=java.base") }
     }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/957")
+    def "uses layer jars instead of inherited binary classpath for layer-create build"() {
+        given:
+        def project = newProject()
+        project.plugins.apply(ApplicationPlugin)
+        project.plugins.apply(NativeImagePlugin)
+        def appJar = testDirectory.resolve("app.jar").toFile()
+        def dependencyJar = testDirectory.resolve("dependency.jar").toFile()
+        appJar.text = "application"
+        dependencyJar.text = "dependency"
+        def options = project.extensions.getByType(GraalVMExtension).binaries.create("libdependencies")
+        options.classpath.from(appJar)
+        options.createLayer {
+            it.modules.add("java.base")
+            it.jars.from(dependencyJar)
+        }
+        options.excludeConfigArgs.set([])
+        options.configurationFileDirectories.setFrom([])
+
+        when:
+        def args = new NativeImageCommandLineProvider(
+                project.provider { options },
+                project.provider { "libdependencies" },
+                project.provider { testDirectory.toString() },
+                project.provider { testDirectory.toString() },
+                project.objects.fileProperty(),
+                project.provider { false },
+                project.provider { 25 },
+                project.provider { false }
+        ).asArguments()
+
+        then:
+        !options.classpath.files.contains(appJar)
+        !args.contains(appJar.absolutePath)
+        args.any { it.startsWith("${NativeImageFlags.LAYER_CREATE}=libdependencies.nil") && it.contains("path=${dependencyJar}") }
+        args.contains("-cp")
+        args.contains(dependencyJar.absolutePath)
+    }
 }

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -63,14 +63,17 @@ abstract class AbstractFunctionalTest extends Specification {
     boolean IS_LINUX = System.getProperty("os.name", "unknown").contains("Linux")
     boolean IS_MAC = System.getProperty("os.name", "unknown").contains("Mac")
 
+    private final URI commonRepositoryUri = commonRepositoryUri()
     private StringWriter outputWriter
     private StringWriter errorOutputWriter
     private String output
     private String errorOutput
+    private String configurationCacheStoreOutput
     private File initScript
     private Map<String, String> environment
 
     BuildResult result
+    BuildResult configurationCacheStoreResult
 
     private static String testGradleVersion() {
         String version = System.getProperty("gradle.test.version", GradleVersion.current().version)
@@ -78,6 +81,11 @@ abstract class AbstractFunctionalTest extends Specification {
             version = GradleVersion.current().version
         }
         version
+    }
+
+    private static URI commonRepositoryUri() {
+        String repositoryPath = System.getProperty("common.repo.url")
+        repositoryPath == null ? null : new File(repositoryPath).toURI()
     }
 
     Path path(String... pathElements) {
@@ -167,12 +175,33 @@ abstract class AbstractFunctionalTest extends Specification {
 
     void run(String... args) {
         try {
+            configurationCacheStoreResult = null
+            configurationCacheStoreOutput = null
             result = newRunner(args)
                     .run()
             if (hasConfigurationCache) {
                 // run a 2d time to check that not only we can store in
                 // the configuration cache, but that we can also load from it
+                configurationCacheStoreResult = result
+                configurationCacheStoreOutput = normalizeString(outputWriter.toString())
                 result = newRunner([*args, "--rerun-tasks"] as String[])
+                        .run()
+            }
+        } finally {
+            recordOutputs()
+        }
+    }
+
+    void runAndReloadConfigurationCache(String... args) {
+        try {
+            configurationCacheStoreResult = null
+            configurationCacheStoreOutput = null
+            result = newRunner(args)
+                    .run()
+            if (hasConfigurationCache) {
+                configurationCacheStoreResult = result
+                configurationCacheStoreOutput = normalizeString(outputWriter.toString())
+                result = newRunner(args)
                         .run()
             }
         } finally {
@@ -182,6 +211,11 @@ abstract class AbstractFunctionalTest extends Specification {
 
     void outputContains(String text) {
         assert output.contains(normalizeString(text))
+    }
+
+    void configurationCacheStoreOutputContains(String text) {
+        assert configurationCacheStoreOutput != null: "No configuration-cache store build output is available"
+        assert configurationCacheStoreOutput.contains(normalizeString(text))
     }
 
     void outputDoesNotContain(String text) {
@@ -205,7 +239,17 @@ abstract class AbstractFunctionalTest extends Specification {
     }
 
     void tasks(@DelegatesTo(value = TaskExecutionGraph, strategy = Closure.DELEGATE_FIRST) Closure spec) {
+        inspectTasks(result, spec)
+    }
+
+    void configurationCacheStoreTasks(@DelegatesTo(value = TaskExecutionGraph, strategy = Closure.DELEGATE_FIRST) Closure spec) {
+        assert configurationCacheStoreResult != null: "No configuration-cache store build result is available"
+        inspectTasks(configurationCacheStoreResult, spec)
+    }
+
+    private void inspectTasks(BuildResult buildResult, @DelegatesTo(value = TaskExecutionGraph, strategy = Closure.DELEGATE_FIRST) Closure spec) {
         def graph = new TaskExecutionGraph()
+        graph.result = buildResult
         spec.delegate = graph
         spec.resolveStrategy = Closure.DELEGATE_FIRST
         spec()
@@ -272,11 +316,13 @@ abstract class AbstractFunctionalTest extends Specification {
     private void assertInitScript() {
         initScript = file("init.gradle")
         if (!initScript.exists()) {
+            assert commonRepositoryUri != null: "Expected common.repo.url system property for functional test repository"
+            // The generated init script must be self-contained before the first cached TestKit build starts. §AR-gradle-plugin.6, §E2E-functional-tests.4.
             initScript << """
             allprojects {
                 repositories {
                     maven {
-                        url = "\${providers.systemProperty('common.repo.url').get()}"
+                        url = "${commonRepositoryUri}"
                     }
                     mavenCentral()
                 }
@@ -286,6 +332,8 @@ abstract class AbstractFunctionalTest extends Specification {
     }
 
     private class TaskExecutionGraph {
+        BuildResult result
+
         void succeeded(String... tasks) {
             tasks.each { task ->
                 contains(task)


### PR DESCRIPTION
## What changed

Layered native-image builds in the Gradle plugin now work in the configuration-cache functional-test path. A dependency layer declared with `createLayer { jars.from(...) }` uses its declared layer JARs as the Native Image invocation classpath, keeping the dependency-layer command line independent of application artifacts.

The binary classpath is no longer cleared when configuring a layer. This preserves package-based layer creation: `createLayer { packages = [...] }` retains the binary classpath that supplies the selected package classes.

The layered application functional test now runs with configuration cache enabled on Linux and verifies cache storage and reuse. After an application-only source change, the dependency layer stays up to date while the application layer rebuilds.

## Why

The earlier implementation made the dependency layer inherit an application classpath, invalidating it for application-only changes. Clearing that classpath fixed the JAR-layer scenario but unintentionally broke package-based layer declarations and made the DSL order-dependent.

The command-line provider now chooses the declared layer JARs only for JAR-based layers, while package-based layers retain their configured binary classpath.

## Example

```groovy
graalvmNative {
    binaries {
        libdependencies {
            createLayer {
                jars.from(configurations.runtimeClasspath)
            }
        }
        libpackages {
            classpath.from(layout.projectDirectory.file("packages.jar"))
            createLayer {
                packages = ["com.example.shared"]
            }
        }
    }
}
```

`nativeLibdependenciesCompile` uses the declared layer JARs for both `-H:LayerCreate` and `-cp`; `nativeLibpackagesCompile` retains `packages.jar` as `-cp`.

## Implementation summary

- Select the declared `CreateLayerOptions.jars` as `-cp` in `NativeImageCommandLineProvider`, without mutating `NativeImageOptions.classpath`.
- Add unit coverage for both JAR-based and package-based layer creation.
- Specify the layer classpath rules in `FS-native-invocation.3`.
- Keep the configuration-cache fixture changes that separately assert cache-store output and cache reuse.

Fixes #957.

## Validation

Passed locally with Gradle running on JDK 17 and Native Image from GraalVM 25:

```text
grund check
git diff --check
JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal \
  GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/current \
  ./gradlew :native-gradle-plugin:test \
  --tests org.graalvm.buildtools.gradle.tasks.NativeImageCommandLineProviderTest

JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal \
  GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/current \
  ./gradlew :native-gradle-plugin:configCacheFunctionalTest \
  --tests org.graalvm.buildtools.gradle.LayeredApplicationFunctionalTest
```

The focused configuration-cache test passed with zero failures and verified cache reuse, `LayerCreate`, `LayerUse`, and that the dependency layer remains up to date after an application-only source change.