### PR TITLE
Document Maven resource configuration

### DIFF
--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -221,6 +221,49 @@ For example, to build a native image named `myapp` that uses `org.example.ClassN
 Most of the aforementioned properties can also be set on the command line as a part of Maven invocation. For example, if you want to temporarily enable verbose mode, you can append `-Dverbose` to your Maven command.
 ====
 
+[[resources]]
+== Resources
+
+To include classpath resources in a native image, configure resource patterns and run
+`generateResourceConfig` before the native build goal. For example, the following execution
+includes `application.properties` and creates the native image during the `package` phase:
+
+[source,xml, role="multi-language-sample"]
+----
+<plugin>
+  <groupId>org.graalvm.buildtools</groupId>
+  <artifactId>native-maven-plugin</artifactId>
+  <executions>
+    <execution>
+      <id>build-native</id>
+      <phase>package</phase>
+      <goals>
+        <goal>generateResourceConfig</goal>
+        <goal>compile-no-fork</goal>
+      </goals>
+    </execution>
+  </executions>
+  <configuration>
+    <resourceIncludedPatterns>
+      <pattern>application.properties</pattern>
+    </resourceIncludedPatterns>
+  </configuration>
+</plugin>
+----
+
+`generateResourceConfig` writes the configuration to
+_target/native/generated/generateResourceConfig/resource-config.json_. The following
+`compile-no-fork` goal automatically consumes that generated configuration when it builds the
+native image.
+
+To detect resources automatically instead of listing patterns, enable autodetection when running
+the same execution:
+
+[source,bash, role="multi-language-sample"]
+----
+./mvnw -Pnative -Dresources.autodetection.enabled=true package
+----
+
 [[native-image-tracing-agent]]
 == Native Image Tracing Agent
 


### PR DESCRIPTION
## What changed

The Maven plugin guide now explains how to include classpath resources in a native image, including resource patterns, automatic resource detection, and the required goal order.

## Why

Previously, the Maven guide did not cover this workflow, leaving users to discover the correct configuration and execution order from samples or issue comments. The documented sequence ensures generated resource metadata is available to the native build. Fixes #180.

## Example

```xml
<goals>
  <goal>generateResourceConfig</goal>
  <goal>compile-no-fork</goal>
</goals>
<configuration>
  <resourceIncludedPatterns>
    <pattern>application.properties</pattern>
  </resourceIncludedPatterns>
</configuration>
```

Running `./mvnw -Pnative -Dresources.autodetection.enabled=true package` enables automatic resource detection. Generated metadata is written to `target/native/generated/generateResourceConfig/resource-config.json` and consumed by the following native build goal.

## Implementation summary

Added a Maven Resources section with the supported nested pattern syntax, a package-phase execution that generates resource metadata before the native image, the generated file location, and the autodetection command.

## Validation

- `git diff --check`
- `grund check`
- `grund fmt . --marker --cross-refs --check`
- Compared the example with `samples/java-application-with-resources/pom.xml` and `native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithResourcesFunctionalTest.groovy`.
- Attempted `./gradlew :docs:tasks --all`, `./gradlew :docs:asciidoctor --dry-run`, and `./gradlew --no-daemon :docs:asciidoctor --stacktrace`; each stalled during Gradle startup before task execution, so a local documentation render result is not available.