### PR TITLE
Resolve reachability metadata through Maven relocations

### DIFF
--- a/common/docs/functional-spec.md
+++ b/common/docs/functional-spec.md
@@ -95,6 +95,15 @@ and [§maven/FS-resources-and-metadata.2](../../native-maven-plugin/docs/functio
 generated build directory that the plugin can pass to Native Image as a configuration file
 directory.
 
+### 5.3 Maven relocation fallback
+
+When a build tool verifies that an exact requested dependency coordinate is relocated by Maven to
+the resolved artifact coordinate, it must prefer metadata for the resolved coordinate. If that
+metadata is unavailable, it may use metadata for the requested pre-relocation coordinate. The
+plugin must select one coordinate's configuration only; it must not merge both. A requested
+coordinate must not be used as a fallback for ordinary dependency substitution, version conflict
+resolution, or unverified transitive dependencies.
+
 ## 6. Missing metadata reporting
 
 Missing metadata reporting must identify libraries where users are likely to need additional

--- a/native-gradle-plugin/docs/functional/resources-and-metadata.md
+++ b/native-gradle-plugin/docs/functional/resources-and-metadata.md
@@ -28,6 +28,11 @@ directory must be consumable by native compile tasks and must contain only metad
 the binary's dependency graph. When no URI or version is pinned, the Gradle default should follow
 the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs/spec/goals.md#goal-fresh-metadata-users-can-fetch-the-latest-graalvm-reachability-metadata).
 
+For a verified Maven relocation, collection prefers metadata for the resolved dependency and falls
+back to the requested pre-relocation coordinate only when the resolved coordinate has no metadata.
+It selects one coordinate's metadata and does not apply this fallback to substitution or conflict
+resolution. [§common/FS-common-libraries.5.3](../../../common/docs/functional-spec.md#53-maven-relocation-fallback).
+
 ## 4. Missing metadata reports
 
 `listLibrariesMissingMetadata` inspects direct runtime dependencies, compares them with the

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadata.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadata.java
@@ -45,6 +45,8 @@ import org.graalvm.buildtools.gradle.internal.GraalVMReachabilityMetadataService
 import org.graalvm.reachability.DirectoryConfiguration;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
@@ -60,14 +62,22 @@ import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.IOException;
+import java.io.File;
 import java.net.URI;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
- * Collects reachability metadata for Gradle runtime dependencies. §FS-resources-and-metadata.3.
+ * Collects reachability metadata for Gradle runtime dependencies. §FS-resources-and-metadata.3 §common/FS-common-libraries.5.3.
  * The output is consumed by native compile tasks through the generated configuration directory.
  */
 public abstract class CollectReachabilityMetadata extends DefaultTask {
@@ -136,25 +146,111 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
             GraalVMReachabilityMetadataService service = getMetadataService().get();
             Set<String> excludedModules = getExcludedModules().getOrElse(Collections.emptySet());
             Map<String, String> forcedVersions = getModuleToConfigVersion().getOrElse(Collections.emptyMap());
-            visit(getRootComponent().get(), service, excludedModules, forcedVersions, new HashSet<>());
+            Map<ResolvedComponentResult, Set<ModuleComponentSelector>> requestedBySelected = new LinkedHashMap<>();
+            collectRequestedComponents(getRootComponent().get(), requestedBySelected, new HashSet<>());
+            for (Map.Entry<ResolvedComponentResult, Set<ModuleComponentSelector>> entry : requestedBySelected.entrySet()) {
+                copyMetadata(entry.getKey(), entry.getValue(), service, excludedModules, forcedVersions);
+            }
         }
     }
 
-    private void visit(ResolvedComponentResult component,
-                       GraalVMReachabilityMetadataService service,
-                       Set<String> excludedModules,
-                       Map<String, String> forcedVersions,
-                       Set<ResolvedComponentResult> visited) throws IOException {
+    private void collectRequestedComponents(ResolvedComponentResult component,
+                                            Map<ResolvedComponentResult, Set<ModuleComponentSelector>> requestedBySelected,
+                                            Set<ResolvedComponentResult> visited) {
         if (visited.add(component)) {
-            ModuleVersionIdentifier moduleVersion = component.getModuleVersion();
-            Set<DirectoryConfiguration> configurations = service.findConfigurationsFor(excludedModules, forcedVersions, moduleVersion);
-            DirectoryConfiguration.copy(configurations, getInto().get().getAsFile().toPath());
+            requestedBySelected.computeIfAbsent(component, ignored -> new LinkedHashSet<>());
             for (DependencyResult dependency : component.getDependencies()) {
                 if (dependency instanceof ResolvedDependencyResult) {
-                    visit(((ResolvedDependencyResult) dependency).getSelected(), service, excludedModules, forcedVersions, visited);
+                    ResolvedDependencyResult resolvedDependency = (ResolvedDependencyResult) dependency;
+                    ResolvedComponentResult selected = resolvedDependency.getSelected();
+                    ComponentSelector requested = resolvedDependency.getRequested();
+                    if (requested instanceof ModuleComponentSelector) {
+                        requestedBySelected.computeIfAbsent(selected, ignored -> new LinkedHashSet<>())
+                                .add((ModuleComponentSelector) requested);
+                    }
+                    collectRequestedComponents(selected, requestedBySelected, visited);
                 }
             }
         }
+    }
+
+    private void copyMetadata(ResolvedComponentResult component,
+                              Set<ModuleComponentSelector> requestedComponents,
+                              GraalVMReachabilityMetadataService service,
+                              Set<String> excludedModules,
+                              Map<String, String> forcedVersions) throws IOException {
+        ModuleVersionIdentifier selected = component.getModuleVersion();
+        Set<DirectoryConfiguration> configurations = service.findConfigurationsFor(excludedModules, forcedVersions, selected);
+        if (configurations.isEmpty()) {
+            for (ModuleComponentSelector requested : requestedComponents) {
+                if (isMavenRelocationTo(requested, selected)) {
+                    configurations = findConfigurations(service, excludedModules, forcedVersions, requested);
+                    if (!configurations.isEmpty()) {
+                        break;
+                    }
+                }
+            }
+        }
+        DirectoryConfiguration.copy(configurations, getInto().get().getAsFile().toPath());
+    }
+
+    private Set<DirectoryConfiguration> findConfigurations(GraalVMReachabilityMetadataService service,
+                                                            Set<String> excludedModules,
+                                                            Map<String, String> forcedVersions,
+                                                            ModuleComponentSelector requested) {
+        String groupAndArtifact = requested.getGroup() + ":" + requested.getModule();
+        return service.findConfigurationsFor(query -> {
+            if (!excludedModules.contains(groupAndArtifact)) {
+                query.forArtifact(artifact -> {
+                    artifact.gav(groupAndArtifact + ":" + requested.getVersionConstraint().getRequiredVersion());
+                    if (forcedVersions.containsKey(groupAndArtifact)) {
+                        artifact.forceConfigVersion(forcedVersions.get(groupAndArtifact));
+                    }
+                });
+            }
+            query.useLatestConfigWhenVersionIsUntested();
+        });
+    }
+
+    private boolean isMavenRelocationTo(ModuleComponentSelector requested, ModuleVersionIdentifier selected) {
+        String version = requested.getVersionConstraint().getRequiredVersion();
+        if (version.isEmpty()) {
+            return false;
+        }
+        try {
+            Configuration configuration = getProject().getConfigurations().detachedConfiguration(
+                    getProject().getDependencies().create(requested.getGroup() + ":" + requested.getModule() + ":" + version + "@pom")
+            );
+            configuration.setTransitive(false);
+            File pom = configuration.resolve().stream().findFirst().orElse(null);
+            if (pom == null) {
+                return false;
+            }
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            Document document = factory.newDocumentBuilder().parse(pom);
+            NodeList relocations = document.getElementsByTagNameNS("*", "relocation");
+            if (relocations.getLength() == 0) {
+                return false;
+            }
+            Element relocation = (Element) relocations.item(0);
+            return relocationValue(relocation, "groupId", requested.getGroup()).equals(selected.getGroup())
+                    && relocationValue(relocation, "artifactId", requested.getModule()).equals(selected.getName())
+                    && relocationValue(relocation, "version", version).equals(selected.getVersion());
+        } catch (Exception exception) {
+            getLogger().debug("Unable to inspect Maven relocation for {}:{}:{}", requested.getGroup(), requested.getModule(), version, exception);
+            return false;
+        }
+    }
+
+    private static String relocationValue(Element relocation, String name, String defaultValue) {
+        NodeList values = relocation.getElementsByTagNameNS("*", name);
+        if (values.getLength() == 0) {
+            return defaultValue;
+        }
+        String value = values.item(0).getTextContent().trim();
+        return value.isEmpty() ? defaultValue : value;
     }
 
 }

--- a/native-maven-plugin/docs/functional/resources-and-metadata.md
+++ b/native-maven-plugin/docs/functional/resources-and-metadata.md
@@ -18,6 +18,11 @@ configuration directory to the native image build without requiring users to man
 repository contents. When no URI, version, or local path is pinned, the Maven default should follow
 the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs/spec/goals.md#goal-fresh-metadata-users-can-fetch-the-latest-graalvm-reachability-metadata).
 
+For a verified Maven relocation, Maven metadata collection prefers the resolved artifact's metadata
+and falls back to metadata for the requested pre-relocation coordinate only when the resolved
+artifact has no metadata. It selects one coordinate's metadata and must not treat substitution or
+conflict resolution as relocation. [§common/FS-common-libraries.5.3](../../../common/docs/functional-spec.md#53-maven-relocation-fallback).
+
 ## 3. Missing metadata reports
 
 `native:list-libraries-missing-metadata` reports project dependencies that do not appear to have

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -58,6 +58,8 @@ import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.graalvm.buildtools.VersionInfo;
 import org.graalvm.buildtools.maven.config.MetadataRepositoryConfiguration;
 import org.graalvm.buildtools.utils.ExponentialBackoff;
@@ -77,6 +79,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -314,22 +317,70 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
         }
     }
 
