### PR TITLE
Fix Groovy agent predicate closures

### DIFF
--- a/docs/src/docs/snippets/gradle/groovy/build.gradle
+++ b/docs/src/docs/snippets/gradle/groovy/build.gradle
@@ -125,7 +125,7 @@ graalvmNative {
             mergeWithExisting = true
         }
 
-        tasksToInstrumentPredicate = t -> true
+        tasksToInstrumentPredicate = { t -> true }
     }
 }
 // end::all-config-options[]

--- a/native-gradle-plugin/docs/functional/tracing-agent.md
+++ b/native-gradle-plugin/docs/functional/tracing-agent.md
@@ -14,7 +14,8 @@ run. The default mode convention is `standard`, except projects that apply Gradl
 
 Every task that implements `JavaForkOptions` is eligible for instrumentation. The
 `tasksToInstrumentPredicate` setting may narrow that set. Non-matching tasks must be skipped
-without failing the build.
+without failing the build. In Groovy DSL, the predicate may be assigned directly as a closure;
+its result must determine whether each eligible task is instrumented.
 
 ### 2.1 Agent Java runtime
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -50,6 +50,90 @@ import spock.lang.Unroll
 
 class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
 
+    // Groovy closures narrow instrumented tasks while preserving nested agent DSL blocks. §FS-tracing-agent.2.
+    @Issue("https://github.com/graalvm/native-build-tools/issues/303")
+    def "direct Groovy predicate closure can disable instrumentation"() {
+        given:
+        withSample("java-application-with-reflection")
+        buildFile << """
+            graalvmNative {
+                agent {
+                    tasksToInstrumentPredicate = { t -> false }
+                    modes {
+                        conditional {
+                            parallel = false
+                        }
+                    }
+                    metadataCopy {
+                        mergeWithExisting = true
+                    }
+                }
+            }
+        """.stripIndent()
+
+        when:
+        run 'test', '-Pagent'
+
+        then:
+        tasks {
+            succeeded ':test'
+        }
+        !file("build/native/agent-output/test").exists()
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/303")
+    def "explicit Predicate assignment remains supported"() {
+        given:
+        withSample("java-application-with-reflection")
+        buildFile << """
+            import java.util.function.Predicate
+            import org.gradle.api.Task
+
+            graalvmNative {
+                agent {
+                    Predicate<Task> predicate = { t -> false }
+                    tasksToInstrumentPredicate = predicate
+                }
+            }
+        """.stripIndent()
+
+        when:
+        run 'test', '-Pagent'
+
+        then:
+        tasks {
+            succeeded ':test'
+        }
+        !file("build/native/agent-output/test").exists()
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/303")
+    def "Kotlin DSL continues to configure the managed predicate property"() {
+        given:
+        kotlinSettingsFile.text = 'rootProject.name = "agent-predicate-kotlin-dsl"\n'
+        kotlinBuildFile.text = """
+            import java.util.function.Predicate
+            import org.gradle.api.Task
+
+            plugins {
+                java
+                id("org.graalvm.buildtools.native")
+            }
+
+            graalvmNative {
+                agent {
+                    tasksToInstrumentPredicate.set(Predicate<Task> { false })
+                }
+            }
+        """.stripIndent()
+
+        when:
+        run 'test', '-Pagent'
+
+        then:
+        !file("build/native/agent-output/test").exists()
+    }
+
     def getCurrentJDKVersion() {
         return NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString())
     }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -81,6 +81,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         !file("build/native/agent-output/test").exists()
     }
 
+    // Explicit predicates must continue to narrow the eligible instrumented task set. §FS-tracing-agent.2.
     @Issue("https://github.com/graalvm/native-build-tools/issues/303")
     def "explicit Predicate assignment remains supported"() {
         given:
@@ -107,6 +108,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
         !file("build/native/agent-output/test").exists()
     }
 
