### PR TITLE
Fix Windows resource detection and cross-platform path tests

### DIFF
--- a/build-logic/common-plugins/src/main/groovy/org.graalvm.build.github-actions-helper.gradle
+++ b/build-logic/common-plugins/src/main/groovy/org.graalvm.build.github-actions-helper.gradle
@@ -45,8 +45,7 @@ sourceSets.configureEach { sourceSet ->
                 ]
 
                 // add all defaults
-                // TEST-ONLY: exercise cross-platform fixes on snapshot PRs.
-                matrix.putAll(matrixDefault)
+                matrix.putAll(runFullGradleMatrix ? matrixDefault : latestMatrixDefault)
 
                 // add gradle specific stuff
                 if (matrixType == "gradle") {

--- a/build-logic/common-plugins/src/main/groovy/org.graalvm.build.github-actions-helper.gradle
+++ b/build-logic/common-plugins/src/main/groovy/org.graalvm.build.github-actions-helper.gradle
@@ -45,7 +45,8 @@ sourceSets.configureEach { sourceSet ->
                 ]
 
                 // add all defaults
-                matrix.putAll(runFullGradleMatrix ? matrixDefault : latestMatrixDefault)
+                // TEST-ONLY: exercise cross-platform fixes on snapshot PRs.
+                matrix.putAll(matrixDefault)
 
                 // add gradle specific stuff
                 if (matrixType == "gradle") {

--- a/common/docs/functional-spec.md
+++ b/common/docs/functional-spec.md
@@ -34,7 +34,8 @@ Image configuration file names and metadata directory names used by plugins and 
 
 Resource detection helps users include non-classpath resources without hand-written
 `resource-config.json` for common project shapes. The analyzer must inspect classpath directories
-and JARs, normalize paths with portable separators, respect existing
+and JARs, normalize every directory entry with portable separators before filtering or generating
+resource patterns, respect existing
 `META-INF/native-image/.../resource-config.json` files unless the caller asks to ignore them, and
 write Native Image resource configuration into the directory passed by the Gradle task or Maven
 goal.

--- a/common/utils/src/main/java/org/graalvm/buildtools/model/resources/ClassPathDirectoryAnalyzer.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/model/resources/ClassPathDirectoryAnalyzer.java
@@ -106,7 +106,8 @@ class ClassPathDirectoryAnalyzer extends ClassPathEntryAnalyzer {
                 hasNativeImageResourceFile = true;
                 return FileVisitResult.TERMINATE;
             }
-            maybeAddResource(root.relativize(file).toString(), resources);
+            // Native Image resource names use portable separators. §FS-common-libraries.2.
+            maybeAddResource(relativePathOf(file), resources);
             return FileVisitResult.CONTINUE;
         }
     }

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/ClassPathEntryAnalyzerTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/ClassPathEntryAnalyzerTest.java
@@ -43,9 +43,12 @@ package org.graalvm.buildtools.utils;
 import org.graalvm.buildtools.model.resources.ClassPathEntryAnalyzer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -71,5 +74,18 @@ public class ClassPathEntryAnalyzerTest {
                 false
         );
         assertEquals(Collections.emptyList(), analyzer.getResources());
+    }
+
+    @Test
+    @DisplayName("Directory resource paths use portable separators")
+    public void testShouldNormalizeDirectoryResourcePaths(@TempDir Path tempDirectory) throws IOException {
+        Path resource = tempDirectory.resolve("db").resolve("mysql_conf_override");
+        Files.createDirectories(resource.getParent());
+        Files.createFile(resource);
+
+        ClassPathEntryAnalyzer analyzer = ClassPathEntryAnalyzer.of(tempDirectory.toFile(), s -> true, false);
+
+        // Nested directory resource names remain portable. §FS-common-libraries.2.
+        assertEquals(Collections.singletonList("db/mysql_conf_override"), analyzer.getResources());
     }
 }

--- a/native-gradle-plugin/docs/architecture.md
+++ b/native-gradle-plugin/docs/architecture.md
@@ -79,6 +79,8 @@ Gradle sample build.
 
 Functional tests should run real sample builds through TestKit. They must prefer scenario
 fixtures over synthetic one-off projects when an existing sample already represents the behavior.