+    /**
+     * Selects canonical metadata first, then verified requested-coordinate relocation metadata. §common/FS-common-libraries.5.3.
+     */
     protected void maybeAddDependencyMetadata(Artifact dependency, Consumer<File> excludeAction) {
         if (isMetadataRepositoryEnabled() && metadataRepository != null && !isArtifactExcludedFromMetadataRepository(dependency)) {
-            Set<DirectoryConfiguration> configurations = metadataRepository.findConfigurationsFor(q -> {
-                q.useLatestConfigWhenVersionIsUntested();
-                q.forArtifact(artifact -> {
-                    artifact.gav(String.join(":",
-                            dependency.getGroupId(),
-                            dependency.getArtifactId(),
-                            dependency.getVersion()));
-                    getMetadataVersion(dependency).ifPresent(artifact::forceConfigVersion);
-                });
-            });
+            Set<DirectoryConfiguration> configurations = findMetadataConfigurations(dependency);
+            if (configurations.isEmpty()) {
+                for (Artifact requested : requestedRelocationSources(dependency)) {
+                    configurations = findMetadataConfigurations(requested);
+                    if (!configurations.isEmpty()) {
+                        break;
+                    }
+                }
+            }
             metadataRepositoryConfigurations.addAll(configurations);
             if (excludeAction != null && configurations.stream().anyMatch(DirectoryConfiguration::isOverride)) {
                 excludeAction.accept(dependency.getFile());
             }
+        }
+    }
+
+    private Set<DirectoryConfiguration> findMetadataConfigurations(Artifact dependency) {
+        return metadataRepository.findConfigurationsFor(q -> {
+            q.useLatestConfigWhenVersionIsUntested();
+            q.forArtifact(artifact -> {
+                artifact.gav(String.join(":", dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion()));
+                getMetadataVersion(dependency).ifPresent(artifact::forceConfigVersion);
+            });
+        });
+    }
+
+    private Set<Artifact> requestedRelocationSources(Artifact selected) {
+        Set<Artifact> candidates = new LinkedHashSet<>();
+        if (project.getDependencyArtifacts() != null) {
+            candidates.addAll(project.getDependencyArtifacts());
+        }
+        return candidates.stream()
+                .filter(candidate -> isMavenRelocationTo(candidate, selected))
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private boolean isMavenRelocationTo(Artifact requested, Artifact selected) {
+        if (requested.getGroupId().equals(selected.getGroupId())
+                && requested.getArtifactId().equals(selected.getArtifactId())
+                && requested.getVersion().equals(selected.getVersion())) {
+            return false;
+        }
+        try {
+            ArtifactDescriptorRequest request = new ArtifactDescriptorRequest();
+            request.setArtifact(new DefaultArtifact(
+                    requested.getGroupId(), requested.getArtifactId(), "", "pom", requested.getVersion()));
+            request.setRepositories(project.getRemoteProjectRepositories());
+            ArtifactDescriptorResult descriptor = repositorySystem.readArtifactDescriptor(
+                    mavenSession.getRepositorySession(), request);
+            if (descriptor.getRelocations().isEmpty()) {
+                return false;
+            }
+            org.eclipse.aether.artifact.Artifact relocationTarget = descriptor.getArtifact();
+            return relocationTarget.getGroupId().equals(selected.getGroupId())
+                    && relocationTarget.getArtifactId().equals(selected.getArtifactId())
+                    && relocationTarget.getVersion().equals(selected.getVersion());
+        } catch (Exception exception) {
+            getLog().debug("Unable to inspect Maven relocation for " + requested, exception);
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary

Implements the metadata-lookup side of [#968](https://github.com/graalvm/native-build-tools/issues/968). This is the Native Build Tools counterpart to [oracle/graalvm-reachability-metadata#9025](https://github.com/oracle/graalvm-reachability-metadata/pull/9025).

A dependency may be declared under a pre-relocation Maven coordinate while Gradle or Maven resolves the relocated binary. Metadata generated for the requested coordinate is currently ignored because both plugins query only the selected artifact GAV.

## Behavior

For a verified Maven relocation from a requested coordinate to the selected artifact:

1. Query metadata for the selected/canonical artifact first.
2. If no configuration is available, query the requested pre-relocation coordinate.
3. Use only the first non-empty configuration set.
4. Require an actual Maven relocation POM match; ordinary substitutions and conflict resolution do not activate fallback.

## Implementation

- Gradle retains requested module selectors while traversing the resolution graph and verifies relocation by resolving/parsing the requested POM.
- Maven compares direct requested artifacts with the selected artifact using Maven Resolver artifact-descriptor relocation data.
- Shared and plugin-specific metadata-consumption specifications document precedence and non-duplication.

## Validation

- `:native-gradle-plugin:compileJava`
- `:native-maven-plugin:compileJava`
- `:native-gradle-plugin:checkstyleMain`
- `:native-maven-plugin:checkstyleMain`
- `grund check`

All pass with JDK 17.

## Draft follow-up

This is a draft while adding end-to-end relocation fixtures for both plugins, including canonical preference, old-coordinate fallback, and non-relocation rejection.

Closes #968