### PR TITLE
Make Maven skip apply to all goals

### DIFF
--- a/native-maven-plugin/docs/functional/configuration-model.md
+++ b/native-maven-plugin/docs/functional/configuration-model.md
@@ -42,3 +42,10 @@ when no explicit configuration is present. The exception is a parameter intentio
 let the property win for one run, such as the agent toggle in [§FS-tracing-agent.1](tracing-agent.md#1-agent-enablement) where
 `-Dagent=false` disables an agent enabled in the POM. This is the Maven adaptation of
 [§root/FS-option-precedence](../../../docs/spec/functional/option-precedence.md#fs-option-precedence-command-line-input-and-durable-configuration-produce-one-option-state).
+
+## 6. Plugin-wide goal skipping
+
+Setting `<skip>true</skip>` in the native Maven plugin's root `<configuration>` must skip every
+plugin goal before it resolves dependencies, downloads metadata, generates files, or otherwise
+causes a goal-specific side effect. When it is absent or false, each goal retains its existing
+specialized skip controls and behavior.

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
@@ -206,4 +206,23 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
   }
 ]''')
     }
+
+    // Plugin-level skip prevents add-reachability-metadata side effects. §FS-config-model.6, §E2E-functional-tests.3.2.
+    void "plugin-level skip prevents reachability metadata download and copy"() {
+        given:
+        withSample("native-config-integration")
+        def pom = file("pom.xml")
+        pom.text = pom.text.replaceFirst(/(?s)(<id>addMetadataHints<\/id>.*?<configuration>)/,
+                '$1\n                            <skip>true</skip>')
+
+        when:
+        mvn '-PaddMetadataHints', 'package'
+
+        then:
+        buildSucceeded
+        outputContains "Skipping native Maven plugin goal (parameter 'skip' is true)."
+        outputDoesNotContain "Downloaded GraalVM reachability metadata repository"
+        !file("target/graalvm-reachability-metadata").exists()
+        !file("target/classes/META-INF/native-image/org.graalvm.internal/library-with-reflection/1.5/reflect-config.json").exists()
+    }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -44,7 +44,6 @@ package org.graalvm.buildtools.maven;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.BuildPluginManager;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -43,8 +43,8 @@ package org.graalvm.buildtools.maven;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -87,7 +87,7 @@ import static org.graalvm.buildtools.utils.SharedConstants.METADATA_REPO_URL_TEM
 /**
  * @author Sebastien Deleuze
  */
-public abstract class AbstractNativeMojo extends AbstractMojo {
+public abstract class AbstractNativeMojo extends AbstractSkippableMojo {
     private static final String GROUP_ID = "org.graalvm.buildtools";
     private static final String GRAALVM_REACHABILITY_METADATA_ARTIFACT_ID = "graalvm-reachability-metadata";
     private static final String REPOSITORY_FORMAT = "zip";

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractResourceConfigMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractResourceConfigMojo.java
@@ -43,7 +43,6 @@ package org.graalvm.buildtools.maven;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -71,7 +70,7 @@ import static java.util.stream.Collectors.toCollection;
 import static org.graalvm.buildtools.model.resources.Helper.asNamedValues;
 import static org.graalvm.buildtools.model.resources.Helper.asPatternValues;
 
-public abstract class AbstractResourceConfigMojo extends AbstractMojo {
+public abstract class AbstractResourceConfigMojo extends AbstractSkippableMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true)
     protected MavenProject mavenProject;
@@ -108,7 +107,7 @@ public abstract class AbstractResourceConfigMojo extends AbstractMojo {
     private boolean ignoreExistingResourcesConfig;
 
     @Override
-    public void execute() throws MojoExecutionException {
+    protected void executeInternal() throws MojoExecutionException {
         Set<PatternValue> includes = asPatternValues(resourceIncludedPatterns);
         Set<PatternValue> excludes = asPatternValues(resourceExcludedPatterns);
         Set<NamedValue> bundles = asNamedValues(resourceBundles);

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractSkippableMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractSkippableMojo.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ */
+
+package org.graalvm.buildtools.maven;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
+
+public abstract class AbstractSkippableMojo extends AbstractMojo {
+
+    // A root plugin configuration skips every goal before its goal-specific work begins. §FS-config-model.6.
+    @Parameter(property = "skip", defaultValue = "false")
+    private boolean skip;
+
+    @Override
+    public final void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping native Maven plugin goal (parameter 'skip' is true).");
+            return;
+        }
+        executeInternal();
+    }
+
+    protected abstract void executeInternal() throws MojoExecutionException, MojoFailureException;
+}

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractSkippableMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractSkippableMojo.java
@@ -3,6 +3,40 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 package org.graalvm.buildtools.maven;

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AddReachabilityMetadataMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AddReachabilityMetadataMojo.java
@@ -78,7 +78,7 @@ public class AddReachabilityMetadataMojo extends AbstractNativeMojo {
 
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    protected void executeInternal() throws MojoExecutionException, MojoFailureException {
         configureMetadataRepository();
         project.getArtifacts().stream().filter(this::isInScope)
                 .forEach(dependency -> maybeAddDependencyMetadata(dependency, null));

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/DeprecatedNativeBuildMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/DeprecatedNativeBuildMojo.java
@@ -57,9 +57,9 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 public class DeprecatedNativeBuildMojo extends NativeCompileNoForkMojo {
 
     @Override
-    public void execute() throws MojoExecutionException {
+    protected void executeInternal() throws MojoExecutionException {
         logger.warn("'native:build' goal is deprecated. Use 'native:compile-no-fork' instead.");
-        super.execute();
+        super.executeInternal();
     }
 
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/ListLibrariesMissingMetadataMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/ListLibrariesMissingMetadataMojo.java
@@ -82,7 +82,7 @@ public class ListLibrariesMissingMetadataMojo extends AbstractNativeMojo {
     private File reportFile;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    protected void executeInternal() throws MojoExecutionException, MojoFailureException {
         if (!isMetadataRepositoryEnabled()) {
             throw new MojoExecutionException("GraalVM reachability metadata repository is disabled.");
         }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MergeAgentFilesMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MergeAgentFilesMojo.java
@@ -44,7 +44,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.FileUtils;
 import org.graalvm.buildtools.maven.config.AbstractMergeAgentFilesMojo;
 import org.graalvm.buildtools.maven.config.agent.AgentConfiguration;
@@ -65,9 +64,6 @@ import java.util.stream.Stream;
  */
 @Mojo(name = "merge-agent-files", defaultPhase = LifecyclePhase.TEST)
 public class MergeAgentFilesMojo extends AbstractMergeAgentFilesMojo {
-    @Parameter(defaultValue = "${project}", readonly = true, required = true)
-    protected MavenProject project;
-
     @Parameter(defaultValue = "${project.build.directory}", readonly = true, required = true)
     protected String target;
 
@@ -82,7 +78,7 @@ public class MergeAgentFilesMojo extends AbstractMergeAgentFilesMojo {
     private static final List<String> DEFAULT_DIRS = Arrays.asList("main", "test");
 
     @Override
-    public void execute() throws MojoExecutionException {
+    protected void executeInternal() throws MojoExecutionException {
         // we need this mojo to be executed only once
         numberOfExecutions++;
         if (numberOfExecutions > 1) {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/MetadataCopyMojo.java
@@ -83,7 +83,7 @@ public class MetadataCopyMojo extends AbstractMergeAgentFilesMojo {
     private MavenSession session;
 
     @Override
-    public void execute() throws MojoExecutionException {
+    protected void executeInternal() throws MojoExecutionException {
         if (agentConfiguration != null && (agentConfiguration.isEnabled() || agentIsEnabledFromCmd())) {
             // in direct mode user is fully responsible for agent configuration, and we will not execute anything besides line that user provided
             if (agentConfiguration.getDefaultMode().equalsIgnoreCase("direct")) {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildDynamicAccessMetadataMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildDynamicAccessMetadataMojo.java
@@ -97,7 +97,7 @@ public class NativeBuildDynamicAccessMetadataMojo extends AbstractNativeMojo {
     private File outputJson;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    protected void executeInternal() throws MojoExecutionException, MojoFailureException {
         configureMetadataRepository();
         File jsonFile = ((FileSystemRepository) metadataRepository).getRootDirectory().resolve(LIBRARY_AND_FRAMEWORK_LIST).toFile();
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeCompileNoForkMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeCompileNoForkMojo.java
@@ -98,7 +98,7 @@ public class NativeCompileNoForkMojo extends AbstractNativeImageMojo {
     }
 
     @Override
-    public void execute() throws MojoExecutionException {
+    protected void executeInternal() throws MojoExecutionException {
         if (skip) {
             logger.info("Skipping native-image generation (parameter 'skipNativeBuild' is true).");
             return;

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -162,7 +162,7 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
     }
 
     @Override
-    public void execute() throws MojoExecutionException {
+    protected void executeInternal() throws MojoExecutionException {
         if (skipTests || skipNativeTests) {
             logger.info("Skipping native-image tests (parameter 'skipTests' or 'skipNativeTests' is true).");
             return;

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/WriteArgsFileMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/WriteArgsFileMojo.java
@@ -69,7 +69,7 @@ public class WriteArgsFileMojo extends NativeCompileNoForkMojo {
     public static final String PROPERTY_NAME = "graalvm.native-image.args-file";
 
     @Override
-    public void execute() throws MojoExecutionException {
+    protected void executeInternal() throws MojoExecutionException {
         List<String> args = getBuildArgs();
 
         getLog().debug("Cleaning old native image build args");

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/AbstractMergeAgentFilesMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/AbstractMergeAgentFilesMojo.java
@@ -42,12 +42,12 @@
 package org.graalvm.buildtools.maven.config;
 
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.logging.Logger;
+import org.graalvm.buildtools.maven.AbstractSkippableMojo;
 import org.graalvm.buildtools.utils.NativeImageConfigurationUtils;
 
 import java.io.File;
@@ -55,8 +55,7 @@ import java.nio.file.Path;
 
 import static org.graalvm.buildtools.utils.NativeImageUtils.nativeImageConfigureFileName;
 
-public abstract class AbstractMergeAgentFilesMojo extends AbstractMojo {
-
+public abstract class AbstractMergeAgentFilesMojo extends AbstractSkippableMojo {
 
     @Component
     protected Logger logger;

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
@@ -78,7 +78,7 @@ class AbstractNativeImageMojoTest extends Specification {
 
     private static class TestNativeImageMojo extends AbstractNativeImageMojo {
         @Override
-        void execute() {
+        protected void executeInternal() {
         }
 
         @Override

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeMojoTest.groovy
@@ -82,7 +82,7 @@ class AbstractNativeMojoTest extends Specification {
         }
 
         @Override
-        void execute() {
+        protected void executeInternal() {
         }
 
         @Override


### PR DESCRIPTION
## What changed

Plugin-level `<skip>true</skip>` now stops every native Maven plugin goal before that goal performs work. This includes `add-reachability-metadata`, so it no longer downloads, copies, or generates reachability metadata when the plugin is skipped.

## Why

A root plugin skip previously applied to native build goals but not to metadata retrieval. Builds that intentionally disabled the native Maven plugin could still perform metadata work and leave generated files behind.

## Example

With this plugin configuration, a bound `add-reachability-metadata` execution is skipped along with the other native Maven goals:

```xml
<plugin>
  <groupId>org.graalvm.buildtools</groupId>
  <artifactId>native-maven-plugin</artifactId>
  <configuration>
    <skip>true</skip>
  </configuration>
</plugin>
```

The Maven output includes `Skipping native Maven plugin goal (parameter skip is true).`, and no reachability-metadata directory or copied metadata files are created.

## Implementation summary

Added one shared skip guard used by the Maven goal hierarchy, moved goal-specific work behind that guard, documented the plugin-wide behavior, and added a real-Maven regression test for the metadata goal.

The inspection follow-up makes the existing `AbstractNativeMojo` test double implement the new `executeInternal()` hook instead of overriding the guard’s final `execute()` method. It also completes the required UPL header on the new shared class and removes the import made unused by the refactor. These changes are required for the test compilation and Checkstyle inspections to pass without weakening the skip guard.

## Validation

- `JAVA_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/17.0.12-graal ./gradlew :graalvm-reachability-metadata:publishAllPublicationsToCommonRepository :native-maven-plugin:publishAllPublicationsToCommonRepository :native-maven-plugin:inspections --no-parallel`
- `grund check`
- `grund fmt . --marker --cross-refs --check`
- `git diff --check`

Fixes #628