### PR TITLE
Fix Maven native test resource handling

### DIFF
--- a/native-maven-plugin/docs/functional/native-tests.md
+++ b/native-maven-plugin/docs/functional/native-tests.md
@@ -6,9 +6,11 @@ run those tests as a native image through Maven's test lifecycle.
 ## 1. Test classpath
 
 `native:test` must include compile, runtime, test, compile-plus-runtime, and provided-scope
-dependencies needed by the test image. It must add compiled test classes, test resources, plugin
-artifacts relevant to Native Build Tools and JUnit, and inferred `junit-platform-native`
-dependencies.
+dependencies needed by the test image. Current-project content must come from Maven's build
+outputs, including the processed test output directory; raw test resource source directories must
+not be added because doing so bypasses Maven resource filtering and exclusions and duplicates
+resources already present in the processed output. The goal must also add plugin artifacts relevant
+to Native Build Tools and JUnit and inferred `junit-platform-native` dependencies.
 
 ## 2. Test discovery preconditions
 

--- a/native-maven-plugin/docs/functional/resources-and-metadata.md
+++ b/native-maven-plugin/docs/functional/resources-and-metadata.md
@@ -11,9 +11,9 @@ respect existing Native Image resource configuration and the shared classpath sc
 [§common/FS-common-libraries.2](../../../common/docs/functional-spec.md#2-resource-configuration).
 
 For `native:generateTestResourceConfig`, autodetection for the current project must use Maven's
-processed test output directory instead of the main output artifact or raw test resource source
-directories. This preserves resource filtering, exclusions, and resources generated directly into
-the test output.
+processed main and test output directories instead of raw resource source directories. This scans
+the native-test runtime classpath while preserving resource filtering, exclusions, and resources
+generated directly into either output.
 
 ## 2. Reachability metadata
 

--- a/native-maven-plugin/docs/functional/resources-and-metadata.md
+++ b/native-maven-plugin/docs/functional/resources-and-metadata.md
@@ -10,6 +10,11 @@ The plugin must generate resource configuration for main and test classpaths. Ge
 respect existing Native Image resource configuration and the shared classpath scanning behavior in
 [§common/FS-common-libraries.2](../../../common/docs/functional-spec.md#2-resource-configuration).
 
+For `native:generateTestResourceConfig`, autodetection for the current project must use Maven's
+processed test output directory instead of the main output artifact or raw test resource source
+directories. This preserves resource filtering, exclusions, and resources generated directly into
+the test output.
+
 ## 2. Reachability metadata
 
 `native:add-reachability-metadata` resolves metadata for project dependencies from the configured

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -1,6 +1,5 @@
 package org.graalvm.buildtools.maven
 
-
 import java.util.regex.Pattern
 
 class JavaApplicationWithResourcesFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
@@ -103,29 +102,119 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractGraalVMMavenFun
         buildSucceeded
 
         and:
-        matches(file("target/native/generated/generateTestResourceConfig/resource-config.json").text, '''{
+        // Autodetection scans processed test output, not main output or raw test sources. §FS-resources-and-metadata.1.
+        matches(file("target/native/generated/generateTestResourceConfig/resource-config.json").text, resourceConfigFor(expectedPatterns))
+
+        and: "native:test uses Maven build outputs without adding the raw test resource directory"
+        def nativeImageInvocation = outputLines.find { it.contains('Executing:') && it.contains('native-image') }
+        nativeImageInvocation != null
+        nativeImageInvocation.contains(file("target/classes").absolutePath)
+        nativeImageInvocation.contains(file("target/test-classes").absolutePath)
+        !nativeImageInvocation.contains(file("src/main/resources").absolutePath)
+        !nativeImageInvocation.contains(file("src/test/resources").absolutePath)
+
+        where:
+        detection | includedPatterns                                                               | restrictToModules | detectionExclusionPatterns                         || expectedPatterns
+        false     | [Pattern.quote("message.txt"), Pattern.quote("org/graalvm/demo/expected.txt")] | false             | []                                                 || [Pattern.quote("message.txt"), Pattern.quote("org/graalvm/demo/expected.txt")]
+        true      | []                                                                             | false             | ["META-INF/.*", "junit-platform-unique-ids.*"]     || [Pattern.quote("org/graalvm/demo/expected.txt")]
+        true      | []                                                                             | true              | ["META-INF/.*", "junit-platform-unique-ids.*"]     || [Pattern.quote("org/graalvm/demo/expected.txt")]
+    }
+
+    def "test resource autodetection follows Maven's processed test output"() {
+        given:
+        withSample("java-application-with-resources")
+        configureProcessedTestResources()
+
+        when:
+        mvn '-Pnative', '-DskipNativeTests', '-Dresources.autodetection.enabled=true',
+                '-Dresources.autodetection.restrictToModuleDependencies=true',
+                '-Dresources.autodetection.detectionExclusionPatterns=META-INF/.*,junit-platform-unique-ids.*',
+                'test'
+
+        then:
+        buildSucceeded
+        file("target/test-classes/generated-only.txt").isFile()
+        !file("target/test-classes/excluded-source-only.txt").exists()
+
+        and: "only resources that Maven put in the processed test output are detected"
+        matches(file("target/native/generated/generateTestResourceConfig/resource-config.json").text, resourceConfigFor([
+                Pattern.quote("org/graalvm/demo/expected.txt"),
+                Pattern.quote("generated-only.txt")
+        ]))
+    }
+
+    private void configureProcessedTestResources() {
+        def excluded = file("src/test/resources/excluded-source-only.txt")
+        excluded.parentFile.mkdirs()
+        excluded.text = "must not be detected"
+
+        def generated = file("src/generated-test-resources/generated-only.txt")
+        generated.parentFile.mkdirs()
+        generated.text = "must be detected"
+
+        def pom = file("pom.xml")
+        def buildStart = '''    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>'''
+        def configuredBuildStart = '''    <build>
+        <finalName>${project.artifactId}</finalName>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <excludes>
+                    <exclude>excluded-source-only.txt</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-generated-test-resources</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/generated-test-resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>'''
+        assert pom.text.contains(buildStart)
+        pom.text = pom.text.replace(buildStart, configuredBuildStart)
+    }
+
+    private static String resourceConfigFor(List<String> patterns) {
+        String includes = patterns.collect { pattern ->
+"""      {
+        "pattern": "${escapeJson(pattern)}"
+      }"""
+        }.join(",\n")
+"""{
   "resources": {
     "includes": [
-      {
-        "pattern": "\\\\Qmessage.txt\\\\E"
-      },
-      {
-        "pattern": "\\\\Qorg/graalvm/demo/expected.txt\\\\E"
-      }
+${includes}
     ],
     "excludes": []
   },
   "bundles": []
-}''')
-
-        where:
-        detection | includedPatterns                                                               | restrictToModules | detectionExclusionPatterns
-        false     | [Pattern.quote("message.txt"), Pattern.quote("org/graalvm/demo/expected.txt")] | false             | []
-        true      | []                                                                             | false             | ["META-INF/.*", "junit-platform-unique-ids.*"]
-        true      | []                                                                             | true              | ["META-INF/.*", "junit-platform-unique-ids.*"]
+}"""
     }
 
     private static String joinForCliArg(List<String> patterns) {
         patterns.join(",")
+    }
+
+    private static String escapeJson(String value) {
+        value.replace('\\', '\\\\')
     }
 }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -1,5 +1,7 @@
 package org.graalvm.buildtools.maven
 
+import com.github.openjson.JSONObject
+
 import java.util.regex.Pattern
 
 class JavaApplicationWithResourcesFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
@@ -80,6 +82,7 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractGraalVMMavenFun
         given:
 //        withDebug()
         withSample("java-application-with-resources")
+        configureDynamicMainResourceLookup()
 
         List<String> options = []
         if (detection) {
@@ -96,33 +99,37 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractGraalVMMavenFun
         }
 
         when:
-        mvn(['-Pnative', '-DquickBuild', 'test', *options])
+        mvn(['-Pnative', '-DquickBuild', '-DuseArgFile=true', 'test', *options])
 
         then:
         buildSucceeded
 
         and:
-        // Autodetection scans processed test output, not main output or raw test sources. §FS-resources-and-metadata.1.
-        matches(file("target/native/generated/generateTestResourceConfig/resource-config.json").text, resourceConfigFor(expectedPatterns))
+        // Autodetection scans processed main and test outputs, not raw resource sources. §FS-resources-and-metadata.1.
+        assertResourcePatterns(file("target/native/generated/generateTestResourceConfig/resource-config.json"), expectedPatterns)
 
-        and: "native:test uses Maven build outputs without adding the raw test resource directory"
-        def nativeImageInvocation = outputLines.find { it.contains('Executing:') && it.contains('native-image') }
-        nativeImageInvocation != null
-        nativeImageInvocation.contains(file("target/classes").absolutePath)
-        nativeImageInvocation.contains(file("target/test-classes").absolutePath)
-        !nativeImageInvocation.contains(file("src/main/resources").absolutePath)
-        !nativeImageInvocation.contains(file("src/test/resources").absolutePath)
+        and: "native:test uses Maven build outputs without adding raw resource directories"
+        def argsFiles = file("target/tmp").listFiles().findAll {
+            it.name.startsWith("native-image-") && it.name.endsWith(".args")
+        }
+        argsFiles.size() == 1
+        def nativeImageArguments = normalizePaths(argsFiles.first().text)
+        nativeImageArguments.contains(normalizePaths(file("target/classes").absolutePath))
+        nativeImageArguments.contains(normalizePaths(file("target/test-classes").absolutePath))
+        !nativeImageArguments.contains(normalizePaths(file("src/main/resources").absolutePath))
+        !nativeImageArguments.contains(normalizePaths(file("src/test/resources").absolutePath))
 
         where:
         detection | includedPatterns                                                               | restrictToModules | detectionExclusionPatterns                         || expectedPatterns
         false     | [Pattern.quote("message.txt"), Pattern.quote("org/graalvm/demo/expected.txt")] | false             | []                                                 || [Pattern.quote("message.txt"), Pattern.quote("org/graalvm/demo/expected.txt")]
-        true      | []                                                                             | false             | ["META-INF/.*", "junit-platform-unique-ids.*"]     || [Pattern.quote("org/graalvm/demo/expected.txt")]
-        true      | []                                                                             | true              | ["META-INF/.*", "junit-platform-unique-ids.*"]     || [Pattern.quote("org/graalvm/demo/expected.txt")]
+        true      | []                                                                             | false             | ["META-INF/.*", "junit-platform-unique-ids.*"]     || [Pattern.quote("message.txt"), Pattern.quote("org/graalvm/demo/expected.txt")]
+        true      | []                                                                             | true              | ["META-INF/.*", "junit-platform-unique-ids.*"]     || [Pattern.quote("message.txt"), Pattern.quote("org/graalvm/demo/expected.txt")]
     }
 
-    def "test resource autodetection follows Maven's processed test output"() {
+    def "test resource autodetection follows Maven's processed outputs"() {
         given:
         withSample("java-application-with-resources")
+        configureDynamicMainResourceLookup()
         configureProcessedTestResources()
 
         when:
@@ -137,10 +144,19 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractGraalVMMavenFun
         !file("target/test-classes/excluded-source-only.txt").exists()
 
         and: "only resources that Maven put in the processed test output are detected"
-        matches(file("target/native/generated/generateTestResourceConfig/resource-config.json").text, resourceConfigFor([
+        assertResourcePatterns(file("target/native/generated/generateTestResourceConfig/resource-config.json"), [
+                Pattern.quote("message.txt"),
                 Pattern.quote("org/graalvm/demo/expected.txt"),
                 Pattern.quote("generated-only.txt")
-        ]))
+        ])
+    }
+
+    private void configureDynamicMainResourceLookup() {
+        def source = file("src/main/java/org/graalvm/demo/Application.java")
+        def staticLookup = 'Application.class.getResourceAsStream("/message.txt")'
+        def dynamicLookup = 'Application.class.getResourceAsStream(System.getProperty("org.graalvm.buildtools.test.resource", "/message.txt"))'
+        assert source.text.contains(staticLookup)
+        source.text = source.text.replace(staticLookup, dynamicLookup)
     }
 
     private void configureProcessedTestResources() {
@@ -193,28 +209,20 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractGraalVMMavenFun
         pom.text = pom.text.replace(buildStart, configuredBuildStart)
     }
 
-    private static String resourceConfigFor(List<String> patterns) {
-        String includes = patterns.collect { pattern ->
-"""      {
-        "pattern": "${escapeJson(pattern)}"
-      }"""
-        }.join(",\n")
-"""{
-  "resources": {
-    "includes": [
-${includes}
-    ],
-    "excludes": []
-  },
-  "bundles": []
-}"""
+    private static void assertResourcePatterns(File configFile, List<String> expectedPatterns) {
+        def config = new JSONObject(configFile.text)
+        def resources = config.getJSONObject("resources")
+        def actualPatterns = resources.getJSONArray("includes").iterator().collect { it.getString("pattern") } as Set
+        assert actualPatterns == expectedPatterns as Set
+        assert resources.getJSONArray("excludes").isEmpty()
+        assert config.getJSONArray("bundles").isEmpty()
     }
 
     private static String joinForCliArg(List<String> patterns) {
         patterns.join(",")
     }
 
-    private static String escapeJson(String value) {
-        value.replace('\\', '\\\\')
+    private static String normalizePaths(String value) {
+        value.replace('\\\\', '\\').replace('\\', '/')
     }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractResourceConfigMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractResourceConfigMojo.java
@@ -134,11 +134,15 @@ public abstract class AbstractResourceConfigMojo extends AbstractMojo {
 
     private Set<File> findAllProjectArtifacts() {
         Set<File> all = new LinkedHashSet<>();
-        all.add(mavenProject.getArtifact().getFile());
+        all.addAll(getProjectArtifacts());
         all.addAll(transitiveProjectsArtifacts());
         Collection<? extends File> extraProjectArtifacts = getExtraProjectArtifacts();
         all.addAll(extraProjectArtifacts);
         return all;
+    }
+
+    protected Collection<? extends File> getProjectArtifacts() {
+        return Collections.singleton(mavenProject.getArtifact().getFile());
     }
 
     protected Collection<? extends File> getExtraProjectArtifacts() {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildTestResourceConfigMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildTestResourceConfigMojo.java
@@ -46,11 +46,11 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 /**
- * Scans test resources and generates resource metadata for them.
+ * Scans processed resources available to native tests and generates resource metadata for them.
  * §FS-goal-surface.3, §FS-resources-and-metadata.1.
  */
 @Mojo(
@@ -66,7 +66,10 @@ public class NativeBuildTestResourceConfigMojo extends AbstractResourceConfigMoj
 
     @Override
     protected Collection<? extends File> getProjectArtifacts() {
-        // Autodetection reflects Maven's processed test resources, including filtering and exclusions. §FS-resources-and-metadata.1.
-        return Collections.singleton(new File(mavenProject.getBuild().getTestOutputDirectory()));
+        // Autodetection reflects Maven's processed runtime classpath, including filtering and exclusions. §FS-resources-and-metadata.1.
+        return Arrays.asList(
+                new File(mavenProject.getBuild().getOutputDirectory()),
+                new File(mavenProject.getBuild().getTestOutputDirectory())
+        );
     }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildTestResourceConfigMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeBuildTestResourceConfigMojo.java
@@ -41,14 +41,13 @@
 
 package org.graalvm.buildtools.maven;
 
-import org.apache.maven.model.FileSet;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.io.File;
 import java.util.Collection;
-import java.util.stream.Collectors;
+import java.util.Collections;
 
 /**
  * Scans test resources and generates resource metadata for them.
@@ -66,12 +65,8 @@ public class NativeBuildTestResourceConfigMojo extends AbstractResourceConfigMoj
     }
 
     @Override
-    protected Collection<? extends File> getExtraProjectArtifacts() {
-        return mavenProject.getBuild()
-                .getTestResources()
-                .stream()
-                .map(FileSet::getDirectory)
-                .map(File::new)
-                .collect(Collectors.toList());
+    protected Collection<? extends File> getProjectArtifacts() {
+        // Autodetection reflects Maven's processed test resources, including filtering and exclusions. §FS-resources-and-metadata.1.
+        return Collections.singleton(new File(mavenProject.getBuild().getTestOutputDirectory()));
     }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -42,7 +42,6 @@
 package org.graalvm.buildtools.maven;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.model.FileSet;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -128,13 +127,8 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
     @Override
     protected void populateApplicationClasspath() throws MojoExecutionException {
         super.populateApplicationClasspath();
+        // Maven's processed test output contains both compiled tests and processed test resources. §FS-native-tests.1.
         imageClasspath.add(Paths.get(project.getBuild().getTestOutputDirectory()));
-        project.getBuild()
-            .getTestResources()
-            .stream()
-            .map(FileSet::getDirectory)
-            .map(Paths::get)
-            .forEach(imageClasspath::add);
     }
 
     @Override


### PR DESCRIPTION
## Summary

Use Maven's processed build outputs consistently for native tests:

- stop adding raw `src/test/resources` directories to the `native:test` image classpath
- make `native:generateTestResourceConfig` scan both `project.build.outputDirectory` and `project.build.testOutputDirectory` for the current project
- preserve dependency artifact scanning
- document the Maven lifecycle semantics in the functional specs

This supersedes #926 and closes #566. Unlike #926, it also fixes the native-test runtime classpath, where both `target/test-classes` and `src/test/resources` were previously passed to `native-image`.

## Why

`target/classes` and `target/test-classes` are Maven's processed main and test outputs. They contain compiled classes plus resources after filtering, exclusions, custom output paths, and resource-generating executions. Adding raw test resource source directories as well:

- duplicates resources already copied to `target/test-classes`
- bypasses Maven filtering and exclusions
- omits resources generated directly into the test output
- can make duplicate-resource detection fail during native test image generation

If a build intentionally skips test-resource processing, the native plugin now respects that lifecycle choice rather than reintroducing raw resources behind Maven's back.

Main resources do not have the same current duplication path: the native test classpath already uses the processed main output or packaged artifact and does not add `src/main/resources`. Test-resource autodetection nevertheless scans both processed main and test outputs because both are part of the native-test runtime classpath.

## TDD / verification

The functional tests were changed before the follow-up source fix and failed against the previous implementation:

- dynamic main-resource lookup failed in the native test because `message.txt` was absent from generated resource configuration
- generated test resource configuration contained only processed test resources, omitting processed main resources

The implementation then made those tests pass. Integration coverage now verifies from generated build artifacts and the actual native-image argument file that:

- `target/classes` and `target/test-classes` are on the native-test classpath
- neither `src/main/resources` nor `src/test/resources` is on that classpath
- processed main resources required through a runtime-selected name are included and available in the native test image
- a raw test resource excluded by Maven is not detected
- a resource generated directly into `target/test-classes` is detected
- test resource autodetection scans both processed outputs
- resource-config checks are independent of JSON entry ordering

Local verification:

- `grund check`
- `./gradlew :native-maven-plugin:test :native-maven-plugin:checkstyleMain --no-daemon`
- `./gradlew :native-maven-plugin:functionalTest --no-daemon --tests 'org.graalvm.buildtools.maven.JavaApplicationWithResourcesFunctionalTest'`