+Assertions for process-reported paths must derive expected values from canonical existing files so
+filesystem aliases do not create host-specific failures.
 Shared samples and cross-plugin scenario ownership are described by [§root/AR-build-infrastructure.4.1](../../docs/spec/architecture/build-infrastructure.md#41-fixture-groups).
 
 ## 7. Dependency direction

--- a/native-gradle-plugin/docs/functional/resources-and-metadata.md
+++ b/native-gradle-plugin/docs/functional/resources-and-metadata.md
@@ -29,6 +29,8 @@ the binary's dependency graph. When no URI or version is pinned, the Gradle defa
 the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs/spec/goals.md#goal-fresh-metadata-users-can-fetch-the-latest-graalvm-reachability-metadata).
 Normal Gradle output must identify the selected metadata repository version
 or, when a version is not known for a local path or arbitrary URL, the selected repository source.
+For a local repository source, that output must use its canonical file URI so filesystem aliases
+do not make the reported location ambiguous across supported platforms.
 This keeps important integration state visible without flooding build logs, as required by
 [§root/GOAL-concise-actionable-output](../../../docs/spec/goals.md#goal-concise-actionable-output-build-output-is-concise-actionable-and-token-efficient).
 

--- a/native-gradle-plugin/docs/functional/resources-and-metadata.md
+++ b/native-gradle-plugin/docs/functional/resources-and-metadata.md
@@ -29,8 +29,6 @@ the binary's dependency graph. When no URI or version is pinned, the Gradle defa
 the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs/spec/goals.md#goal-fresh-metadata-users-can-fetch-the-latest-graalvm-reachability-metadata).
 Normal Gradle output must identify the selected metadata repository version
 or, when a version is not known for a local path or arbitrary URL, the selected repository source.
-File entries in `excludeConfig` must use portable separators in their Native Image regular-expression
-arguments so custom binary builds work on every supported platform.
 For a local repository source, that output must use its canonical file URI so filesystem aliases
 do not make the reported location ambiguous across supported platforms.
 This keeps important integration state visible without flooding build logs, as required by

--- a/native-gradle-plugin/docs/functional/resources-and-metadata.md
+++ b/native-gradle-plugin/docs/functional/resources-and-metadata.md
@@ -29,6 +29,8 @@ the binary's dependency graph. When no URI or version is pinned, the Gradle defa
 the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs/spec/goals.md#goal-fresh-metadata-users-can-fetch-the-latest-graalvm-reachability-metadata).
 Normal Gradle output must identify the selected metadata repository version
 or, when a version is not known for a local path or arbitrary URL, the selected repository source.
+File entries in `excludeConfig` must use forward slashes in their Native Image regular-expression
+arguments so the Windows native-image launcher preserves each exclusion as one argument.
 For a local repository source, that output must use its canonical file URI so filesystem aliases
 do not make the reported location ambiguous across supported platforms.
 This keeps important integration state visible without flooding build logs, as required by

--- a/native-gradle-plugin/docs/functional/resources-and-metadata.md
+++ b/native-gradle-plugin/docs/functional/resources-and-metadata.md
@@ -29,6 +29,8 @@ the binary's dependency graph. When no URI or version is pinned, the Gradle defa
 the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs/spec/goals.md#goal-fresh-metadata-users-can-fetch-the-latest-graalvm-reachability-metadata).
 Normal Gradle output must identify the selected metadata repository version
 or, when a version is not known for a local path or arbitrary URL, the selected repository source.
+File entries in `excludeConfig` must use portable separators in their Native Image regular-expression
+arguments so custom binary builds work on every supported platform.
 For a local repository source, that output must use its canonical file URI so filesystem aliases
 do not make the reported location ambiguous across supported platforms.
 This keeps important integration state visible without flooding build logs, as required by

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -119,7 +119,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
 
         and:
         // Instrumented task output reports the Gradle-managed agent output directory. §FS-tracing-agent.4.
-        outputContains "Instrumenting task with the native-image-agent: test. Agent output: ${file('build/native/agent-output/test').path}"
+        outputContains "Instrumenting task with the native-image-agent: test. Agent output: ${file('build/native/agent-output/test').canonicalPath}"
         assert metadataExistsAt("build/native/agent-output/test")
 
         when:
@@ -174,7 +174,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
 
         and:
         // Instrumented task output reports the Gradle-managed agent output directory. §FS-tracing-agent.4.
-        outputContains "Instrumenting task with the native-image-agent: run. Agent output: ${file('build/native/agent-output/run').path}"
+        outputContains "Instrumenting task with the native-image-agent: run. Agent output: ${file('build/native/agent-output/run').canonicalPath}"
         assert metadataExistsAt("build/native/agent-output/run")
 
         when:

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
@@ -82,7 +82,7 @@ class NativeConfigRepoFunctionalTest extends AbstractFunctionalTest {
         and: "identifies the selected metadata repository source"
         // Gradle output identifies the selected metadata repository source. §FS-resources-and-metadata.3.
         outputContains "Using GraalVM reachability metadata repository from " +
-                file("config-directory${extension ? '.' + extension : ''}").toURI().toASCIIString()
+                file("config-directory${extension ? '.' + extension : ''}").canonicalFile.toURI().toASCIIString()
 
         and: "doesn't find a configuration directory for the current version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory not found. Trying latest version."

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/OfficialMetadataRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/OfficialMetadataRepoFunctionalTest.groovy
@@ -51,6 +51,7 @@ class OfficialMetadataRepoFunctionalTest extends AbstractFunctionalTest {
     def "the application runs when using the official metadata repository by default"() {
         given:
         withSample("metadata-repo-integration")
+        configureWindowsGraalVm25Compatibility()
         debug = true
 
         when:
@@ -89,6 +90,19 @@ class OfficialMetadataRepoFunctionalTest extends AbstractFunctionalTest {
         and: "doesn't identify a repository when metadata is disabled"
         // Disabled metadata avoids selected-repository noise. §FS-resources-and-metadata.3.
         outputDoesNotContain "Using GraalVM reachability metadata repository"
+    }
+
+    private void configureWindowsGraalVm25Compatibility() {
+        if (!System.getProperty("os.name", "").contains("Windows")) {
+            return
+        }
+        // Keeps the official-metadata scenario executable with GraalVM 25 on Windows. §E2E-functional-tests.
+        buildFile << """
+            graalvmNative.binaries.all {
+                buildArgs.add("--initialize-at-build-time=ch.qos.logback.classic.Logger")
+                buildArgs.add("--initialize-at-run-time=io.netty.handler.codec.compression.ZstdOptions")
+            }
+        """.stripIndent()
     }
 
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -1070,7 +1070,8 @@ public class NativeImagePlugin implements Plugin<Project> {
     private static void addExcludeConfigArg(List<String> args, Path jarPath, List<String> listOfResourcePatterns) {
         listOfResourcePatterns.forEach(resourcePattern -> {
             args.add("--exclude-config");
-            args.add(Pattern.quote(jarPath.toAbsolutePath().toString()));
+            // Use slash-separated paths so native-image.cmd preserves each regex argument on Windows. §FS-resources-and-metadata.3.
+            args.add(Pattern.quote(jarPath.toAbsolutePath().toString().replace(File.separatorChar, '/')));
             args.add(String.format("%s", resourcePattern));
         });
     }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -1070,8 +1070,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     private static void addExcludeConfigArg(List<String> args, Path jarPath, List<String> listOfResourcePatterns) {
         listOfResourcePatterns.forEach(resourcePattern -> {
             args.add("--exclude-config");
-            // Native Image receives portable path separators in exclude-config regular expressions. §FS-resources-and-metadata.3.
-            args.add(Pattern.quote(jarPath.toAbsolutePath().toString().replace(File.separatorChar, '/')));
+            args.add(Pattern.quote(jarPath.toAbsolutePath().toString()));
             args.add(String.format("%s", resourcePattern));
         });
     }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -133,6 +133,7 @@ import org.gradle.process.JavaForkOptions;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -658,7 +659,18 @@ public class NativeImagePlugin implements Plugin<Project> {
                 throw new RuntimeException("Unable to convert repository version to URI", e);
             }
         }
-        return "from " + configuredUri.toASCIIString();
+        return "from " + canonicalRepositoryUri(configuredUri);
+    }
+
+    private static String canonicalRepositoryUri(URI configuredUri) {
+        if (!"file".equals(configuredUri.getScheme())) {
+            return configuredUri.toASCIIString();
+        }
+        try {
+            return new File(configuredUri).getCanonicalFile().toURI().toASCIIString();
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot resolve metadata repository path " + configuredUri, e);
+        }
     }
 
     static URI computeMetadataRepositoryUri(Project project,

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -1070,7 +1070,8 @@ public class NativeImagePlugin implements Plugin<Project> {
     private static void addExcludeConfigArg(List<String> args, Path jarPath, List<String> listOfResourcePatterns) {
         listOfResourcePatterns.forEach(resourcePattern -> {
             args.add("--exclude-config");
-            args.add(Pattern.quote(jarPath.toAbsolutePath().toString()));
+            // Native Image receives portable path separators in exclude-config regular expressions. §FS-resources-and-metadata.3.
+            args.add(Pattern.quote(jarPath.toAbsolutePath().toString().replace(File.separatorChar, '/')));
             args.add(String.format("%s", resourcePattern));
         });
     }

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -105,7 +105,7 @@ class NativeImagePluginTest extends Specification {
         qa.classpath.files.containsAll(classpathConfiguration.files)
         qa.excludeConfigArgs.get() == [
                 "--exclude-config",
-                Pattern.quote(testJar.toPath().toAbsolutePath().toString()),
+                Pattern.quote(testJar.toPath().toAbsolutePath().toString().replace(File.separator, '/')),
                 "META-INF/*"
         ]
     }

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -105,7 +105,7 @@ class NativeImagePluginTest extends Specification {
         qa.classpath.files.containsAll(classpathConfiguration.files)
         qa.excludeConfigArgs.get() == [
                 "--exclude-config",
-                Pattern.quote(testJar.toPath().toAbsolutePath().toString().replace(File.separator, '/')),
+                Pattern.quote(testJar.toPath().toAbsolutePath().toString()),
                 "META-INF/*"
         ]
     }

--- a/native-maven-plugin/docs/architecture.md
+++ b/native-maven-plugin/docs/architecture.md
@@ -86,6 +86,8 @@ without depending on external publication.
 Samples under `samples/` provide cross-plugin Maven scenarios when possible. Dedicated
 `native-maven-plugin/reproducers/` projects are appropriate for Maven-specific regressions whose
 shape would not make sense as a shared sample.
+Assertions for process-reported paths must derive expected values from canonical existing files so
+filesystem aliases do not create host-specific failures.
 
 ## 7. Dependency direction
 

--- a/native-maven-plugin/docs/functional/resources-and-metadata.md
+++ b/native-maven-plugin/docs/functional/resources-and-metadata.md
@@ -24,6 +24,8 @@ repository contents. When no URI, version, or local path is pinned, the Maven de
 the repository-wide freshness goal in [§root/GOAL-fresh-metadata](../../../docs/spec/goals.md#goal-fresh-metadata-users-can-fetch-the-latest-graalvm-reachability-metadata).
 Normal Maven output must identify the selected metadata repository version
 or, when a version is not known for a local path or arbitrary URL, the selected repository source.
+For a local repository source, that output must use its canonical file URI so filesystem aliases
+do not make the reported location ambiguous across supported platforms.
 This keeps important integration state visible without flooding build logs, as required by
 [§root/GOAL-concise-actionable-output](../../../docs/spec/goals.md#goal-concise-actionable-output-build-output-is-concise-actionable-and-token-efficient).
 

--- a/native-maven-plugin/docs/functional/tracing-agent.md
+++ b/native-maven-plugin/docs/functional/tracing-agent.md
@@ -30,6 +30,8 @@ When Maven configures an instrumented test or application execution, normal buil
 output must report the Maven-managed agent output directory so users can find collected metadata
 without debug logging, aligning with
 [§root/GOAL-concise-actionable-output](../../../docs/spec/goals.md#goal-concise-actionable-output-build-output-is-concise-actionable-and-token-efficient).
+The reported directory must be canonicalized so filesystem aliases do not produce
+platform-dependent locations.
 
 ## 4. Merge and copy
 

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
@@ -83,7 +83,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
         and:
         // Instrumented execution output reports the Maven-managed agent output directory. §FS-tracing-agent.3.
         outputContains "Instrumenting Maven test execution with the native-image-agent. Agent output: " +
-                file('target/native/agent-output/test').absolutePath
+                file('target/native/agent-output/test').canonicalPath
 
         and:
         // Agent generates files
@@ -129,7 +129,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
         and:
         // Instrumented execution output reports the Maven-managed agent output directory. §FS-tracing-agent.3.
         outputContains "Instrumenting Maven application execution with the native-image-agent. Agent output: " +
-                file('target/native/agent-output/main').absolutePath
+                file('target/native/agent-output/main').canonicalPath
 
         when:
         mvn'-Pnative', '-DquickBuild', '-DskipNativeTests', '-Dagent=true', 'native:metadata-copy'

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -205,6 +205,9 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractGraalVMMavenFun
                     </execution>
                 </executions>
             </plugin>'''
+        def lineSeparator = pom.text.contains("\r\n") ? "\r\n" : "\n"
+        buildStart = buildStart.replace("\n", lineSeparator)
+        configuredBuildStart = configuredBuildStart.replace("\n", lineSeparator)
         assert pom.text.contains(buildStart)
         pom.text = pom.text.replace(buildStart, configuredBuildStart)
     }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
@@ -69,7 +69,7 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         outputContains "Hello, from reflection!"
         // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
         outputContains "Using GraalVM reachability metadata repository from " +
-                file("config-directory").toURI().toASCIIString()
+                file("config-directory").canonicalFile.toURI().toASCIIString()
 
         and: "it doesn't find a configuration directory for the current version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory not found. Trying latest version."
@@ -126,7 +126,7 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration is forced to version 2"
         // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
         outputContains "Using GraalVM reachability metadata repository from " +
-                file("config-directory").toURI().toASCIIString()
+                file("config-directory").canonicalFile.toURI().toASCIIString()
         outputContains "Reflection failed"
     }
 
@@ -142,7 +142,7 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         outputContains "Hello, from reflection!"
         // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
         outputContains "Using GraalVM reachability metadata repository from " +
-                file("target/repo.zip").toURI().toASCIIString()
+                file("target/repo.zip").canonicalFile.toURI().toASCIIString()
 
         and: "it doesn't find a configuration directory for the current version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory not found. Trying latest version."

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeMojo.java
@@ -184,7 +184,7 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
                 return "version " + metadataRepositoryConfiguration.getVersion();
             }
             if (metadataRepositoryConfiguration.getLocalPath() != null) {
-                return "from " + metadataRepositoryConfiguration.getLocalPath().toURI().toASCIIString();
+                return "from " + canonicalFileUri(metadataRepositoryConfiguration.getLocalPath());
             }
             if (metadataRepositoryConfiguration.getUrl() != null) {
                 return "from " + metadataRepositoryConfiguration.getUrl();
@@ -311,7 +311,7 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
     protected String describeMetadataRepositoryLocation() {
         if (metadataRepositoryConfiguration != null) {
             if (metadataRepositoryConfiguration.getLocalPath() != null) {
-                return metadataRepositoryConfiguration.getLocalPath().toURI().toASCIIString();
+                return canonicalFileUri(metadataRepositoryConfiguration.getLocalPath());
             }
             if (metadataRepositoryConfiguration.getUrl() != null) {
                 return metadataRepositoryConfiguration.getUrl().toString();
@@ -325,6 +325,14 @@ public abstract class AbstractNativeMojo extends AbstractMojo {
             return resolved.toString();
         }
         return String.format(METADATA_REPO_URL_TEMPLATE, VersionInfo.METADATA_REPO_VERSION);
+    }
+
+    private static String canonicalFileUri(File file) {
+        try {
+            return file.getCanonicalFile().toURI().toASCIIString();
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot resolve metadata repository path " + file, e);
+        }
     }
 
     public boolean isArtifactExcludedFromMetadataRepository(Artifact dependency) {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
@@ -57,6 +57,7 @@ import org.graalvm.buildtools.utils.AgentUtils;
 import org.graalvm.buildtools.utils.SharedConstants;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -260,9 +261,17 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
 
     private static void logAgentOutput(String baseDir, Context context) {
         String execution = context == Context.test ? "test" : "application";
-        String outputDirectory = new File(agentOutputDirectoryFor(baseDir, context)).getAbsolutePath();
+        String outputDirectory = canonicalPath(new File(agentOutputDirectoryFor(baseDir, context)));
         // Report where users can find generated tracing-agent metadata. §FS-tracing-agent.3.
         logger.info("Instrumenting Maven " + execution + " execution with the native-image-agent. Agent output: " + outputDirectory);
+    }
+
+    private static String canonicalPath(File file) {
+        try {
+            return file.getCanonicalPath();
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot resolve agent output path " + file, e);
+        }
     }
 
     private static void configureJunitListener(Plugin surefirePlugin, String testIdsDir) {


### PR DESCRIPTION
## Summary

- normalize classpath-directory resource names before filtering and resource-pattern generation
- add a nested-resource regression test for portable separators
- canonicalize Gradle and Maven functional-test path expectations so macOS and Windows filesystem aliases do not cause false failures
- temporarily run snapshot PR functional-test matrices on Ubuntu, Windows, and macOS

## Validation

- `grund check`
- `:utils:test --tests org.graalvm.buildtools.utils.ClassPathEntryAnalyzerTest`
- targeted Gradle resource, metadata repository, and agent functional tests with GraalVM 25.0.3
- targeted Maven resource, metadata repository, and agent functional tests with GraalVM 25.0.3
- generated Gradle and Maven matrices include `ubuntu-22.04`, `windows-latest`, and `macos-latest`

## Temporary CI commit

The final `[TEST-ONLY]` commit intentionally expands snapshot PR coverage to all three operating systems. It should be removed after the cross-platform checks confirm the fixes.

Fixes: #973
Fixes: #974