### PR TITLE
Respect build-tool console colors for Native Image output

### DIFF
--- a/common/utils/src/main/java/org/graalvm/buildtools/model/resources/NativeImageFlags.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/model/resources/NativeImageFlags.java
@@ -42,6 +42,8 @@ package org.graalvm.buildtools.model.resources;
 
 public abstract class NativeImageFlags {
     public static final String BUILD_OUTPUT_COLORFUL = "-H:+BuildOutputColorful";
+    // Legacy console-color arguments are shared by both adapters. §root/FS-native-builds.2.
+    public static final String BUILD_OUTPUT_COLORLESS = "-H:-BuildOutputColorful";
     public static final String COLOR = "--color";
     public static final String CONFIGURATION_FILE_DIRECTORIES = "-H:ConfigurationFileDirectories";
     public static final String LAYER_CREATE = "-H:LayerCreate";

--- a/docs/spec/functional/native-image-builds.md
+++ b/docs/spec/functional/native-image-builds.md
@@ -33,6 +33,11 @@ Both plugins must construct the `native-image` command line through shared utili
 [§common/FS-common-libraries.1](../../../common/docs/functional-spec.md#1-shared-native-image-utilities) so escaping, quoting, and argument-file conversion stay identical.
 Plugin-specific string handling must not bypass those utilities.
 
+When a build tool disables colored console output, its adapter must explicitly disable Native
+Image colors with the flag supported by the discovered Native Image version. When console colors
+are enabled, plugin-specific rich-output configuration may enable them explicitly. User-supplied
+build arguments retain precedence over the adapter's detected console mode.
+
 When a user-configured option set exceeds platform argument limits, or when configuration requests
 it explicitly, the command line must be written as a Native Image argument file (`@<path>`).
 

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -27,7 +27,8 @@ conversion must come from common utilities rather than Gradle-only string handli
 aligned with [§root/FS-option-precedence](../../../docs/spec/functional/option-precedence.md#fs-option-precedence-command-line-input-and-durable-configuration-produce-one-option-state).
 
 When Gradle uses its plain console, the Native Image invocation must explicitly disable colorful
-build output. Otherwise, the `richOutput` option controls Native Image's color-enabled argument.
+build output. Otherwise, the `richOutput` option controls Native Image's color-enabled argument,
+adapting [§root/FS-native-builds.2](../../../docs/spec/functional/native-image-builds.md#2-command-line-construction).
 
 ## 4. Argument files
 

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -26,6 +26,9 @@ configuration directories, generated resources, reachability metadata, layer opt
 conversion must come from common utilities rather than Gradle-only string handling, keeping Gradle
 aligned with [§root/FS-option-precedence](../../../docs/spec/functional/option-precedence.md#fs-option-precedence-command-line-input-and-durable-configuration-produce-one-option-state).
 
+When Gradle uses its plain console, the Native Image invocation must explicitly disable colorful
+build output. Otherwise, the `richOutput` option controls Native Image's color-enabled argument.
+
 ## 4. Argument files
 
 The plugin must support Native Image argument files for command lines that should not be passed as

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -183,6 +183,7 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
 
     }
 
+    // Gradle console mode controls Native Image color arguments. §FS-native-invocation.3.
     @Issue("https://github.com/graalvm/native-build-tools/issues/366")
     @Unroll
     def "passes Gradle's #console console color mode to Native Image"() {

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -43,10 +43,13 @@ package org.graalvm.buildtools.gradle
 
 import org.gradle.util.GradleVersion
 import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
+import org.graalvm.buildtools.gradle.fixtures.GraalVMSupport
+import org.graalvm.buildtools.utils.NativeImageUtils
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Requires
+import spock.lang.Unroll
 
 import java.nio.file.Files
 
@@ -178,6 +181,35 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         then:
         process.output.contains "Hello, native!"
 
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/366")
+    @Unroll
+    def "passes Gradle's #console console color mode to Native Image"() {
+        given:
+        withSample("java-application")
+        buildFile << """
+            graalvmNative {
+                binaries.all {
+                    richOutput = true
+                    verbose = true
+                }
+            }
+        """.stripIndent()
+
+        when:
+        run 'nativeCompile', "--console=${console}"
+
+        then:
+        tasks {
+            succeeded ':nativeCompile'
+        }
+        outputContains expectedColorArgument
+
+        where:
+        console | expectedColorArgument
+        'plain' | (NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 21 ? '--color=never' : '-H:-BuildOutputColorful')
+        'rich'  | (NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 21 ? '--color=always' : '-H:+BuildOutputColorful')
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/129")

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -195,7 +195,7 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         appendBooleanOption(cliArgs, options.getSharedLibrary(), NativeImageFlags.SHARED);
         appendBooleanOption(cliArgs, options.getQuickBuild(), NativeImageFlags.QUICK_BUILD);
         if (plainConsole.get()) {
-            cliArgs.add(majorJDKVersion.getOrElse(-1) >= 21 ? NativeImageFlags.COLOR + "=never" : "-H:-BuildOutputColorful");
+            cliArgs.add(majorJDKVersion.getOrElse(-1) >= 21 ? NativeImageFlags.COLOR + "=never" : NativeImageFlags.BUILD_OUTPUT_COLORLESS);
         } else {
             appendBooleanOption(cliArgs, options.getRichOutput(), majorJDKVersion.getOrElse(-1) >= 21 ? NativeImageFlags.COLOR + "=always" : NativeImageFlags.BUILD_OUTPUT_COLORFUL);
         }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -84,7 +84,7 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
     private final Provider<RegularFile> classpathJar;
     private final Provider<Boolean> useArgFile;
     private final Provider<Integer> majorJDKVersion;
-    private final Provider<Boolean> useColors;
+    private final Provider<Boolean> plainConsole;
 
     public NativeImageCommandLineProvider(Provider<NativeImageOptions> options,
                                           Provider<String> executableName,
@@ -93,7 +93,7 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
                                           Provider<RegularFile> classpathJar,
                                           Provider<Boolean> useArgFile,
                                           Provider<Integer> majorJDKVersion,
-                                          Provider<Boolean> useColors) {
+                                          Provider<Boolean> plainConsole) {
         this.options = options;
         this.executableName = executableName;
         this.workingDirectory = workingDirectory;
@@ -101,7 +101,7 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         this.classpathJar = classpathJar;
         this.useArgFile = useArgFile;
         this.majorJDKVersion = majorJDKVersion;
-        this.useColors = useColors;
+        this.plainConsole = plainConsole;
     }
 
     @Nested
@@ -194,8 +194,10 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         appendBooleanOption(cliArgs, options.getVerbose(), NativeImageFlags.VERBOSE);
         appendBooleanOption(cliArgs, options.getSharedLibrary(), NativeImageFlags.SHARED);
         appendBooleanOption(cliArgs, options.getQuickBuild(), NativeImageFlags.QUICK_BUILD);
-        if (useColors.get()) {
-            appendBooleanOption(cliArgs, options.getRichOutput(), majorJDKVersion.getOrElse(-1) >= 21 ? NativeImageFlags.COLOR : NativeImageFlags.BUILD_OUTPUT_COLORFUL);
+        if (plainConsole.get()) {
+            cliArgs.add(majorJDKVersion.getOrElse(-1) >= 21 ? NativeImageFlags.COLOR + "=never" : "-H:-BuildOutputColorful");
+        } else {
+            appendBooleanOption(cliArgs, options.getRichOutput(), majorJDKVersion.getOrElse(-1) >= 21 ? NativeImageFlags.COLOR + "=always" : NativeImageFlags.BUILD_OUTPUT_COLORFUL);
         }
         appendBooleanOption(cliArgs, options.getPgoInstrument(), NativeImageFlags.PGO_INSTRUMENT);
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -55,6 +55,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.provider.MapProperty;
@@ -95,7 +96,7 @@ import static org.graalvm.buildtools.utils.SharedConstants.EXECUTABLE_EXTENSION;
 public abstract class BuildNativeImageTask extends DefaultTask {
     private final Provider<String> graalvmHomeProvider;
     private final NativeImageExecutableLocator.Diagnostics diagnostics;
-    private final boolean useColors;
+    private final boolean plainConsole;
 
     @Internal
     public abstract Property<NativeImageOptions> getOptions();
@@ -271,7 +272,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         ProviderFactory providers = getProject().getProviders();
         this.diagnostics = new NativeImageExecutableLocator.Diagnostics();
         this.graalvmHomeProvider = graalvmHomeProvider(providers, diagnostics);
-        this.useColors = "plain".equals(getProject().getGradle().getStartParameter().getConsoleOutput());
+        this.plainConsole = ConsoleOutput.Plain.equals(getProject().getGradle().getStartParameter().getConsoleOutput());
         getDisableToolchainDetection().convention(false);
     }
 
@@ -287,7 +288,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
             getClasspathJar(),
             getUseArgFile(),
             getProviders().provider(() -> majorJDKVersion),
-            getProviders().provider(() -> useColors))
+            getProviders().provider(() -> plainConsole))
             .asArguments();
     }
 

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -141,7 +141,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
 
         where:
         nativeImageVersion | disabledColorArgument
-        17                 | "-H:-BuildOutputColorful"
+        17                 | NativeImageFlags.BUILD_OUTPUT_COLORLESS
         21                 | "--color=never"
     }
 
@@ -170,7 +170,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
 
         then:
         args.contains(enabledColorArgument)
-        !args.contains("-H:-BuildOutputColorful")
+        !args.contains(NativeImageFlags.BUILD_OUTPUT_COLORLESS)
 
         where:
         nativeImageVersion | enabledColorArgument

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -111,4 +111,70 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
         args.contains(NativeImageFlags.UNLOCK_EXPERIMENTAL_VMOPTIONS)
         args.any { it.startsWith("${NativeImageFlags.LAYER_CREATE}=libbase.nil") && it.contains("module=java.base") }
     }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/366")
+    def "disables colorful Native Image output for Gradle's plain console with JDK #nativeImageVersion"() {
+        given:
+        def project = newProject()
+        project.plugins.apply(ApplicationPlugin)
+        project.plugins.apply(NativeImagePlugin)
+        def options = project.extensions.getByType(GraalVMExtension).binaries.getByName("main")
+        options.richOutput.set(true)
+        options.excludeConfigArgs.set([])
+        options.configurationFileDirectories.setFrom([])
+
+        when:
+        def args = new NativeImageCommandLineProvider(
+                project.provider { options },
+                project.provider { "main" },
+                project.provider { testDirectory.toString() },
+                project.provider { testDirectory.toString() },
+                project.objects.fileProperty(),
+                project.provider { false },
+                project.provider { nativeImageVersion },
+                project.provider { true }
+        ).asArguments()
+
+        then:
+        args.contains(disabledColorArgument)
+        !args.contains(NativeImageFlags.BUILD_OUTPUT_COLORFUL)
+
+        where:
+        nativeImageVersion | disabledColorArgument
+        17                 | "-H:-BuildOutputColorful"
+        21                 | "--color=never"
+    }
+
+    @Issue("https://github.com/graalvm/native-build-tools/issues/366")
+    def "uses the rich-output setting when Gradle enables colors with JDK #nativeImageVersion"() {
+        given:
+        def project = newProject()
+        project.plugins.apply(ApplicationPlugin)
+        project.plugins.apply(NativeImagePlugin)
+        def options = project.extensions.getByType(GraalVMExtension).binaries.getByName("main")
+        options.richOutput.set(true)
+        options.excludeConfigArgs.set([])
+        options.configurationFileDirectories.setFrom([])
+
+        when:
+        def args = new NativeImageCommandLineProvider(
+                project.provider { options },
+                project.provider { "main" },
+                project.provider { testDirectory.toString() },
+                project.provider { testDirectory.toString() },
+                project.objects.fileProperty(),
+                project.provider { false },
+                project.provider { nativeImageVersion },
+                project.provider { false }
+        ).asArguments()
+
+        then:
+        args.contains(enabledColorArgument)
+        !args.contains("-H:-BuildOutputColorful")
+
+        where:
+        nativeImageVersion | enabledColorArgument
+        17                 | NativeImageFlags.BUILD_OUTPUT_COLORFUL
+        21                 | "--color=always"
+    }
 }

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -112,8 +112,8 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
         args.any { it.startsWith("${NativeImageFlags.LAYER_CREATE}=libbase.nil") && it.contains("module=java.base") }
     }
 
