### PR TITLE
Resolve reachability metadata through Maven relocations

### DIFF
--- a/common/docs/functional-spec.md
+++ b/common/docs/functional-spec.md
@@ -102,7 +102,8 @@ the resolved artifact coordinate, it must prefer metadata for the resolved coord
 metadata is unavailable, it may use metadata for the requested pre-relocation coordinate. The
 plugin must select one coordinate's configuration only; it must not merge both. A requested
 coordinate must not be used as a fallback for ordinary dependency substitution, version conflict
-resolution, or unverified transitive dependencies.
+resolution, or unverified transitive dependencies. Verifying a relocation and selecting fallback
+metadata must not modify the build tool's resolved dependency graph.
 
 ## 6. Missing metadata reporting
 

--- a/common/docs/functional-spec.md
+++ b/common/docs/functional-spec.md
@@ -95,6 +95,15 @@ and [§maven/FS-resources-and-metadata.2](../../native-maven-plugin/docs/functio
 generated build directory that the plugin can pass to Native Image as a configuration file
 directory.
 
+### 5.3 Maven relocation fallback
+
+When a build tool verifies that an exact requested dependency coordinate is relocated by Maven to
+the resolved artifact coordinate, it must prefer metadata for the resolved coordinate. If that
+metadata is unavailable, it may use metadata for the requested pre-relocation coordinate. The
+plugin must select one coordinate's configuration only; it must not merge both. A requested
+coordinate must not be used as a fallback for ordinary dependency substitution, version conflict
+resolution, or unverified transitive dependencies.
+
 ## 6. Missing metadata reporting
 
 Missing metadata reporting must identify libraries where users are likely to need additional

--- a/native-gradle-plugin/docs/functional/resources-and-metadata.md
+++ b/native-gradle-plugin/docs/functional/resources-and-metadata.md
@@ -32,7 +32,9 @@ For a verified Maven relocation, collection prefers metadata for the resolved de
 back to the requested pre-relocation coordinate only when the resolved coordinate has no metadata.
 It selects one coordinate's metadata and does not apply this fallback to substitution or conflict
 resolution. The task must retain configuration-cache-compatible wiring, and an exclusion for the
-resolved dependency must prevent fallback metadata. [§common/FS-common-libraries.5.3](../../../common/docs/functional-spec.md#53-maven-relocation-fallback)
+resolved dependency must prevent fallback metadata. It inspects POMs for components already in the
+resolved graph without adding pre-relocation coordinates as dependencies.
+[§common/FS-common-libraries.5.3](../../../common/docs/functional-spec.md#53-maven-relocation-fallback)
 [§REQ-gradle-model](../requirements.md#req-gradle-model-the-gradle-plugin-preserves-gradle-model-compatibility).
 
 ## 4. Missing metadata reports

--- a/native-gradle-plugin/docs/functional/resources-and-metadata.md
+++ b/native-gradle-plugin/docs/functional/resources-and-metadata.md
@@ -28,6 +28,11 @@ directory must be consumable by native compile tasks and must contain only metad
 the binary's dependency graph. When no URI or version is pinned, the Gradle default should follow
 the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs/spec/goals.md#goal-fresh-metadata-users-can-fetch-the-latest-graalvm-reachability-metadata).
 
+For a verified Maven relocation, collection prefers metadata for the resolved dependency and falls
+back to the requested pre-relocation coordinate only when the resolved coordinate has no metadata.
+It selects one coordinate's metadata and does not apply this fallback to substitution or conflict
+resolution. [§common/FS-common-libraries.5.3](../../../common/docs/functional-spec.md#53-maven-relocation-fallback).
+
 ## 4. Missing metadata reports
 
 `listLibrariesMissingMetadata` inspects direct runtime dependencies, compares them with the

--- a/native-gradle-plugin/docs/functional/resources-and-metadata.md
+++ b/native-gradle-plugin/docs/functional/resources-and-metadata.md
@@ -25,7 +25,8 @@ automatically.
 `collectReachabilityMetadata` resolves metadata for the runtime classpath from the configured
 metadata repository URI, version, exclusions, and module-to-config-version overrides. Its output
 directory must be consumable by native compile tasks and must contain only metadata selected for
-the binary's dependency graph. When no URI or version is pinned, the Gradle default should follow
+the binary's dependency graph. Each execution replaces any output from earlier executions before
+copying the current selection. When no URI or version is pinned, the Gradle default should follow
 the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs/spec/goals.md#goal-fresh-metadata-users-can-fetch-the-latest-graalvm-reachability-metadata).
 
 For a verified Maven relocation, collection prefers metadata for the resolved dependency and falls
@@ -33,7 +34,9 @@ back to the requested pre-relocation coordinate only when the resolved coordinat
 It selects one coordinate's metadata and does not apply this fallback to substitution or conflict
 resolution. The task must retain configuration-cache-compatible wiring, and an exclusion for the
 resolved dependency must prevent fallback metadata. It inspects POMs for components already in the
-resolved graph without adding pre-relocation coordinates as dependencies.
+resolved graph without adding pre-relocation coordinates as dependencies. The relocation source is
+the POM artifact's resolved component coordinate, including when the POM declares its project
+version through an unresolved CI-friendly placeholder.
 [§common/FS-common-libraries.5.3](../../../common/docs/functional-spec.md#53-maven-relocation-fallback)
 [§REQ-gradle-model](../requirements.md#req-gradle-model-the-gradle-plugin-preserves-gradle-model-compatibility).
 

--- a/native-gradle-plugin/docs/functional/resources-and-metadata.md
+++ b/native-gradle-plugin/docs/functional/resources-and-metadata.md
@@ -31,7 +31,9 @@ the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs
 For a verified Maven relocation, collection prefers metadata for the resolved dependency and falls
 back to the requested pre-relocation coordinate only when the resolved coordinate has no metadata.
 It selects one coordinate's metadata and does not apply this fallback to substitution or conflict
-resolution. [§common/FS-common-libraries.5.3](../../../common/docs/functional-spec.md#53-maven-relocation-fallback).
+resolution. The task must retain configuration-cache-compatible wiring, and an exclusion for the
+resolved dependency must prevent fallback metadata. [§common/FS-common-libraries.5.3](../../../common/docs/functional-spec.md#53-maven-relocation-fallback)
+[§REQ-gradle-model](../requirements.md#req-gradle-model-the-gradle-plugin-preserves-gradle-model-compatibility).
 
 ## 4. Missing metadata reports
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ReachabilityMetadataFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ReachabilityMetadataFunctionalTest.groovy
@@ -46,7 +46,7 @@ import org.gradle.api.logging.LogLevel
 
 class ReachabilityMetadataFunctionalTest extends AbstractFunctionalTest {
 
-    def "uses legacy metadata for a verified Maven relocation without changing dependencies"() {
+    def "replaces fallback metadata with canonical metadata for a CI-friendly Maven relocation"() {
         given:
         settingsFile.text = ""
         writeFile("repo/example/legacy/legacy-library/1.0/legacy-library-1.0.pom", """
@@ -54,7 +54,10 @@ class ReachabilityMetadataFunctionalTest extends AbstractFunctionalTest {
   <modelVersion>4.0.0</modelVersion>
   <groupId>example.legacy</groupId>
   <artifactId>legacy-library</artifactId>
-  <version>1.0</version>
+  <version>\${revision}</version>
+  <properties>
+    <revision>1.0</revision>
+  </properties>
   <distributionManagement>
     <relocation>
       <groupId>example.current</groupId>
@@ -121,15 +124,38 @@ graalvmNative {
             succeeded ':collectReachabilityMetadata'
         }
 
-        and:
-        File copiedMetadata
-        file("build/native-reachability-metadata").eachFileRecurse { candidate ->
-            if (candidate.name == "resource-config.json") {
-                copiedMetadata = candidate
-            }
+        and: "only fallback metadata is initially available"
+        File legacyMetadata = file("build/native-reachability-metadata/META-INF/native-image/example.legacy/legacy-library/1.0/resource-config.json")
+        legacyMetadata.text.contains("legacy-relocation-marker")
+
+        when: "canonical metadata becomes available on a later execution"
+        writeFile("metadata/example.current/current-library/index.json", '''
+[
+  {
+    "tested-versions": ["2.0"],
+    "metadata-version": "2",
+    "latest": true
+  }
+]
+''')
+        writeFile("metadata/example.current/current-library/2/resource-config.json", '''
+{
+  "resources": {
+    "includes": [{"pattern": "canonical-relocation-marker"}]
+  }
+}
+''')
+        run 'collectReachabilityMetadata', '--rerun-tasks'
+
+        then:
+        tasks {
+            succeeded ':collectReachabilityMetadata'
         }
-        copiedMetadata != null
-        copiedMetadata.text.contains("legacy-relocation-marker")
+
+        and: "the current selection replaces the previous output without merging coordinates"
+        File canonicalMetadata = file("build/native-reachability-metadata/META-INF/native-image/example.current/current-library/2.0/resource-config.json")
+        canonicalMetadata.text.contains("canonical-relocation-marker")
+        !legacyMetadata.exists()
     }
 
     def "the application runs when using the official metadata repository"() {

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ReachabilityMetadataFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/ReachabilityMetadataFunctionalTest.groovy
@@ -46,6 +46,92 @@ import org.gradle.api.logging.LogLevel
 
 class ReachabilityMetadataFunctionalTest extends AbstractFunctionalTest {
 
+    def "uses legacy metadata for a verified Maven relocation without changing dependencies"() {
+        given:
+        settingsFile.text = ""
+        writeFile("repo/example/legacy/legacy-library/1.0/legacy-library-1.0.pom", """
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example.legacy</groupId>
+  <artifactId>legacy-library</artifactId>
+  <version>1.0</version>
+  <distributionManagement>
+    <relocation>
+      <groupId>example.current</groupId>
+      <artifactId>current-library</artifactId>
+      <version>2.0</version>
+    </relocation>
+  </distributionManagement>
+</project>
+""")
+        writeFile("repo/example/current/current-library/2.0/current-library-2.0.pom", """
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example.current</groupId>
+  <artifactId>current-library</artifactId>
+  <version>2.0</version>
+  <packaging>pom</packaging>
+</project>
+""")
+        writeFile("metadata/schemas/reachability-metadata-schema-v1.2.0.json", '{"version":"1.2.0"}')
+        writeFile("metadata/schemas/metadata-library-index-schema-v2.0.0.json", '{}')
+        writeFile("metadata/schemas/library-and-framework-list-schema-v1.0.0.json", '{}')
+        writeFile("metadata/example.legacy/legacy-library/index.json", '''
+[
+  {
+    "tested-versions": ["1.0"],
+    "metadata-version": "1",
+    "latest": true
+  }
+]
+''')
+        writeFile("metadata/example.legacy/legacy-library/1/resource-config.json", '''
+{
+  "resources": {
+    "includes": [{"pattern": "legacy-relocation-marker"}]
+  }
+}
+''')
+        buildFile.text = """
+plugins {
+    id 'java'
+    id 'org.graalvm.buildtools.native'
+}
+
+repositories {
+    maven { url = uri(file('repo')) }
+}
+
+dependencies {
+    implementation 'example.legacy:legacy-library:1.0'
+}
+
+graalvmNative {
+    metadataRepository {
+        uri(file('metadata'))
+    }
+}
+"""
+
+        when:
+        run 'collectReachabilityMetadata'
+
+        then:
+        tasks {
+            succeeded ':collectReachabilityMetadata'
+        }
+
+        and:
+        File copiedMetadata
+        file("build/native-reachability-metadata").eachFileRecurse { candidate ->
+            if (candidate.name == "resource-config.json") {
+                copiedMetadata = candidate
+            }
+        }
+        copiedMetadata != null
+        copiedMetadata.text.contains("legacy-relocation-marker")
+    }
+
     def "the application runs when using the official metadata repository"() {
         given:
         withSample("metadata-repo-integration")
@@ -71,6 +157,12 @@ class ReachabilityMetadataFunctionalTest extends AbstractFunctionalTest {
 ''')
         and: "has copied reachability-metadata.properties file"
         file("build/native-reachability-metadata/META-INF/native-image/io.netty/netty-codec-http/4.1.80.Final/reachability-metadata.properties").text.trim() == 'override=true'
+    }
+
+    private void writeFile(String relativePath, String contents) {
+        File target = file(relativePath)
+        target.parentFile.mkdirs()
+        target.text = contents
     }
 
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -79,7 +79,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -321,10 +320,6 @@ public class NativeImagePlugin implements Plugin<Project> {
             task.setDescription("Collects reachability metadata for the runtime classpath.");
             Configuration runtimeClasspath = project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
             task.setClasspath(runtimeClasspath);
-            Configuration relocationPoms = project.getConfigurations().detachedConfiguration();
-            relocationPoms.extendsFrom(runtimeClasspath);
-            relocationPoms.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "pom");
-            task.getRelocationPoms().from(relocationPoms);
         });
 
         GraalVMReachabilityMetadataRepositoryExtension metadataRepositoryExtension = reachabilityExtensionOn(graalExtension);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -79,6 +79,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -318,7 +319,12 @@ public class NativeImagePlugin implements Plugin<Project> {
         project.getTasks().register("collectReachabilityMetadata", CollectReachabilityMetadata.class, task -> {
             task.setGroup(LifecycleBasePlugin.BUILD_GROUP);
             task.setDescription("Collects reachability metadata for the runtime classpath.");
-            task.setClasspath(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+            Configuration runtimeClasspath = project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            task.setClasspath(runtimeClasspath);
+            Configuration relocationPoms = project.getConfigurations().detachedConfiguration();
+            relocationPoms.extendsFrom(runtimeClasspath);
+            relocationPoms.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "pom");
+            task.getRelocationPoms().from(relocationPoms);
         });
 
         GraalVMReachabilityMetadataRepositoryExtension metadataRepositoryExtension = reachabilityExtensionOn(graalExtension);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadata.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadata.java
@@ -45,16 +45,21 @@ import org.graalvm.buildtools.gradle.internal.GraalVMReachabilityMetadataService
 import org.graalvm.reachability.DirectoryConfiguration;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.result.DependencyResult;
+import org.gradle.api.artifacts.result.ArtifactResult;
+import org.gradle.api.artifacts.result.ComponentArtifactsResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -64,21 +69,22 @@ import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.maven.MavenModule;
+import org.gradle.maven.MavenPomArtifact;
 
-import java.io.IOException;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
+import org.w3c.dom.Node;
 
 /**
  * Collects reachability metadata for Gradle runtime dependencies. §FS-resources-and-metadata.3 §common/FS-common-libraries.5.3.
@@ -87,7 +93,10 @@ import org.w3c.dom.NodeList;
 public abstract class CollectReachabilityMetadata extends DefaultTask {
 
     public void setClasspath(Configuration classpath) {
-        getRootComponent().set(classpath.getIncoming().getResolutionResult().getRootComponent());
+        Provider<ResolvedComponentResult> rootComponent = classpath.getIncoming().getResolutionResult().getRootComponent();
+        getRootComponent().set(rootComponent);
+        DependencyHandler dependencies = getProject().getDependencies();
+        getRelocationPoms().from(rootComponent.map(root -> resolveMavenPoms(root, dependencies)));
     }
 
     @Input
@@ -157,79 +166,135 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
             GraalVMReachabilityMetadataService service = getMetadataService().get();
             Set<String> excludedModules = getExcludedModules().getOrElse(Collections.emptySet());
             Map<String, String> forcedVersions = getModuleToConfigVersion().getOrElse(Collections.emptyMap());
-            Set<Relocation> relocations = readRelocations(getRelocationPoms().getFiles());
-            Map<ResolvedComponentResult, Set<ModuleComponentSelector>> requestedBySelected = new LinkedHashMap<>();
-            collectRequestedComponents(getRootComponent().get(), requestedBySelected, new HashSet<>());
-            for (Map.Entry<ResolvedComponentResult, Set<ModuleComponentSelector>> entry : requestedBySelected.entrySet()) {
-                copyMetadata(entry.getKey(), entry.getValue(), relocations, service, excludedModules, forcedVersions);
-            }
-        }
-    }
-
-    private void collectRequestedComponents(ResolvedComponentResult component,
-                                            Map<ResolvedComponentResult, Set<ModuleComponentSelector>> requestedBySelected,
-                                            Set<ResolvedComponentResult> visited) {
-        if (visited.add(component)) {
-            requestedBySelected.computeIfAbsent(component, ignored -> new LinkedHashSet<>());
-            for (DependencyResult dependency : component.getDependencies()) {
-                if (dependency instanceof ResolvedDependencyResult) {
-                    ResolvedDependencyResult resolvedDependency = (ResolvedDependencyResult) dependency;
-                    ResolvedComponentResult selected = resolvedDependency.getSelected();
-                    ComponentSelector requested = resolvedDependency.getRequested();
-                    if (requested instanceof ModuleComponentSelector) {
-                        requestedBySelected.computeIfAbsent(selected, ignored -> new LinkedHashSet<>())
-                                .add((ModuleComponentSelector) requested);
-                    }
-                    collectRequestedComponents(selected, requestedBySelected, visited);
+            Map<String, ResolvedComponentResult> components = collectComponents(getRootComponent().get());
+            Map<String, String> relocations = verifiedRelocations(components, readRelocations(getRelocationPoms().getFiles()));
+            Map<String, Set<ModuleVersionIdentifier>> relocationSources = relocationSourcesByCanonical(components, relocations);
+            for (Map.Entry<String, ResolvedComponentResult> entry : components.entrySet()) {
+                if (!relocations.containsKey(entry.getKey())) {
+                    copyMetadata(entry.getValue(), relocationSources.getOrDefault(entry.getKey(), Collections.emptySet()),
+                            service, excludedModules, forcedVersions);
                 }
             }
         }
     }
 
+    private static Set<File> resolveMavenPoms(ResolvedComponentResult root, DependencyHandler dependencies) {
+        Set<ComponentIdentifier> componentIds = new LinkedHashSet<>();
+        collectComponentIds(root, componentIds, new LinkedHashSet<>());
+        Set<File> poms = new LinkedHashSet<>();
+        for (ComponentArtifactsResult component : dependencies.createArtifactResolutionQuery()
+                .forComponents(componentIds)
+                .withArtifacts(MavenModule.class, MavenPomArtifact.class)
+                .execute()
+                .getResolvedComponents()) {
+            for (ArtifactResult artifact : component.getArtifacts(MavenPomArtifact.class)) {
+                if (artifact instanceof ResolvedArtifactResult) {
+                    poms.add(((ResolvedArtifactResult) artifact).getFile());
+                }
+            }
+        }
+        return poms;
+    }
+
+    private static void collectComponentIds(ResolvedComponentResult component,
+                                            Set<ComponentIdentifier> componentIds,
+                                            Set<ComponentIdentifier> visited) {
+        if (visited.add(component.getId())) {
+            if (component.getId() instanceof ModuleComponentIdentifier) {
+                componentIds.add(component.getId());
+            }
+            for (DependencyResult dependency : component.getDependencies()) {
+                if (dependency instanceof ResolvedDependencyResult) {
+                    collectComponentIds(((ResolvedDependencyResult) dependency).getSelected(), componentIds, visited);
+                }
+            }
+        }
+    }
+
+    static Map<String, ResolvedComponentResult> collectComponents(ResolvedComponentResult root) {
+        Map<String, ResolvedComponentResult> components = new LinkedHashMap<>();
+        collectComponents(root, components, new LinkedHashSet<>());
+        return components;
+    }
+
+    private static void collectComponents(ResolvedComponentResult component,
+                                          Map<String, ResolvedComponentResult> components,
+                                          Set<ComponentIdentifier> visited) {
+        if (visited.add(component.getId())) {
+            if (component.getModuleVersion() != null) {
+                components.put(coordinatesWithVersion(component.getModuleVersion()), component);
+            }
+            for (DependencyResult dependency : component.getDependencies()) {
+                if (dependency instanceof ResolvedDependencyResult) {
+                    collectComponents(((ResolvedDependencyResult) dependency).getSelected(), components, visited);
+                }
+            }
+        }
+    }
+
+    static Map<String, String> verifiedRelocations(Map<String, ResolvedComponentResult> components,
+                                                   Set<Relocation> candidates) {
+        Map<String, String> relocations = new LinkedHashMap<>();
+        for (Relocation candidate : candidates) {
+            ResolvedComponentResult source = components.get(candidate.sourceCoordinates());
+            if (source != null && directlyDependsOn(source, candidate.targetCoordinates())) {
+                relocations.put(candidate.sourceCoordinates(), candidate.targetCoordinates());
+            }
+        }
+        return relocations;
+    }
+
+    private static boolean directlyDependsOn(ResolvedComponentResult source, String targetCoordinates) {
+        for (DependencyResult dependency : source.getDependencies()) {
+            if (dependency instanceof ResolvedDependencyResult) {
+                ModuleVersionIdentifier selected = ((ResolvedDependencyResult) dependency).getSelected().getModuleVersion();
+                if (selected != null && coordinatesWithVersion(selected).equals(targetCoordinates)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static Map<String, Set<ModuleVersionIdentifier>> relocationSourcesByCanonical(
+            Map<String, ResolvedComponentResult> components,
+            Map<String, String> relocations) {
+        Map<String, Set<ModuleVersionIdentifier>> sources = new LinkedHashMap<>();
+        for (String source : relocations.keySet()) {
+            String target = finalRelocationTarget(source, relocations);
+            ResolvedComponentResult sourceComponent = components.get(source);
+            if (sourceComponent != null && !source.equals(target)) {
+                sources.computeIfAbsent(target, ignored -> new LinkedHashSet<>()).add(sourceComponent.getModuleVersion());
+            }
+        }
+        return sources;
+    }
+
+    private static String finalRelocationTarget(String source, Map<String, String> relocations) {
+        Set<String> visited = new LinkedHashSet<>();
+        String target = source;
+        while (visited.add(target) && relocations.containsKey(target)) {
+            target = relocations.get(target);
+        }
+        return target;
+    }
+
     private void copyMetadata(ResolvedComponentResult component,
-                              Set<ModuleComponentSelector> requestedComponents,
-                              Set<Relocation> relocations,
+                              Set<ModuleVersionIdentifier> relocationSources,
                               GraalVMReachabilityMetadataService service,
                               Set<String> excludedModules,
                               Map<String, String> forcedVersions) throws IOException {
         ModuleVersionIdentifier selected = component.getModuleVersion();
         Set<DirectoryConfiguration> configurations = service.findConfigurationsFor(excludedModules, forcedVersions, selected);
         if (configurations.isEmpty() && !isExcluded(selected, excludedModules)) {
-            for (ModuleComponentSelector requested : requestedComponents) {
-                if (isMavenRelocationTo(requested, selected, relocations)) {
-                    configurations = findConfigurations(service, excludedModules, forcedVersions, requested);
-                    if (!configurations.isEmpty()) {
-                        break;
-                    }
+            for (ModuleVersionIdentifier source : relocationSources) {
+                configurations = service.findConfigurationsFor(excludedModules, forcedVersions, source);
+                if (!configurations.isEmpty()) {
+                    break;
                 }
             }
         }
         DirectoryConfiguration.copy(configurations, getInto().get().getAsFile().toPath());
-    }
-
-    private Set<DirectoryConfiguration> findConfigurations(GraalVMReachabilityMetadataService service,
-                                                            Set<String> excludedModules,
-                                                            Map<String, String> forcedVersions,
-                                                            ModuleComponentSelector requested) {
-        String groupAndArtifact = requested.getGroup() + ":" + requested.getModule();
-        return service.findConfigurationsFor(query -> {
-            if (!excludedModules.contains(groupAndArtifact)) {
-                query.forArtifact(artifact -> {
-                    artifact.gav(groupAndArtifact + ":" + requested.getVersionConstraint().getRequiredVersion());
-                    if (forcedVersions.containsKey(groupAndArtifact)) {
-                        artifact.forceConfigVersion(forcedVersions.get(groupAndArtifact));
-                    }
-                });
-            }
-            query.useLatestConfigWhenVersionIsUntested();
-        });
-    }
-
-    static boolean isMavenRelocationTo(ModuleComponentSelector requested,
-                                      ModuleVersionIdentifier selected,
-                                      Set<Relocation> relocations) {
-        String version = requested.getVersionConstraint().getRequiredVersion();
-        return !version.isEmpty() && relocations.stream().anyMatch(relocation -> relocation.matches(requested, selected, version));
     }
 
     static Set<Relocation> readRelocations(Set<File> poms) {
@@ -239,11 +304,13 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
                 DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
                 factory.setNamespaceAware(true);
                 factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
                 Document document = factory.newDocumentBuilder().parse(pom);
                 Element project = document.getDocumentElement();
-                NodeList relocationElements = document.getElementsByTagNameNS("*", "relocation");
-                if (relocationElements.getLength() != 0) {
-                    Element relocation = (Element) relocationElements.item(0);
+                Element distributionManagement = directChild(project, "distributionManagement");
+                Element relocation = directChild(distributionManagement, "relocation");
+                if (relocation != null) {
                     String sourceGroup = projectValue(project, "groupId", parentValue(project, "groupId"));
                     String sourceArtifact = projectValue(project, "artifactId", "");
                     String sourceVersion = projectValue(project, "version", parentValue(project, "version"));
@@ -262,31 +329,31 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
     }
 
     private static String relocationValue(Element relocation, String name, String defaultValue) {
-        NodeList values = relocation.getElementsByTagNameNS("*", name);
-        if (values.getLength() == 0) {
-            return defaultValue;
-        }
-        String value = values.item(0).getTextContent().trim();
+        Element valueElement = directChild(relocation, name);
+        String value = valueElement == null ? "" : valueElement.getTextContent().trim();
         return value.isEmpty() ? defaultValue : value;
     }
 
     private static String projectValue(Element project, String name, String defaultValue) {
-        NodeList values = project.getElementsByTagNameNS("*", name);
-        for (int i = 0; i < values.getLength(); i++) {
-            if (values.item(i).getParentNode() == project) {
-                String value = values.item(i).getTextContent().trim();
-                return value.isEmpty() ? defaultValue : value;
-            }
-        }
-        return defaultValue;
+        Element valueElement = directChild(project, name);
+        String value = valueElement == null ? "" : valueElement.getTextContent().trim();
+        return value.isEmpty() ? defaultValue : value;
     }
 
     private static String parentValue(Element project, String name) {
-        NodeList parents = project.getElementsByTagNameNS("*", "parent");
-        if (parents.getLength() == 0) {
-            return "";
+        return projectValue(directChild(project, "parent"), name, "");
+    }
+
+    private static Element directChild(Element parent, String name) {
+        if (parent != null) {
+            for (Node child = parent.getFirstChild(); child != null; child = child.getNextSibling()) {
+                if (child.getNodeType() == Node.ELEMENT_NODE
+                        && name.equals(child.getLocalName() == null ? child.getNodeName() : child.getLocalName())) {
+                    return (Element) child;
+                }
+            }
         }
-        return projectValue((Element) parents.item(0), name, "");
+        return null;
     }
 
     static boolean isExcluded(ModuleVersionIdentifier module, Set<String> excludedModules) {
@@ -295,6 +362,10 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
 
     private static String coordinates(ModuleVersionIdentifier module) {
         return module.getGroup() + ":" + module.getName();
+    }
+
+    private static String coordinatesWithVersion(ModuleVersionIdentifier module) {
+        return coordinates(module) + ":" + module.getVersion();
     }
 
     static final class Relocation {
@@ -315,13 +386,12 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
             this.targetVersion = targetVersion;
         }
 
-        boolean matches(ModuleComponentSelector requested, ModuleVersionIdentifier selected, String requestedVersion) {
-            return sourceGroup.equals(requested.getGroup())
-                    && sourceArtifact.equals(requested.getModule())
-                    && sourceVersion.equals(requestedVersion)
-                    && targetGroup.equals(selected.getGroup())
-                    && targetArtifact.equals(selected.getName())
-                    && targetVersion.equals(selected.getVersion());
+        String sourceCoordinates() {
+            return sourceGroup + ":" + sourceArtifact + ":" + sourceVersion;
+        }
+
+        String targetCoordinates() {
+            return targetGroup + ":" + targetArtifact + ":" + targetVersion;
         }
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadata.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadata.java
@@ -55,15 +55,17 @@ import org.gradle.api.artifacts.result.ComponentArtifactsResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
@@ -74,12 +76,16 @@ import org.gradle.maven.MavenPomArtifact;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.inject.Inject;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.w3c.dom.Document;
@@ -92,11 +98,14 @@ import org.w3c.dom.Node;
  */
 public abstract class CollectReachabilityMetadata extends DefaultTask {
 
+    @Inject
+    protected abstract FileSystemOperations getFileSystemOperations();
+
     public void setClasspath(Configuration classpath) {
         Provider<ResolvedComponentResult> rootComponent = classpath.getIncoming().getResolutionResult().getRootComponent();
         getRootComponent().set(rootComponent);
         DependencyHandler dependencies = getProject().getDependencies();
-        getRelocationPoms().from(rootComponent.map(root -> resolveMavenPoms(root, dependencies)));
+        getRelocationPoms().set(rootComponent.map(root -> resolveMavenPoms(root, dependencies)));
     }
 
     @Input
@@ -109,9 +118,9 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
     /**
      * Maven POMs from the runtime graph used to verify relocations. §FS-resources-and-metadata.3.
      */
-    @InputFiles
-    @PathSensitive(PathSensitivity.NONE)
-    public abstract ConfigurableFileCollection getRelocationPoms();
+    @Nested
+    @Optional
+    public abstract ListProperty<RelocationPom> getRelocationPoms();
 
     /**
      * A URI pointing to a GraalVM reachability metadata repository. This must
@@ -162,12 +171,16 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
 
     @TaskAction
     void copyReachabilityMetadata() throws IOException {
+        if (getInto().isPresent()) {
+            // A collection run replaces stale output from earlier selections. §FS-resources-and-metadata.3.
+            getFileSystemOperations().delete(spec -> spec.delete(getInto().get().getAsFile()));
+        }
         if (getRootComponent().isPresent()) {
             GraalVMReachabilityMetadataService service = getMetadataService().get();
             Set<String> excludedModules = getExcludedModules().getOrElse(Collections.emptySet());
             Map<String, String> forcedVersions = getModuleToConfigVersion().getOrElse(Collections.emptyMap());
             Map<String, ResolvedComponentResult> components = collectComponents(getRootComponent().get());
-            Map<String, String> relocations = verifiedRelocations(components, readRelocations(getRelocationPoms().getFiles()));
+            Map<String, String> relocations = verifiedRelocations(components, readRelocations(getRelocationPoms().get()));
             Map<String, Set<ModuleVersionIdentifier>> relocationSources = relocationSourcesByCanonical(components, relocations);
             for (Map.Entry<String, ResolvedComponentResult> entry : components.entrySet()) {
                 if (!relocations.containsKey(entry.getKey())) {
@@ -178,18 +191,27 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
         }
     }
 
-    private static Set<File> resolveMavenPoms(ResolvedComponentResult root, DependencyHandler dependencies) {
+    private static List<RelocationPom> resolveMavenPoms(ResolvedComponentResult root, DependencyHandler dependencies) {
         Set<ComponentIdentifier> componentIds = new LinkedHashSet<>();
         collectComponentIds(root, componentIds, new LinkedHashSet<>());
-        Set<File> poms = new LinkedHashSet<>();
+        List<RelocationPom> poms = new ArrayList<>();
         for (ComponentArtifactsResult component : dependencies.createArtifactResolutionQuery()
                 .forComponents(componentIds)
                 .withArtifacts(MavenModule.class, MavenPomArtifact.class)
                 .execute()
                 .getResolvedComponents()) {
+            ComponentIdentifier componentId = component.getId();
+            if (!(componentId instanceof ModuleComponentIdentifier)) {
+                continue;
+            }
+            ModuleComponentIdentifier moduleId = (ModuleComponentIdentifier) componentId;
             for (ArtifactResult artifact : component.getArtifacts(MavenPomArtifact.class)) {
                 if (artifact instanceof ResolvedArtifactResult) {
-                    poms.add(((ResolvedArtifactResult) artifact).getFile());
+                    poms.add(new RelocationPom(
+                            moduleId.getGroup(),
+                            moduleId.getModule(),
+                            moduleId.getVersion(),
+                            ((ResolvedArtifactResult) artifact).getFile()));
                 }
             }
         }
@@ -297,29 +319,24 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
         DirectoryConfiguration.copy(configurations, getInto().get().getAsFile().toPath());
     }
 
-    static Set<Relocation> readRelocations(Set<File> poms) {
+    static Set<Relocation> readRelocations(List<RelocationPom> poms) {
         Set<Relocation> relocations = new LinkedHashSet<>();
-        for (File pom : poms) {
+        for (RelocationPom pom : poms) {
             try {
                 DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
                 factory.setNamespaceAware(true);
                 factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
                 factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
                 factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-                Document document = factory.newDocumentBuilder().parse(pom);
+                Document document = factory.newDocumentBuilder().parse(pom.getPom());
                 Element project = document.getDocumentElement();
                 Element distributionManagement = directChild(project, "distributionManagement");
                 Element relocation = directChild(distributionManagement, "relocation");
                 if (relocation != null) {
-                    String sourceGroup = projectValue(project, "groupId", parentValue(project, "groupId"));
-                    String sourceArtifact = projectValue(project, "artifactId", "");
-                    String sourceVersion = projectValue(project, "version", parentValue(project, "version"));
-                    if (!sourceGroup.isEmpty() && !sourceArtifact.isEmpty() && !sourceVersion.isEmpty()) {
-                        relocations.add(new Relocation(sourceGroup, sourceArtifact, sourceVersion,
-                                relocationValue(relocation, "groupId", sourceGroup),
-                                relocationValue(relocation, "artifactId", sourceArtifact),
-                                relocationValue(relocation, "version", sourceVersion)));
-                    }
+                    relocations.add(new Relocation(pom.getSourceGroup(), pom.getSourceArtifact(), pom.getSourceVersion(),
+                            relocationValue(relocation, "groupId", pom.getSourceGroup()),
+                            relocationValue(relocation, "artifactId", pom.getSourceArtifact()),
+                            relocationValue(relocation, "version", pom.getSourceVersion())));
                 }
             } catch (Exception exception) {
                 // A malformed or unreadable POM cannot verify a relocation. §FS-resources-and-metadata.3.
@@ -332,16 +349,6 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
         Element valueElement = directChild(relocation, name);
         String value = valueElement == null ? "" : valueElement.getTextContent().trim();
         return value.isEmpty() ? defaultValue : value;
-    }
-
-    private static String projectValue(Element project, String name, String defaultValue) {
-        Element valueElement = directChild(project, name);
-        String value = valueElement == null ? "" : valueElement.getTextContent().trim();
-        return value.isEmpty() ? defaultValue : value;
-    }
-
-    private static String parentValue(Element project, String name) {
-        return projectValue(directChild(project, "parent"), name, "");
     }
 
     private static Element directChild(Element parent, String name) {
@@ -366,6 +373,44 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
 
     private static String coordinatesWithVersion(ModuleVersionIdentifier module) {
         return coordinates(module) + ":" + module.getVersion();
+    }
+
+    /** Associates a POM input with its resolved component identity. §FS-resources-and-metadata.3. */
+    public static final class RelocationPom implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final String sourceGroup;
+        private final String sourceArtifact;
+        private final String sourceVersion;
+        private final File pom;
+
+        RelocationPom(String sourceGroup, String sourceArtifact, String sourceVersion, File pom) {
+            this.sourceGroup = sourceGroup;
+            this.sourceArtifact = sourceArtifact;
+            this.sourceVersion = sourceVersion;
+            this.pom = pom;
+        }
+
+        @Input
+        public String getSourceGroup() {
+            return sourceGroup;
+        }
+
+        @Input
+        public String getSourceArtifact() {
+            return sourceArtifact;
+        }
+
+        @Input
+        public String getSourceVersion() {
+            return sourceVersion;
+        }
+
+        @InputFile
+        @PathSensitive(PathSensitivity.NONE)
+        public File getPom() {
+            return pom;
+        }
     }
 
     static final class Relocation {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadata.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadata.java
@@ -51,14 +51,18 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.IOException;
@@ -92,6 +96,13 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
 
     @Internal
     public abstract Property<GraalVMReachabilityMetadataService> getMetadataService();
+
+    /**
+     * Maven POMs from the runtime graph used to verify relocations. §FS-resources-and-metadata.3.
+     */
+    @InputFiles
+    @PathSensitive(PathSensitivity.NONE)
+    public abstract ConfigurableFileCollection getRelocationPoms();
 
     /**
      * A URI pointing to a GraalVM reachability metadata repository. This must
@@ -146,10 +157,11 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
             GraalVMReachabilityMetadataService service = getMetadataService().get();
             Set<String> excludedModules = getExcludedModules().getOrElse(Collections.emptySet());
             Map<String, String> forcedVersions = getModuleToConfigVersion().getOrElse(Collections.emptyMap());
+            Set<Relocation> relocations = readRelocations(getRelocationPoms().getFiles());
             Map<ResolvedComponentResult, Set<ModuleComponentSelector>> requestedBySelected = new LinkedHashMap<>();
             collectRequestedComponents(getRootComponent().get(), requestedBySelected, new HashSet<>());
             for (Map.Entry<ResolvedComponentResult, Set<ModuleComponentSelector>> entry : requestedBySelected.entrySet()) {
-                copyMetadata(entry.getKey(), entry.getValue(), service, excludedModules, forcedVersions);
+                copyMetadata(entry.getKey(), entry.getValue(), relocations, service, excludedModules, forcedVersions);
             }
         }
     }
@@ -176,14 +188,15 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
 
     private void copyMetadata(ResolvedComponentResult component,
                               Set<ModuleComponentSelector> requestedComponents,
+                              Set<Relocation> relocations,
                               GraalVMReachabilityMetadataService service,
                               Set<String> excludedModules,
                               Map<String, String> forcedVersions) throws IOException {
         ModuleVersionIdentifier selected = component.getModuleVersion();
         Set<DirectoryConfiguration> configurations = service.findConfigurationsFor(excludedModules, forcedVersions, selected);
-        if (configurations.isEmpty()) {
+        if (configurations.isEmpty() && !isExcluded(selected, excludedModules)) {
             for (ModuleComponentSelector requested : requestedComponents) {
-                if (isMavenRelocationTo(requested, selected)) {
+                if (isMavenRelocationTo(requested, selected, relocations)) {
                     configurations = findConfigurations(service, excludedModules, forcedVersions, requested);
                     if (!configurations.isEmpty()) {
                         break;
@@ -212,36 +225,40 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
         });
     }
 
-    private boolean isMavenRelocationTo(ModuleComponentSelector requested, ModuleVersionIdentifier selected) {
+    static boolean isMavenRelocationTo(ModuleComponentSelector requested,
+                                      ModuleVersionIdentifier selected,
+                                      Set<Relocation> relocations) {
         String version = requested.getVersionConstraint().getRequiredVersion();
-        if (version.isEmpty()) {
-            return false;
-        }
-        try {
-            Configuration configuration = getProject().getConfigurations().detachedConfiguration(
-                    getProject().getDependencies().create(requested.getGroup() + ":" + requested.getModule() + ":" + version + "@pom")
-            );
-            configuration.setTransitive(false);
-            File pom = configuration.resolve().stream().findFirst().orElse(null);
-            if (pom == null) {
-                return false;
+        return !version.isEmpty() && relocations.stream().anyMatch(relocation -> relocation.matches(requested, selected, version));
+    }
+
+    static Set<Relocation> readRelocations(Set<File> poms) {
+        Set<Relocation> relocations = new LinkedHashSet<>();
+        for (File pom : poms) {
+            try {
+                DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                factory.setNamespaceAware(true);
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                Document document = factory.newDocumentBuilder().parse(pom);
+                Element project = document.getDocumentElement();
+                NodeList relocationElements = document.getElementsByTagNameNS("*", "relocation");
+                if (relocationElements.getLength() != 0) {
+                    Element relocation = (Element) relocationElements.item(0);
+                    String sourceGroup = projectValue(project, "groupId", parentValue(project, "groupId"));
+                    String sourceArtifact = projectValue(project, "artifactId", "");
+                    String sourceVersion = projectValue(project, "version", parentValue(project, "version"));
+                    if (!sourceGroup.isEmpty() && !sourceArtifact.isEmpty() && !sourceVersion.isEmpty()) {
+                        relocations.add(new Relocation(sourceGroup, sourceArtifact, sourceVersion,
+                                relocationValue(relocation, "groupId", sourceGroup),
+                                relocationValue(relocation, "artifactId", sourceArtifact),
+                                relocationValue(relocation, "version", sourceVersion)));
+                    }
+                }
+            } catch (Exception exception) {
+                // A malformed or unreadable POM cannot verify a relocation. §FS-resources-and-metadata.3.
             }
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setNamespaceAware(true);
-            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            Document document = factory.newDocumentBuilder().parse(pom);
-            NodeList relocations = document.getElementsByTagNameNS("*", "relocation");
-            if (relocations.getLength() == 0) {
-                return false;
-            }
-            Element relocation = (Element) relocations.item(0);
-            return relocationValue(relocation, "groupId", requested.getGroup()).equals(selected.getGroup())
-                    && relocationValue(relocation, "artifactId", requested.getModule()).equals(selected.getName())
-                    && relocationValue(relocation, "version", version).equals(selected.getVersion());
-        } catch (Exception exception) {
-            getLogger().debug("Unable to inspect Maven relocation for {}:{}:{}", requested.getGroup(), requested.getModule(), version, exception);
-            return false;
         }
+        return relocations;
     }
 
     private static String relocationValue(Element relocation, String name, String defaultValue) {
@@ -251,6 +268,61 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
         }
         String value = values.item(0).getTextContent().trim();
         return value.isEmpty() ? defaultValue : value;
+    }
+
+    private static String projectValue(Element project, String name, String defaultValue) {
+        NodeList values = project.getElementsByTagNameNS("*", name);
+        for (int i = 0; i < values.getLength(); i++) {
+            if (values.item(i).getParentNode() == project) {
+                String value = values.item(i).getTextContent().trim();
+                return value.isEmpty() ? defaultValue : value;
+            }
+        }
+        return defaultValue;
+    }
+
+    private static String parentValue(Element project, String name) {
+        NodeList parents = project.getElementsByTagNameNS("*", "parent");
+        if (parents.getLength() == 0) {
+            return "";
+        }
+        return projectValue((Element) parents.item(0), name, "");
+    }
+
+    static boolean isExcluded(ModuleVersionIdentifier module, Set<String> excludedModules) {
+        return excludedModules.contains(coordinates(module));
+    }
+
+    private static String coordinates(ModuleVersionIdentifier module) {
+        return module.getGroup() + ":" + module.getName();
+    }
+
+    static final class Relocation {
+        private final String sourceGroup;
+        private final String sourceArtifact;
+        private final String sourceVersion;
+        private final String targetGroup;
+        private final String targetArtifact;
+        private final String targetVersion;
+
+        Relocation(String sourceGroup, String sourceArtifact, String sourceVersion,
+                   String targetGroup, String targetArtifact, String targetVersion) {
+            this.sourceGroup = sourceGroup;
+            this.sourceArtifact = sourceArtifact;
+            this.sourceVersion = sourceVersion;
+            this.targetGroup = targetGroup;
+            this.targetArtifact = targetArtifact;
+            this.targetVersion = targetVersion;
+        }
+
+        boolean matches(ModuleComponentSelector requested, ModuleVersionIdentifier selected, String requestedVersion) {
+            return sourceGroup.equals(requested.getGroup())
+                    && sourceArtifact.equals(requested.getModule())
+                    && sourceVersion.equals(requestedVersion)
+                    && targetGroup.equals(selected.getGroup())
+                    && targetArtifact.equals(selected.getName())
+                    && targetVersion.equals(selected.getVersion());
+        }
     }
 
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadata.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadata.java
@@ -45,6 +45,8 @@ import org.graalvm.buildtools.gradle.internal.GraalVMReachabilityMetadataService
 import org.graalvm.reachability.DirectoryConfiguration;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
@@ -60,14 +62,22 @@ import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.IOException;
+import java.io.File;
 import java.net.URI;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
- * Collects reachability metadata for Gradle runtime dependencies. §FS-resources-and-metadata.3.
+ * Collects reachability metadata for Gradle runtime dependencies. §FS-resources-and-metadata.3 §common/FS-common-libraries.5.3.
  * The output is consumed by native compile tasks through the generated configuration directory.
  */
 public abstract class CollectReachabilityMetadata extends DefaultTask {
@@ -136,25 +146,111 @@ public abstract class CollectReachabilityMetadata extends DefaultTask {
             GraalVMReachabilityMetadataService service = getMetadataService().get();
             Set<String> excludedModules = getExcludedModules().getOrElse(Collections.emptySet());
             Map<String, String> forcedVersions = getModuleToConfigVersion().getOrElse(Collections.emptyMap());
-            visit(getRootComponent().get(), service, excludedModules, forcedVersions, new HashSet<>());
+            Map<ResolvedComponentResult, Set<ModuleComponentSelector>> requestedBySelected = new LinkedHashMap<>();
+            collectRequestedComponents(getRootComponent().get(), requestedBySelected, new HashSet<>());
+            for (Map.Entry<ResolvedComponentResult, Set<ModuleComponentSelector>> entry : requestedBySelected.entrySet()) {
+                copyMetadata(entry.getKey(), entry.getValue(), service, excludedModules, forcedVersions);
+            }
         }
     }
 
-    private void visit(ResolvedComponentResult component,
-                       GraalVMReachabilityMetadataService service,
-                       Set<String> excludedModules,
-                       Map<String, String> forcedVersions,
-                       Set<ResolvedComponentResult> visited) throws IOException {
+    private void collectRequestedComponents(ResolvedComponentResult component,
+                                            Map<ResolvedComponentResult, Set<ModuleComponentSelector>> requestedBySelected,
+                                            Set<ResolvedComponentResult> visited) {
         if (visited.add(component)) {
-            ModuleVersionIdentifier moduleVersion = component.getModuleVersion();
-            Set<DirectoryConfiguration> configurations = service.findConfigurationsFor(excludedModules, forcedVersions, moduleVersion);
-            DirectoryConfiguration.copy(configurations, getInto().get().getAsFile().toPath());
+            requestedBySelected.computeIfAbsent(component, ignored -> new LinkedHashSet<>());
             for (DependencyResult dependency : component.getDependencies()) {
                 if (dependency instanceof ResolvedDependencyResult) {
-                    visit(((ResolvedDependencyResult) dependency).getSelected(), service, excludedModules, forcedVersions, visited);
+                    ResolvedDependencyResult resolvedDependency = (ResolvedDependencyResult) dependency;
+                    ResolvedComponentResult selected = resolvedDependency.getSelected();
+                    ComponentSelector requested = resolvedDependency.getRequested();
+                    if (requested instanceof ModuleComponentSelector) {
+                        requestedBySelected.computeIfAbsent(selected, ignored -> new LinkedHashSet<>())
+                                .add((ModuleComponentSelector) requested);
+                    }
+                    collectRequestedComponents(selected, requestedBySelected, visited);
                 }
             }
         }
+    }
+
+    private void copyMetadata(ResolvedComponentResult component,
+                              Set<ModuleComponentSelector> requestedComponents,
+                              GraalVMReachabilityMetadataService service,
+                              Set<String> excludedModules,
+                              Map<String, String> forcedVersions) throws IOException {
+        ModuleVersionIdentifier selected = component.getModuleVersion();
+        Set<DirectoryConfiguration> configurations = service.findConfigurationsFor(excludedModules, forcedVersions, selected);
+        if (configurations.isEmpty()) {
+            for (ModuleComponentSelector requested : requestedComponents) {
+                if (isMavenRelocationTo(requested, selected)) {
+                    configurations = findConfigurations(service, excludedModules, forcedVersions, requested);
+                    if (!configurations.isEmpty()) {
+                        break;
+                    }
+                }
+            }
+        }
+        DirectoryConfiguration.copy(configurations, getInto().get().getAsFile().toPath());
+    }
+
+    private Set<DirectoryConfiguration> findConfigurations(GraalVMReachabilityMetadataService service,
+                                                            Set<String> excludedModules,
+                                                            Map<String, String> forcedVersions,
+                                                            ModuleComponentSelector requested) {
+        String groupAndArtifact = requested.getGroup() + ":" + requested.getModule();
+        return service.findConfigurationsFor(query -> {
+            if (!excludedModules.contains(groupAndArtifact)) {
+                query.forArtifact(artifact -> {
+                    artifact.gav(groupAndArtifact + ":" + requested.getVersionConstraint().getRequiredVersion());
+                    if (forcedVersions.containsKey(groupAndArtifact)) {
+                        artifact.forceConfigVersion(forcedVersions.get(groupAndArtifact));
+                    }
+                });
+            }
+            query.useLatestConfigWhenVersionIsUntested();
+        });
+    }
+
+    private boolean isMavenRelocationTo(ModuleComponentSelector requested, ModuleVersionIdentifier selected) {
+        String version = requested.getVersionConstraint().getRequiredVersion();
+        if (version.isEmpty()) {
+            return false;
+        }
+        try {
+            Configuration configuration = getProject().getConfigurations().detachedConfiguration(
+                    getProject().getDependencies().create(requested.getGroup() + ":" + requested.getModule() + ":" + version + "@pom")
+            );
+            configuration.setTransitive(false);
+            File pom = configuration.resolve().stream().findFirst().orElse(null);
+            if (pom == null) {
+                return false;
+            }
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            Document document = factory.newDocumentBuilder().parse(pom);
+            NodeList relocations = document.getElementsByTagNameNS("*", "relocation");
+            if (relocations.getLength() == 0) {
+                return false;
+            }
+            Element relocation = (Element) relocations.item(0);
+            return relocationValue(relocation, "groupId", requested.getGroup()).equals(selected.getGroup())
+                    && relocationValue(relocation, "artifactId", requested.getModule()).equals(selected.getName())
+                    && relocationValue(relocation, "version", version).equals(selected.getVersion());
+        } catch (Exception exception) {
+            getLogger().debug("Unable to inspect Maven relocation for {}:{}:{}", requested.getGroup(), requested.getModule(), version, exception);
+            return false;
+        }
+    }
+
+    private static String relocationValue(Element relocation, String name, String defaultValue) {
+        NodeList values = relocation.getElementsByTagNameNS("*", name);
+        if (values.getLength() == 0) {
+            return defaultValue;
+        }
+        String value = values.item(0).getTextContent().trim();
+        return value.isEmpty() ? defaultValue : value;
     }
 
 }

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadataTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadataTest.groovy
@@ -27,8 +27,8 @@
 package org.graalvm.buildtools.gradle.tasks
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier
-import org.gradle.api.artifacts.VersionConstraint
-import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -37,7 +37,7 @@ class CollectReachabilityMetadataTest extends Specification {
     @TempDir
     File testDirectory
 
-    def "recognizes a POM relocation only for its exact requested and selected coordinates"() {
+    def "recognizes a POM relocation only when the resolved graph contains its exact edge"() {
         given:
         File pom = new File(testDirectory, "legacy-library-1.0.pom")
         pom.text = """
@@ -56,12 +56,54 @@ class CollectReachabilityMetadataTest extends Specification {
 </project>
 """
         def relocations = CollectReachabilityMetadata.readRelocations([pom] as Set)
-        def legacyRequested = requested("example.legacy", "legacy-library", "1.0")
+        def canonical = component("example.current", "current-library", "2.0")
+        def legacy = component("example.legacy", "legacy-library", "1.0", canonical)
+        def components = [
+                "example.legacy:legacy-library:1.0": legacy,
+                "example.current:current-library:2.0": canonical,
+        ]
 
         expect:
-        CollectReachabilityMetadata.isMavenRelocationTo(legacyRequested, selected("example.current", "current-library", "2.0"), relocations)
-        !CollectReachabilityMetadata.isMavenRelocationTo(legacyRequested, selected("example.current", "current-library", "3.0"), relocations)
-        !CollectReachabilityMetadata.isMavenRelocationTo(requested("example.legacy", "legacy-library", "1.1"), selected("example.current", "current-library", "2.0"), relocations)
+        CollectReachabilityMetadata.verifiedRelocations(components, relocations) == [
+                "example.legacy:legacy-library:1.0": "example.current:current-library:2.0",
+        ]
+
+        when:
+        components["example.legacy:legacy-library:1.0"] = component("example.legacy", "legacy-library", "1.0")
+
+        then:
+        CollectReachabilityMetadata.verifiedRelocations(components, relocations).isEmpty()
+    }
+
+    def "ignores relocation elements outside Maven distribution management"() {
+        given:
+        File pom = new File(testDirectory, "shade-plugin.pom")
+        pom.text = """
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example</groupId>
+  <artifactId>library</artifactId>
+  <version>1.0</version>
+  <build>
+    <plugins>
+      <plugin>
+        <configuration>
+          <relocations>
+            <relocation>
+              <groupId>not.maven</groupId>
+              <artifactId>not-a-relocation</artifactId>
+              <version>2.0</version>
+            </relocation>
+          </relocations>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+"""
+
+        expect:
+        CollectReachabilityMetadata.readRelocations([pom] as Set).isEmpty()
     }
 
     def "uses the resolved module to decide whether fallback is excluded"() {
@@ -69,15 +111,13 @@ class CollectReachabilityMetadataTest extends Specification {
         CollectReachabilityMetadata.isExcluded(selected("example.current", "current-library", "2.0"), ["example.current:current-library"] as Set)
         !CollectReachabilityMetadata.isExcluded(selected("example.legacy", "legacy-library", "1.0"), ["example.current:current-library"] as Set)
     }
-
-
-    private ModuleComponentSelector requested(String group, String module, String version) {
-        Stub(ModuleComponentSelector) {
-            getGroup() >> group
-            getModule() >> module
-            getVersionConstraint() >> Stub(VersionConstraint) {
-                getRequiredVersion() >> version
-            }
+    private ResolvedComponentResult component(String group, String name, String version,
+                                              ResolvedComponentResult dependency = null) {
+        Stub(ResolvedComponentResult) {
+            getModuleVersion() >> selected(group, name, version)
+            getDependencies() >> (dependency == null ? [] : [Stub(ResolvedDependencyResult) {
+                getSelected() >> dependency
+            }])
         }
     }
 

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadataTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadataTest.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following
+ * condition:
+ *
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.tasks
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.VersionConstraint
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import spock.lang.Specification
+import spock.lang.TempDir
+
+// Protects verified Maven relocation metadata fallback. §FS-resources-and-metadata.3.
+class CollectReachabilityMetadataTest extends Specification {
+    @TempDir
+    File testDirectory
+
+    def "recognizes a POM relocation only for its exact requested and selected coordinates"() {
+        given:
+        File pom = new File(testDirectory, "legacy-library-1.0.pom")
+        pom.text = """
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example.legacy</groupId>
+  <artifactId>legacy-library</artifactId>
+  <version>1.0</version>
+  <distributionManagement>
+    <relocation>
+      <groupId>example.current</groupId>
+      <artifactId>current-library</artifactId>
+      <version>2.0</version>
+    </relocation>
+  </distributionManagement>
+</project>
+"""
+        def relocations = CollectReachabilityMetadata.readRelocations([pom] as Set)
+        def legacyRequested = requested("example.legacy", "legacy-library", "1.0")
+
+        expect:
+        CollectReachabilityMetadata.isMavenRelocationTo(legacyRequested, selected("example.current", "current-library", "2.0"), relocations)
+        !CollectReachabilityMetadata.isMavenRelocationTo(legacyRequested, selected("example.current", "current-library", "3.0"), relocations)
+        !CollectReachabilityMetadata.isMavenRelocationTo(requested("example.legacy", "legacy-library", "1.1"), selected("example.current", "current-library", "2.0"), relocations)
+    }
+
+    def "uses the resolved module to decide whether fallback is excluded"() {
+        expect:
+        CollectReachabilityMetadata.isExcluded(selected("example.current", "current-library", "2.0"), ["example.current:current-library"] as Set)
+        !CollectReachabilityMetadata.isExcluded(selected("example.legacy", "legacy-library", "1.0"), ["example.current:current-library"] as Set)
+    }
+
+
+    private ModuleComponentSelector requested(String group, String module, String version) {
+        Stub(ModuleComponentSelector) {
+            getGroup() >> group
+            getModule() >> module
+            getVersionConstraint() >> Stub(VersionConstraint) {
+                getRequiredVersion() >> version
+            }
+        }
+    }
+
+    private ModuleVersionIdentifier selected(String group, String name, String version) {
+        Stub(ModuleVersionIdentifier) {
+            getGroup() >> group
+            getName() >> name
+            getVersion() >> version
+        }
+    }
+}

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadataTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/CollectReachabilityMetadataTest.groovy
@@ -37,7 +37,7 @@ class CollectReachabilityMetadataTest extends Specification {
     @TempDir
     File testDirectory
 
-    def "recognizes a POM relocation only when the resolved graph contains its exact edge"() {
+    def "uses the associated resolved coordinate when the POM has a CI-friendly version"() {
         given:
         File pom = new File(testDirectory, "legacy-library-1.0.pom")
         pom.text = """
@@ -45,7 +45,10 @@ class CollectReachabilityMetadataTest extends Specification {
   <modelVersion>4.0.0</modelVersion>
   <groupId>example.legacy</groupId>
   <artifactId>legacy-library</artifactId>
-  <version>1.0</version>
+  <version>\${revision}</version>
+  <properties>
+    <revision>1.0</revision>
+  </properties>
   <distributionManagement>
     <relocation>
       <groupId>example.current</groupId>
@@ -55,7 +58,9 @@ class CollectReachabilityMetadataTest extends Specification {
   </distributionManagement>
 </project>
 """
-        def relocations = CollectReachabilityMetadata.readRelocations([pom] as Set)
+        def relocationPom = new CollectReachabilityMetadata.RelocationPom(
+                "example.legacy", "legacy-library", "1.0", pom)
+        def relocations = CollectReachabilityMetadata.readRelocations([relocationPom])
         def canonical = component("example.current", "current-library", "2.0")
         def legacy = component("example.legacy", "legacy-library", "1.0", canonical)
         def components = [
@@ -103,7 +108,9 @@ class CollectReachabilityMetadataTest extends Specification {
 """
 
         expect:
-        CollectReachabilityMetadata.readRelocations([pom] as Set).isEmpty()
+        def relocationPom = new CollectReachabilityMetadata.RelocationPom(
+                "example", "library", "1.0", pom)
+        CollectReachabilityMetadata.readRelocations([relocationPom]).isEmpty()
     }
 
     def "uses the resolved module to decide whether fallback is excluded"() {

--- a/native-maven-plugin/docs/functional/resources-and-metadata.md
+++ b/native-maven-plugin/docs/functional/resources-and-metadata.md
@@ -18,6 +18,11 @@ configuration directory to the native image build without requiring users to man
 repository contents. When no URI, version, or local path is pinned, the Maven default should follow
 the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs/spec/goals.md#goal-fresh-metadata-users-can-fetch-the-latest-graalvm-reachability-metadata).
 
+For a verified Maven relocation, Maven metadata collection prefers the resolved artifact's metadata
+and falls back to metadata for the requested pre-relocation coordinate only when the resolved
+artifact has no metadata. It selects one coordinate's metadata and must not treat substitution or
+conflict resolution as relocation. [§common/FS-common-libraries.5.3](../../../common/docs/functional-spec.md#53-maven-relocation-fallback).
+
 ## 3. Missing metadata reports
 
 `native:list-libraries-missing-metadata` reports project dependencies that do not appear to have

--- a/native-maven-plugin/docs/functional/resources-and-metadata.md
+++ b/native-maven-plugin/docs/functional/resources-and-metadata.md
@@ -21,7 +21,9 @@ the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs
 For a verified Maven relocation, Maven metadata collection prefers the resolved artifact's metadata
 and falls back to metadata for the requested pre-relocation coordinate only when the resolved
 artifact has no metadata. It selects one coordinate's metadata and must not treat substitution or
-conflict resolution as relocation. [§common/FS-common-libraries.5.3](../../../common/docs/functional-spec.md#53-maven-relocation-fallback).
+conflict resolution as relocation. Relocation inspection must honor the effective dependency
+management and exclusions without changing the project dependency graph.
+[§common/FS-common-libraries.5.3](../../../common/docs/functional-spec.md#53-maven-relocation-fallback).
 
 ## 3. Missing metadata reports
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -49,17 +49,19 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.RepositoryUtils;
 import org.codehaus.plexus.logging.Logger;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
-import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
-import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.graalvm.buildtools.VersionInfo;
 import org.graalvm.buildtools.maven.config.MetadataRepositoryConfiguration;
 import org.graalvm.buildtools.utils.ExponentialBackoff;
@@ -78,8 +80,11 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -119,6 +124,8 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
     protected final Set<DirectoryConfiguration> metadataRepositoryConfigurations;
 
     protected GraalVMReachabilityMetadataRepository metadataRepository;
+    private Map<String, Set<Artifact>> relocationSources;
+
 
     @Component
     protected Logger logger;
@@ -349,39 +356,44 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
     }
 
     private Set<Artifact> requestedRelocationSources(Artifact selected) {
-        Set<Artifact> candidates = new LinkedHashSet<>();
-        if (project.getDependencyArtifacts() != null) {
-            candidates.addAll(project.getDependencyArtifacts());
+        if (relocationSources == null) {
+            relocationSources = new LinkedHashMap<>();
+            if (project.getDependencyArtifacts() == null) {
+                return Collections.emptySet();
+            }
+            CollectRequest request = new CollectRequest();
+            request.setRepositories(project.getRemoteProjectRepositories());
+            for (Artifact dependency : project.getDependencyArtifacts()) {
+                request.addDependency(RepositoryUtils.toDependency(dependency, null));
+            }
+            try {
+                CollectResult result = repositorySystem.collectDependencies(mavenSession.getRepositorySession(), request);
+                collectRelocationSources(result.getRoot(), relocationSources);
+            } catch (DependencyCollectionException exception) {
+                getLog().debug("Unable to collect Maven relocations", exception);
+            }
         }
-        return candidates.stream()
-                .filter(candidate -> isMavenRelocationTo(candidate, selected))
-                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        return relocationSources.getOrDefault(coordinate(selected), Collections.emptySet());
     }
 
-    private boolean isMavenRelocationTo(Artifact requested, Artifact selected) {
-        if (requested.getGroupId().equals(selected.getGroupId())
-                && requested.getArtifactId().equals(selected.getArtifactId())
-                && requested.getVersion().equals(selected.getVersion())) {
-            return false;
-        }
-        try {
-            ArtifactDescriptorRequest request = new ArtifactDescriptorRequest();
-            request.setArtifact(new DefaultArtifact(
-                    requested.getGroupId(), requested.getArtifactId(), "", "pom", requested.getVersion()));
-            request.setRepositories(project.getRemoteProjectRepositories());
-            ArtifactDescriptorResult descriptor = repositorySystem.readArtifactDescriptor(
-                    mavenSession.getRepositorySession(), request);
-            if (descriptor.getRelocations().isEmpty()) {
-                return false;
+    static void collectRelocationSources(DependencyNode node, Map<String, Set<Artifact>> relocationSources) {
+        if (node.getArtifact() != null && !node.getRelocations().isEmpty()) {
+            Set<Artifact> sources = relocationSources.computeIfAbsent(coordinate(node.getArtifact()), ignored -> new LinkedHashSet<>());
+            for (org.eclipse.aether.artifact.Artifact relocation : node.getRelocations()) {
+                sources.add(RepositoryUtils.toArtifact(relocation));
             }
-            org.eclipse.aether.artifact.Artifact relocationTarget = descriptor.getArtifact();
-            return relocationTarget.getGroupId().equals(selected.getGroupId())
-                    && relocationTarget.getArtifactId().equals(selected.getArtifactId())
-                    && relocationTarget.getVersion().equals(selected.getVersion());
-        } catch (Exception exception) {
-            getLog().debug("Unable to inspect Maven relocation for " + requested, exception);
-            return false;
         }
+        for (DependencyNode child : node.getChildren()) {
+            collectRelocationSources(child, relocationSources);
+        }
+    }
+
+    private static String coordinate(Artifact artifact) {
+        return artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion();
+    }
+
+    private static String coordinate(org.eclipse.aether.artifact.Artifact artifact) {
+        return artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion();
     }
 
     protected Optional<String> getMetadataVersion(Artifact dependency) {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -42,6 +42,7 @@
 package org.graalvm.buildtools.maven;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
@@ -53,6 +54,8 @@ import org.apache.maven.RepositoryUtils;
 import org.codehaus.plexus.logging.Logger;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.ArtifactType;
+import org.eclipse.aether.artifact.ArtifactTypeRegistry;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.collection.CollectResult;
@@ -62,6 +65,8 @@ import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.util.artifact.ArtifactIdUtils;
+import org.eclipse.aether.util.artifact.JavaScopes;
 import org.graalvm.buildtools.VersionInfo;
 import org.graalvm.buildtools.maven.config.MetadataRepositoryConfiguration;
 import org.graalvm.buildtools.utils.ExponentialBackoff;
@@ -80,7 +85,9 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -141,6 +148,9 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
 
     @Component
     protected RepositorySystem repositorySystem;
+
+    @Component
+    protected ArtifactHandlerManager artifactHandlerManager;
 
     @Inject
     protected AbstractNativeMojo() {
@@ -358,14 +368,9 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
     private Set<Artifact> requestedRelocationSources(Artifact selected) {
         if (relocationSources == null) {
             relocationSources = new LinkedHashMap<>();
-            if (project.getDependencyArtifacts() == null) {
-                return Collections.emptySet();
-            }
-            CollectRequest request = new CollectRequest();
+            ArtifactTypeRegistry artifactTypes = RepositoryUtils.newArtifactTypeRegistry(artifactHandlerManager);
+            CollectRequest request = relocationCollectRequest(project, artifactTypes);
             request.setRepositories(project.getRemoteProjectRepositories());
-            for (Artifact dependency : project.getDependencyArtifacts()) {
-                request.addDependency(RepositoryUtils.toDependency(dependency, null));
-            }
             try {
                 CollectResult result = repositorySystem.collectDependencies(mavenSession.getRepositorySession(), request);
                 collectRelocationSources(result.getRoot(), relocationSources);
@@ -374,6 +379,56 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
             }
         }
         return relocationSources.getOrDefault(coordinate(selected), Collections.emptySet());
+    }
+
+    /** Recreates Maven's effective collection request without mutating the project graph. §FS-resources-and-metadata.2. */
+    static CollectRequest relocationCollectRequest(MavenProject project, ArtifactTypeRegistry artifactTypes) {
+        CollectRequest request = new CollectRequest();
+        if (project.getArtifact() != null) {
+            request.setRootArtifact(RepositoryUtils.toArtifact(project.getArtifact()));
+        }
+        request.setRequestContext("project");
+        if (project.getDependencyArtifacts() == null) {
+            for (org.apache.maven.model.Dependency dependency : project.getDependencies()) {
+                if (dependency.getGroupId() != null && dependency.getArtifactId() != null
+                        && dependency.getVersion() != null) {
+                    request.addDependency(RepositoryUtils.toDependency(dependency, artifactTypes));
+                }
+            }
+        } else {
+            Map<String, org.apache.maven.model.Dependency> dependencies = new HashMap<>();
+            for (org.apache.maven.model.Dependency dependency : project.getDependencies()) {
+                String classifier = dependency.getClassifier();
+                if (classifier == null) {
+                    ArtifactType type = artifactTypes.get(dependency.getType());
+                    if (type != null) {
+                        classifier = type.getClassifier();
+                    }
+                }
+                String key = ArtifactIdUtils.toVersionlessId(dependency.getGroupId(), dependency.getArtifactId(),
+                        dependency.getType(), classifier);
+                dependencies.put(key, dependency);
+            }
+            for (Artifact artifact : project.getDependencyArtifacts()) {
+                org.apache.maven.model.Dependency dependency = dependencies.get(artifact.getDependencyConflictId());
+                Collection<org.apache.maven.model.Exclusion> exclusions = dependency == null
+                        ? null
+                        : dependency.getExclusions();
+                Dependency collected = RepositoryUtils.toDependency(artifact, exclusions);
+                if (!JavaScopes.SYSTEM.equals(collected.getScope()) && collected.getArtifact().getFile() != null) {
+                    org.eclipse.aether.artifact.Artifact dependencyArtifact = collected.getArtifact();
+                    dependencyArtifact = dependencyArtifact.setFile(null).setVersion(dependencyArtifact.getBaseVersion());
+                    collected = collected.setArtifact(dependencyArtifact);
+                }
+                request.addDependency(collected);
+            }
+        }
+        if (project.getDependencyManagement() != null) {
+            for (org.apache.maven.model.Dependency dependency : project.getDependencyManagement().getDependencies()) {
+                request.addManagedDependency(RepositoryUtils.toDependency(dependency, artifactTypes));
+            }
+        }
+        return request;
     }
 
     static void collectRelocationSources(DependencyNode node, Map<String, Set<Artifact>> relocationSources) {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -58,6 +58,8 @@ import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.graalvm.buildtools.VersionInfo;
 import org.graalvm.buildtools.maven.config.MetadataRepositoryConfiguration;
 import org.graalvm.buildtools.utils.ExponentialBackoff;
@@ -77,6 +79,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -314,22 +317,70 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
         }
     }
 
+    /**
+     * Selects canonical metadata first, then verified requested-coordinate relocation metadata. §common/FS-common-libraries.5.3.
+     */
     protected void maybeAddDependencyMetadata(Artifact dependency, Consumer<File> excludeAction) {
         if (isMetadataRepositoryEnabled() && metadataRepository != null && !isArtifactExcludedFromMetadataRepository(dependency)) {
-            Set<DirectoryConfiguration> configurations = metadataRepository.findConfigurationsFor(q -> {
-                q.useLatestConfigWhenVersionIsUntested();
-                q.forArtifact(artifact -> {
-                    artifact.gav(String.join(":",
-                            dependency.getGroupId(),
-                            dependency.getArtifactId(),
-                            dependency.getVersion()));
-                    getMetadataVersion(dependency).ifPresent(artifact::forceConfigVersion);
-                });
-            });
+            Set<DirectoryConfiguration> configurations = findMetadataConfigurations(dependency);
+            if (configurations.isEmpty()) {
+                for (Artifact requested : requestedRelocationSources(dependency)) {
+                    configurations = findMetadataConfigurations(requested);
+                    if (!configurations.isEmpty()) {
+                        break;
+                    }
+                }
+            }
             metadataRepositoryConfigurations.addAll(configurations);
             if (excludeAction != null && configurations.stream().anyMatch(DirectoryConfiguration::isOverride)) {
                 excludeAction.accept(dependency.getFile());
             }
+        }
+    }
+
+    private Set<DirectoryConfiguration> findMetadataConfigurations(Artifact dependency) {
+        return metadataRepository.findConfigurationsFor(q -> {
+            q.useLatestConfigWhenVersionIsUntested();
+            q.forArtifact(artifact -> {
+                artifact.gav(String.join(":", dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion()));
+                getMetadataVersion(dependency).ifPresent(artifact::forceConfigVersion);
+            });
+        });
+    }
+
+    private Set<Artifact> requestedRelocationSources(Artifact selected) {
+        Set<Artifact> candidates = new LinkedHashSet<>();
+        if (project.getDependencyArtifacts() != null) {
+            candidates.addAll(project.getDependencyArtifacts());
+        }
+        return candidates.stream()
+                .filter(candidate -> isMavenRelocationTo(candidate, selected))
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private boolean isMavenRelocationTo(Artifact requested, Artifact selected) {
+        if (requested.getGroupId().equals(selected.getGroupId())
+                && requested.getArtifactId().equals(selected.getArtifactId())
+                && requested.getVersion().equals(selected.getVersion())) {
+            return false;
+        }
+        try {
+            ArtifactDescriptorRequest request = new ArtifactDescriptorRequest();
+            request.setArtifact(new DefaultArtifact(
+                    requested.getGroupId(), requested.getArtifactId(), "", "pom", requested.getVersion()));
+            request.setRepositories(project.getRemoteProjectRepositories());
+            ArtifactDescriptorResult descriptor = repositorySystem.readArtifactDescriptor(
+                    mavenSession.getRepositorySession(), request);
+            if (descriptor.getRelocations().isEmpty()) {
+                return false;
+            }
+            org.eclipse.aether.artifact.Artifact relocationTarget = descriptor.getArtifact();
+            return relocationTarget.getGroupId().equals(selected.getGroupId())
+                    && relocationTarget.getArtifactId().equals(selected.getArtifactId())
+                    && relocationTarget.getVersion().equals(selected.getVersion());
+        } catch (Exception exception) {
+            getLog().debug("Unable to inspect Maven relocation for " + requested, exception);
+            return false;
         }
     }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -342,6 +342,9 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
             Set<DirectoryConfiguration> configurations = findMetadataConfigurations(dependency);
             if (configurations.isEmpty()) {
                 for (Artifact requested : requestedRelocationSources(dependency)) {
+                    if (isArtifactExcludedFromMetadataRepository(requested)) {
+                        continue;
+                    }
                     configurations = findMetadataConfigurations(requested);
                     if (!configurations.isEmpty()) {
                         break;

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeMojoTest.groovy
@@ -76,8 +76,8 @@ class AbstractNativeMojoTest extends Specification {
 
     void "collects relocation sources from transitive dependency nodes"() {
         given:
-        def relocated = new DefaultArtifact("example", "legacy-library", "1.0")
-        def selected = new DefaultArtifact("example", "library", "1.0")
+        def relocated = new DefaultArtifact("example", "legacy-library", "jar", "1.0")
+        def selected = new DefaultArtifact("example", "library", "jar", "1.0")
         def child = Mock(DependencyNode) {
             getArtifact() >> selected
             getRelocations() >> [relocated]

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeMojoTest.groovy
@@ -52,6 +52,8 @@ import org.eclipse.aether.artifact.DefaultArtifact
 import org.eclipse.aether.artifact.DefaultArtifactType
 import org.eclipse.aether.graph.DependencyNode
 import org.graalvm.buildtools.VersionInfo
+import org.graalvm.buildtools.maven.config.MetadataRepositoryConfiguration
+import org.graalvm.reachability.GraalVMReachabilityMetadataRepository
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -79,6 +81,28 @@ class AbstractNativeMojoTest extends Specification {
         mojo.downloadedUrl.toString() == String.format(METADATA_REPO_URL_TEMPLATE, VersionInfo.METADATA_REPO_VERSION)
         mojo.metadataRepository != null
         mojo.metadataRepositoryConfiguration == null
+    }
+
+    void "does not use excluded relocation source metadata as fallback"() {
+        given:
+        def mojo = new MetadataFallbackMojo(testDirectory)
+        def repository = Mock(GraalVMReachabilityMetadataRepository)
+        mojo.metadataRepository = repository
+        mojo.metadataRepositoryConfiguration = new MetadataRepositoryConfiguration()
+        mojo.metadataRepositoryConfiguration.dependencies = [
+                new MetadataRepositoryConfiguration.DependencyConfiguration("example.legacy", "legacy-library", true),
+        ]
+        setRelocationSources(mojo, [
+                "example.current:current-library:1.0": [mavenArtifact("example.legacy", "legacy-library", "1.0")] as Set,
+        ])
+
+        when:
+        mojo.maybeAddDependencyMetadata(mavenArtifact("example.current", "current-library", "1.0"), null)
+
+        then:
+        1 * repository.findConfigurationsFor(_) >> Collections.emptySet()
+        0 * repository.findConfigurationsFor(_)
+        mojo.metadataRepositoryConfigurations.empty
     }
 
     void "collects relocation sources from transitive dependency nodes"() {
@@ -139,6 +163,17 @@ class AbstractNativeMojoTest extends Specification {
         request.dependencies.first().exclusions*.groupId == ["excluded"]
         request.dependencies.first().exclusions*.artifactId == ["library"]
         request.managedDependencies*.artifact*.toString() == ["example.legacy:legacy-library:jar:2.0"]
+    }
+
+    private static void setRelocationSources(AbstractNativeMojo mojo, Map<String, Set<org.apache.maven.artifact.Artifact>> sources) {
+        def field = AbstractNativeMojo.getDeclaredField("relocationSources")
+        field.accessible = true
+        field.set(mojo, sources)
+    }
+
+    private static org.apache.maven.artifact.Artifact mavenArtifact(String groupId, String artifactId, String version) {
+        new org.apache.maven.artifact.DefaultArtifact(groupId, artifactId, version, "compile", "jar", null,
+                new DefaultArtifactHandler("jar"))
     }
 
     private static class MetadataFallbackMojo extends AbstractNativeMojo {

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeMojoTest.groovy
@@ -42,6 +42,8 @@
 package org.graalvm.buildtools.maven
 
 import org.codehaus.plexus.logging.Logger
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.eclipse.aether.graph.DependencyNode
 import org.graalvm.buildtools.VersionInfo
 import spock.lang.Specification
 import spock.lang.TempDir
@@ -70,6 +72,31 @@ class AbstractNativeMojoTest extends Specification {
         mojo.downloadedUrl.toString() == String.format(METADATA_REPO_URL_TEMPLATE, VersionInfo.METADATA_REPO_VERSION)
         mojo.metadataRepository != null
         mojo.metadataRepositoryConfiguration == null
+    }
+
+    void "collects relocation sources from transitive dependency nodes"() {
+        given:
+        def relocated = new DefaultArtifact("example", "legacy-library", "1.0")
+        def selected = new DefaultArtifact("example", "library", "1.0")
+        def child = Mock(DependencyNode) {
+            getArtifact() >> selected
+            getRelocations() >> [relocated]
+            getChildren() >> []
+        }
+        def root = Mock(DependencyNode) {
+            getArtifact() >> null
+            getRelocations() >> []
+            getChildren() >> [child]
+        }
+        def relocationSources = [:]
+
+        when:
+        AbstractNativeMojo.collectRelocationSources(root, relocationSources)
+
+        then:
+        relocationSources["example:library:1.0"]*.groupId == ["example"]
+        relocationSources["example:library:1.0"]*.artifactId == ["legacy-library"]
+        relocationSources["example:library:1.0"]*.version == ["1.0"]
     }
 
     private static class MetadataFallbackMojo extends AbstractNativeMojo {

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeMojoTest.groovy
@@ -41,8 +41,15 @@
 
 package org.graalvm.buildtools.maven
 
+import org.apache.maven.artifact.handler.DefaultArtifactHandler
+import org.apache.maven.model.Dependency
+import org.apache.maven.model.DependencyManagement
+import org.apache.maven.model.Exclusion
+import org.apache.maven.project.MavenProject
 import org.codehaus.plexus.logging.Logger
+import org.eclipse.aether.artifact.ArtifactTypeRegistry
 import org.eclipse.aether.artifact.DefaultArtifact
+import org.eclipse.aether.artifact.DefaultArtifactType
 import org.eclipse.aether.graph.DependencyNode
 import org.graalvm.buildtools.VersionInfo
 import spock.lang.Specification
@@ -97,6 +104,41 @@ class AbstractNativeMojoTest extends Specification {
         relocationSources["example:library:1.0"]*.groupId == ["example"]
         relocationSources["example:library:1.0"]*.artifactId == ["legacy-library"]
         relocationSources["example:library:1.0"]*.version == ["1.0"]
+    }
+
+    void "collects relocations with effective dependency management and exclusions"() {
+        given:
+        def direct = new Dependency(
+                groupId: "example",
+                artifactId: "application",
+                version: "1.0",
+                exclusions: [new Exclusion(groupId: "excluded", artifactId: "library")],
+        )
+        def managed = new Dependency(
+                groupId: "example.legacy",
+                artifactId: "legacy-library",
+                version: "2.0",
+        )
+        def dependencyManagement = new DependencyManagement()
+        dependencyManagement.addDependency(managed)
+        def project = new MavenProject()
+        project.model.addDependency(direct)
+        project.model.dependencyManagement = dependencyManagement
+        project.dependencyArtifacts = [new org.apache.maven.artifact.DefaultArtifact(
+                "example", "application", "1.0", "compile", "jar", null, new DefaultArtifactHandler("jar"),
+        )] as Set
+        def artifactTypes = Stub(ArtifactTypeRegistry) {
+            get(_) >> new DefaultArtifactType("jar")
+        }
+
+        when:
+        def request = AbstractNativeMojo.relocationCollectRequest(project, artifactTypes)
+
+        then:
+        request.dependencies*.artifact*.toString() == ["example:application:jar:1.0"]
+        request.dependencies.first().exclusions*.groupId == ["excluded"]
+        request.dependencies.first().exclusions*.artifactId == ["library"]
+        request.managedDependencies*.artifact*.toString() == ["example.legacy:legacy-library:jar:2.0"]
     }
 
     private static class MetadataFallbackMojo extends AbstractNativeMojo {


### PR DESCRIPTION
## Summary

Implements the metadata-lookup side of [#968](https://github.com/graalvm/native-build-tools/issues/968). This is the Native Build Tools counterpart to [oracle/graalvm-reachability-metadata#9025](https://github.com/oracle/graalvm-reachability-metadata/pull/9025).

A dependency may be declared under a pre-relocation Maven coordinate while Gradle or Maven resolves the relocated binary. Metadata generated for the requested coordinate is currently ignored because both plugins query only the selected artifact GAV.

## Behavior

For a verified Maven relocation from a requested coordinate to the selected artifact:

1. Query metadata for the selected/canonical artifact first.
2. If no configuration is available, query the requested pre-relocation coordinate.
3. Use only the first non-empty configuration set.
4. Require an actual Maven relocation POM match; ordinary substitutions and conflict resolution do not activate fallback.

## Implementation

- Gradle retains requested module selectors while traversing the resolution graph and verifies relocation by resolving/parsing the requested POM.
- Maven compares direct requested artifacts with the selected artifact using Maven Resolver artifact-descriptor relocation data.
- Shared and plugin-specific metadata-consumption specifications document precedence and non-duplication.

## Validation

- `:native-gradle-plugin:compileJava`
- `:native-maven-plugin:compileJava`
- `:native-gradle-plugin:checkstyleMain`
- `:native-maven-plugin:checkstyleMain`
- `grund check`

All pass with JDK 17.

## Draft follow-up

This is a draft while adding end-to-end relocation fixtures for both plugins, including canonical preference, old-coordinate fallback, and non-relocation rejection.

Closes #968