+    // Kotlin DSL predicates must continue to narrow the eligible instrumented task set. §FS-tracing-agent.2.
     @Issue("https://github.com/graalvm/native-build-tools/issues/303")
     def "Kotlin DSL continues to configure the managed predicate property"() {
         given:

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
@@ -41,6 +41,7 @@
 
 package org.graalvm.buildtools.gradle.dsl;
 
+import groovy.lang.Closure;
 import org.graalvm.buildtools.gradle.dsl.agent.AgentOptions;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
@@ -71,6 +72,13 @@ public interface GraalVMExtension {
     AgentOptions getAgent();
 
     void agent(Action<? super AgentOptions> spec);
+
+    /**
+     * Configures agent options from a Groovy DSL closure. §FS-tracing-agent.2.
+     *
+     * @param spec Groovy DSL configuration
+     */
+    void agent(Closure<?> spec);
 
     DirectoryProperty getGeneratedResourcesDirectory();
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -41,6 +41,9 @@
 
 package org.graalvm.buildtools.gradle.internal;
 
+import groovy.lang.Closure;
+import groovy.lang.GroovyObjectSupport;
+import org.codehaus.groovy.runtime.InvokerHelper;
 import org.graalvm.buildtools.gradle.NativeImagePlugin;
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
@@ -49,12 +52,14 @@ import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.provider.Property;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 
 import javax.inject.Inject;
+import java.util.function.Predicate;
 
 public abstract class DefaultGraalVmExtension implements GraalVMExtension {
     private final transient NamedDomainObjectContainer<NativeImageOptions> nativeImages;
@@ -110,6 +115,46 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
     @Override
     public void agent(Action<? super AgentOptions> spec) {
         spec.execute(getAgent());
+    }
+
+    @Override
+    public void agent(Closure<?> spec) {
+        Closure<?> configuredSpec = (Closure<?>) spec.clone();
+        configuredSpec.setDelegate(new AgentOptionsGroovyDslAdapter(getAgent()));
+        configuredSpec.setResolveStrategy(Closure.DELEGATE_FIRST);
+        configuredSpec.call();
+    }
+
+    /**
+     * Adapts Groovy's direct closure assignment to the managed predicate property. §FS-tracing-agent.2.
+     */
+    private static final class AgentOptionsGroovyDslAdapter extends GroovyObjectSupport {
+        private final AgentOptions options;
+
+        private AgentOptionsGroovyDslAdapter(AgentOptions options) {
+            this.options = options;
+        }
+
+        @Override
+        public Object getProperty(String property) {
+            return InvokerHelper.getProperty(options, property);
+        }
+
+        @Override
+        public void setProperty(String property, Object value) {
+            if ("tasksToInstrumentPredicate".equals(property) && value instanceof Closure<?>) {
+                Closure<?> predicateClosure = (Closure<?>) value;
+                Predicate<Task> predicate = task -> Boolean.TRUE.equals(predicateClosure.call(task));
+                options.getTasksToInstrumentPredicate().set(predicate);
+                return;
+            }
+            InvokerHelper.setProperty(options, property, value);
+        }
+
+        @Override
+        public Object invokeMethod(String name, Object arguments) {
+            return InvokerHelper.invokeMethod(options, name, arguments);
+        }
     }
 
     @Override


### PR DESCRIPTION
## What changed

Groovy builds can now assign `tasksToInstrumentPredicate` directly with a closure, and its boolean result controls whether each eligible task is instrumented. Returning `false` for every task now disables agent instrumentation as documented.

## Why

Previously, a direct Groovy closure could be accepted by the DSL without becoming the predicate used by the agent, so users could not reliably disable instrumentation this way. Explicit Java `Predicate` assignments and Kotlin DSL configuration remain supported.

## Example

```groovy
graalvmNative {
    agent {
        tasksToInstrumentPredicate = { task -> false }
    }
}
```

Running `gradle test -Pagent` with this configuration leaves no agent output for `test`.

## Implementation summary

Added a Groovy DSL adapter at the `graalvmNative.agent` boundary that converts a direct closure into the existing managed task predicate while delegating nested agent configuration unchanged. Added Groovy and Kotlin functional coverage and corrected the public Groovy DSL snippet.

## Validation

- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:compileJava :native-gradle-plugin:compileFunctionalTestGroovy :native-gradle-plugin:inspections`
- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :native-gradle-plugin:test :native-gradle-plugin:inspections`
- Focused `:native-gradle-plugin:functionalTest` cases: `direct Groovy predicate closure can disable instrumentation`, `explicit Predicate assignment remains supported`, and `Kotlin DSL continues to configure the managed predicate property`
- The same three cases through `:native-gradle-plugin:configCacheFunctionalTest`
- `/home/jovan/.local/bin/grund check`
- `git diff --check`

Fixes #303