-    @Issue("https://github.com/graalvm/native-build-tools/issues/366")
     // Plain Gradle consoles disable Native Image colors with version-appropriate arguments. §FS-native-invocation.3
+    @Issue("https://github.com/graalvm/native-build-tools/issues/366")
     def "disables colorful Native Image output for Gradle's plain console with JDK #nativeImageVersion"() {
         given:
         def project = newProject()
@@ -146,8 +146,8 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
         21                 | "--color=never"
     }
 
-    @Issue("https://github.com/graalvm/native-build-tools/issues/366")
     // Rich Gradle output enables Native Image colors with version-appropriate arguments. §FS-native-invocation.3
+    @Issue("https://github.com/graalvm/native-build-tools/issues/366")
     def "uses the rich-output setting when Gradle enables colors with JDK #nativeImageVersion"() {
         given:
         def project = newProject()

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -113,6 +113,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/366")
+    // Plain Gradle consoles disable Native Image colors with version-appropriate arguments. §FS-native-invocation.3
     def "disables colorful Native Image output for Gradle's plain console with JDK #nativeImageVersion"() {
         given:
         def project = newProject()
@@ -146,6 +147,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/366")
+    // Rich Gradle output enables Native Image colors with version-appropriate arguments. §FS-native-invocation.3
     def "uses the rich-output setting when Gradle enables colors with JDK #nativeImageVersion"() {
         given:
         def project = newProject()

--- a/native-maven-plugin/docs/functional/native-image-builds.md
+++ b/native-maven-plugin/docs/functional/native-image-builds.md
@@ -66,3 +66,10 @@ mvn -Pnative -DquickBuild native:test
 mvn -Pnative native:write-args-file
 mvn -Pnative native:list-libraries-missing-metadata
 ```
+
+## 9. Console colors
+
+The native-image invocation must follow Maven's detected console color state. It must use
+`--color=always` or `--color=never` on JDK 21 and later, and `-H:+BuildOutputColorful` or
+`-H:-BuildOutputColorful` on older versions. Explicit user build arguments come later and may
+override this detected default, adapting [§root/FS-native-builds.2](../../../docs/spec/functional/native-image-builds.md#2-command-line-construction).

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
@@ -41,17 +41,20 @@
 
 package org.graalvm.buildtools.maven
 
+import org.graalvm.buildtools.utils.NativeImageUtils
 import spock.lang.Issue
 
 import static org.graalvm.buildtools.utils.SharedConstants.NATIVE_IMAGE_EXE;
 
 class JavaApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
+    // Maven's disabled console colors propagate to Native Image. §FS-native-builds.9, §E2E-functional-tests.3.1.
     def "proper options are added to the native-image invocation"() {
         withSample("java-application")
 
         when:
         mvn '-Pnative', '-DskipTests', '-DnativeDryRun', '-DuseArgFile=false',
                 '-Dclasspath=/', '-Ddebug', '-Dfallback=false', '-Dverbose', '-DsharedLibrary',
+                '-Dstyle.color=never',
                 '-DquickBuild',
                 'package'
 
@@ -60,6 +63,8 @@ class JavaApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
         outputContains NATIVE_IMAGE_EXE
         outputContains "-cp " // actual path is OS-specific (/ vs C:\)
         outputContains "-g --no-fallback --verbose --shared -Ob"
+        def majorVersion = NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString())
+        outputContains(majorVersion >= 21 ? "--color=never" : "-H:-BuildOutputColorful")
     }
 
     def "can build and execute a native image with the Maven plugin"() {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -51,6 +51,7 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.ToolchainManager;
+import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.codehaus.plexus.logging.Logger;
 import org.graalvm.buildtools.maven.config.ExcludeConfigConfiguration;
 import org.graalvm.buildtools.model.resources.NativeImageFlags;
@@ -246,6 +247,8 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
             cliArgs.add("-Ob");
         }
 
+        addConsoleColorArgument(cliArgs);
+
         cliArgs.add("-o");
         cliArgs.add(outputDirectory.toPath().toAbsolutePath() + File.separator + imageName);
 
@@ -295,6 +298,26 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
             actualCliArgs.add(mainClass);
         }
         return Collections.unmodifiableList(actualCliArgs);
+    }
+
+    // Maven's detected console mode controls version-appropriate Native Image color flags. §FS-native-builds.9.
+    private void addConsoleColorArgument(List<String> cliArgs) throws MojoExecutionException {
+        boolean colorEnabled = isColorEnabled();
+        if (getNativeImageMajorVersion() >= 21) {
+            cliArgs.add(NativeImageFlags.COLOR + (colorEnabled ? "=always" : "=never"));
+        } else {
+            cliArgs.add(colorEnabled ? NativeImageFlags.BUILD_OUTPUT_COLORFUL : NativeImageFlags.BUILD_OUTPUT_COLORLESS);
+        }
+    }
+
+    protected boolean isColorEnabled() {
+        return MessageUtils.isColorEnabled();
+    }
+
+    protected int getNativeImageMajorVersion() throws MojoExecutionException {
+        Path executable = NativeImageConfigurationUtils.getNativeImageSupportingToolchain(
+                logger, toolchainManager, session, enforceToolchain);
+        return NativeImageUtils.getMajorJDKVersion(getVersionInformation(logger, executable));
     }
 
     static List<String> processBuildArgs(List<String> buildArgs) {
@@ -578,7 +601,14 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
             return nativeImageVersionInformation;
         }
 
-        Path nativeImageExecutable = NativeImageConfigurationUtils.getNativeImage(logger);
+        return getVersionInformation(logger, NativeImageConfigurationUtils.getNativeImage(logger));
+    }
+
+    private static String getVersionInformation(Logger logger, Path nativeImageExecutable) throws MojoExecutionException {
+        if (nativeImageVersionInformation != null) {
+            return nativeImageVersionInformation;
+        }
+
         try {
             ProcessBuilder processBuilder = new ProcessBuilder(nativeImageExecutable.toString());
             processBuilder.command().add("--version");

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
@@ -1,6 +1,8 @@
 package org.graalvm.buildtools.maven
 
 import org.apache.maven.plugin.MojoExecutionException
+import org.graalvm.buildtools.model.resources.NativeImageFlags
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -33,6 +35,45 @@ class AbstractNativeImageMojoTest extends Specification {
                 "C:\\Users\\Lahoucine EL ADDALI\\Desktop\\outdir\\target/java-application-with-custom-packaging-0.1.jar",
                 "-H:ConfigurationFileDirectories=C:\\Users\\Lahoucine EL ADDALI\\Downloads\\4.5.0.0_kubernetes_kubernetes-demo-java-maven\\api\\target\\native\\generated\\generateResourceConfig"
         ]
+    }
+
+    // Maven console mode selects the Native Image version's color argument. §FS-native-builds.9.
+    @Issue("https://github.com/graalvm/native-build-tools/issues/366")
+    def "uses Maven's #label console color mode with JDK #nativeImageMajorVersion"() {
+        given:
+        def mojo = newMojo([])
+        mojo.imageClasspath.add(testDirectory.resolve("application.jar"))
+        mojo.colorEnabled = colorEnabled
+        mojo.nativeImageMajorVersion = nativeImageMajorVersion
+
+        when:
+        def args = mojo.getBuildArgs()
+
+        then:
+        args.contains(expectedColorArgument)
+
+        where:
+        label      | colorEnabled | nativeImageMajorVersion | expectedColorArgument
+        "disabled" | false        | 17                      | NativeImageFlags.BUILD_OUTPUT_COLORLESS
+        "disabled" | false        | 21                      | "--color=never"
+        "enabled"  | true         | 17                      | NativeImageFlags.BUILD_OUTPUT_COLORFUL
+        "enabled"  | true         | 21                      | "--color=always"
+    }
+
+    // Explicit build arguments retain precedence over Maven's detected color mode. §FS-native-builds.9.
+    @Issue("https://github.com/graalvm/native-build-tools/issues/366")
+    def "places explicit color build arguments after Maven's detected default"() {
+        given:
+        def mojo = newMojo(["--color=never"])
+        mojo.imageClasspath.add(testDirectory.resolve("application.jar"))
+        mojo.colorEnabled = true
+        mojo.nativeImageMajorVersion = 21
+
+        when:
+        def args = mojo.getBuildArgs()
+
+        then:
+        args.indexOf("--color=always") < args.lastIndexOf("--color=never")
     }
 
     void "it allows empty classpath for layer-create builds"() {
@@ -77,6 +118,9 @@ class AbstractNativeImageMojoTest extends Specification {
     }
 
     private static class TestNativeImageMojo extends AbstractNativeImageMojo {
+        boolean colorEnabled
+        int nativeImageMajorVersion = 25
+
         @Override
         void execute() {
         }
@@ -88,6 +132,16 @@ class AbstractNativeImageMojoTest extends Specification {
 
         @Override
         protected void populateClasspath() {
+        }
+
+        @Override
+        protected boolean isColorEnabled() {
+            colorEnabled
+        }
+
+        @Override
+        protected int getNativeImageMajorVersion() {
+            nativeImageMajorVersion
         }
     }
 }


### PR DESCRIPTION
## What changed

Gradle and Maven native-image builds now follow their build tool console color state.

Gradle plain-console builds pass an explicit no-color argument to Native Image. Maven builds use the color state detected by Maven, including -Dstyle.color=never. JDK 21 and later use --color=always or --color=never; older Native Image versions use -H:+BuildOutputColorful or -H:-BuildOutputColorful.

Gradle rich-console builds continue to honor richOutput. Maven user build arguments remain later in the command line and can override the detected default.

## Why

Captured plain output such as Gradle output piped through tee, or Maven output with style.color=never, should not contain ANSI color escapes emitted by Native Image. This completes the Gradle and Maven behavior requested by issue #366.

## Implementation summary

- Pass Gradle plain-console state into command-line construction.
- Read Maven detected color state through Maven MessageUtils.
- Select the Native Image version-appropriate color argument in both plugins.
- Resolve Maven Native Image versions through the same toolchain-aware executable lookup used by builds.
- Specify the shared parity contract and both plugin adaptations.
- Add Gradle and Maven unit and functional coverage, including Maven user-argument precedence.

## Validation

- grund check
- grund fmt . --marker --cross-refs --check
- git diff --check
- Focused Gradle NativeImageCommandLineProviderTest passed.
- Focused Maven AbstractNativeImageMojoTest passed.
- Maven and Gradle inspections passed.
- Real Maven JavaApplicationFunctionalTest dry-run with -Dstyle.color=never passed and emitted the legacy no-color flag on GraalVM 17.

Fixes #366