### PR TITLE
Normalize platform-dependent resource and test paths

### DIFF
--- a/common/utils/src/main/java/org/graalvm/buildtools/model/resources/ClassPathDirectoryAnalyzer.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/model/resources/ClassPathDirectoryAnalyzer.java
@@ -106,7 +106,8 @@ class ClassPathDirectoryAnalyzer extends ClassPathEntryAnalyzer {
                 hasNativeImageResourceFile = true;
                 return FileVisitResult.TERMINATE;
             }
-            maybeAddResource(root.relativize(file).toString(), resources);
+            // Native Image resource names use portable separators. §FS-common-libraries.2.
+            maybeAddResource(relativePathOf(file), resources);
             return FileVisitResult.CONTINUE;
         }
     }

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/ClassPathEntryAnalyzerTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/ClassPathEntryAnalyzerTest.java
@@ -43,14 +43,20 @@ package org.graalvm.buildtools.utils;
 import org.graalvm.buildtools.model.resources.ClassPathEntryAnalyzer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ClassPathEntryAnalyzerTest {
+    @TempDir
+    Path temporaryDirectory;
+
     @Test
     @DisplayName("A non existent jar shouldn't cause an exception")
     public void testShouldAllowNonExistentJar() throws IOException {
@@ -71,5 +77,22 @@ public class ClassPathEntryAnalyzerTest {
                 false
         );
         assertEquals(Collections.emptyList(), analyzer.getResources());
+    }
+
+    @Test
+    @DisplayName("Directory resources should use portable path separators")
+    public void testShouldNormalizeDirectoryResourcePathSeparators() throws IOException {
+        Path resource = temporaryDirectory.resolve("org/graalvm/demo/expected.txt");
+        Files.createDirectories(resource.getParent());
+        Files.writeString(resource, "resource");
+
+        ClassPathEntryAnalyzer analyzer = ClassPathEntryAnalyzer.of(
+                temporaryDirectory.toFile(),
+                path -> true,
+                false
+        );
+
+        // Directory scanning emits portable Native Image resource names. §FS-common-libraries.2.
+        assertEquals(Collections.singletonList("org/graalvm/demo/expected.txt"), analyzer.getResources());
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -394,7 +394,7 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
 
     // Windows keeps Native Image options in an argument file by default. §FS-native-invocation.3.
     private boolean nativeImageInvocationContains(String taskName, String expectedArgument) {
-        if (outputContains(expectedArgument)) {
+        if (result.output.contains(expectedArgument)) {
             return true
         }
         def matcher = result.output =~ /\[native-image-plugin\] Args are: \[@(.+?\.args), /

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -191,6 +191,7 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         withSample("java-application")
         buildFile << """
             graalvmNative {
+                useArgFile = true
                 binaries.all {
                     richOutput = true
                     verbose = true
@@ -392,7 +393,7 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         outputContains "PGO: user-provided"
     }
 
-    // Windows keeps Native Image options in an argument file by default. §FS-native-invocation.3.
+    // This scenario uses an argument file so console-color assertions are deterministic on every OS. §FS-native-invocation.3.
     private boolean nativeImageInvocationContains(String taskName, String expectedArgument) {
         if (result.output.contains(expectedArgument)) {
             return true

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationFunctionalTest.groovy
@@ -205,7 +205,7 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         tasks {
             succeeded ':nativeCompile'
         }
-        outputContains expectedColorArgument
+        nativeImageInvocationContains('nativeCompile', expectedColorArgument)
 
         where:
         console | expectedColorArgument
@@ -390,6 +390,19 @@ class JavaApplicationFunctionalTest extends AbstractFunctionalTest {
         }
         outputContains "--pgo="
         outputContains "PGO: user-provided"
+    }
+
+    // Windows keeps Native Image options in an argument file by default. §FS-native-invocation.3.
+    private boolean nativeImageInvocationContains(String taskName, String expectedArgument) {
+        if (outputContains(expectedArgument)) {
+            return true
+        }
+        def matcher = result.output =~ /\[native-image-plugin\] Args are: \[@(.+?\.args), /
+        if (!matcher.find()) {
+            return false
+        }
+        def workingDirectory = path('build', 'native', taskName)
+        Files.readAllLines(workingDirectory.resolve(matcher.group(1)).normalize()).contains(expectedArgument)
     }
 
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/JavaApplicationWithAgentFunctionalTest.groovy
@@ -205,7 +205,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
 
         and:
         // Instrumented task output reports the Gradle-managed agent output directory. §FS-tracing-agent.4.
-        outputContains "Instrumenting task with the native-image-agent: test. Agent output: ${file('build/native/agent-output/test').path}"
+        outputContains "Instrumenting task with the native-image-agent: test. Agent output: ${file('build/native/agent-output/test').canonicalPath}"
         assert metadataExistsAt("build/native/agent-output/test")
 
         when:
@@ -260,7 +260,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractFunctionalTest {
 
         and:
         // Instrumented task output reports the Gradle-managed agent output directory. §FS-tracing-agent.4.
-        outputContains "Instrumenting task with the native-image-agent: run. Agent output: ${file('build/native/agent-output/run').path}"
+        outputContains "Instrumenting task with the native-image-agent: run. Agent output: ${file('build/native/agent-output/run').canonicalPath}"
         assert metadataExistsAt("build/native/agent-output/run")
 
         when:

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeConfigRepoFunctionalTest.groovy
@@ -82,7 +82,7 @@ class NativeConfigRepoFunctionalTest extends AbstractFunctionalTest {
         and: "identifies the selected metadata repository source"
         // Gradle output identifies the selected metadata repository source. §FS-resources-and-metadata.3.
         outputContains "Using GraalVM reachability metadata repository from " +
-                file("config-directory${extension ? '.' + extension : ''}").toURI().toASCIIString()
+                file("config-directory${extension ? '.' + extension : ''}").canonicalFile.toURI().toASCIIString()
 
         and: "doesn't find a configuration directory for the current version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory not found. Trying latest version."
@@ -98,8 +98,8 @@ class NativeConfigRepoFunctionalTest extends AbstractFunctionalTest {
         'tar.bz2' | 'tar.bz2 file'
     }
 
-    // Protects custom binary runtime classpath and metadata exclusions. §FS-plugin-model.4
-    // §FS-native-tasks.1 §FS-resources-and-metadata.6
+    // Protects custom binary runtime classpath and metadata exclusions through argument files.
+    // §FS-plugin-model.4 §FS-native-tasks.1 §FS-native-invocation.4 §FS-resources-and-metadata.6
     @Issue("https://github.com/graalvm/native-build-tools/issues/478")
     def "custom binary uses runtime classpath and metadata exclusions"() {
         given:
@@ -107,7 +107,7 @@ class NativeConfigRepoFunctionalTest extends AbstractFunctionalTest {
 
         buildFile << """
 graalvmNative {
-    useArgFile = false
+    useArgFile = true
     binaries {
         qa {
             imageName = 'native-config-integration-qa'
@@ -128,8 +128,9 @@ graalvmNative {
 
         and:
         outputContains "Hello, from reflection!"
-        outputContains "--exclude-config"
-        outputContains "library-with-reflection-1.5.jar"
+        def nativeImageArgs = nativeImageArgsFor("nativeQaCompile")
+        nativeImageArgs.contains("--exclude-config")
+        nativeImageArgs.any { it.contains("library-with-reflection-1.5.jar") }
     }
 
     def "can exclude a dependency from native configuration"() {
@@ -246,6 +247,13 @@ project(':second') {
 
     private static File metadataConfig(Path repository) {
         repository.resolve("org.graalvm.internal/library-with-reflection/1/reflect-config.json").toFile()
+    }
+
+    private List<String> nativeImageArgsFor(String taskName) {
+        def matcher = result.output =~ /\[native-image-plugin\] Args are: \[@(.+?\.args), /
+        assert matcher.find(): "Expected native-image argument file in output"
+        Path workingDirectory = path("build", "native", taskName)
+        Files.readAllLines(workingDirectory.resolve(matcher.group(1)).normalize())
     }
 
     private File metadataOutput(String projectName) {

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
@@ -83,7 +83,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
         and:
         // Instrumented execution output reports the Maven-managed agent output directory. §FS-tracing-agent.3.
         outputContains "Instrumenting Maven test execution with the native-image-agent. Agent output: " +
-                file('target/native/agent-output/test').absolutePath
+                file('target/native/agent-output/test').canonicalPath
 
         and:
         // Agent generates files
@@ -129,7 +129,7 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
         and:
         // Instrumented execution output reports the Maven-managed agent output directory. §FS-tracing-agent.3.
         outputContains "Instrumenting Maven application execution with the native-image-agent. Agent output: " +
-                file('target/native/agent-output/main').absolutePath
+                file('target/native/agent-output/main').canonicalPath
 
         when:
         mvn'-Pnative', '-DquickBuild', '-DskipNativeTests', '-Dagent=true', 'native:metadata-copy'

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithAgentFunctionalTest.groovy
@@ -82,8 +82,9 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
 
         and:
         // Instrumented execution output reports the Maven-managed agent output directory. §FS-tracing-agent.3.
-        outputContains "Instrumenting Maven test execution with the native-image-agent. Agent output: " +
-                file('target/native/agent-output/test').canonicalPath
+        outputContainsAbsoluteOrCanonicalPath(
+                "Instrumenting Maven test execution with the native-image-agent. Agent output: ",
+                file('target/native/agent-output/test'))
 
         and:
         // Agent generates files
@@ -128,8 +129,9 @@ class JavaApplicationWithAgentFunctionalTest extends AbstractGraalVMMavenFunctio
 
         and:
         // Instrumented execution output reports the Maven-managed agent output directory. §FS-tracing-agent.3.
-        outputContains "Instrumenting Maven application execution with the native-image-agent. Agent output: " +
-                file('target/native/agent-output/main').canonicalPath
+        outputContainsAbsoluteOrCanonicalPath(
+                "Instrumenting Maven application execution with the native-image-agent. Agent output: ",
+                file('target/native/agent-output/main'))
 
         when:
         mvn'-Pnative', '-DquickBuild', '-DskipNativeTests', '-Dagent=true', 'native:metadata-copy'

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithResourcesFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationWithResourcesFunctionalTest.groovy
@@ -205,8 +205,9 @@ class JavaApplicationWithResourcesFunctionalTest extends AbstractGraalVMMavenFun
                     </execution>
                 </executions>
             </plugin>'''
-        assert pom.text.contains(buildStart)
-        pom.text = pom.text.replace(buildStart, configuredBuildStart)
+        def pomText = pom.text.replace('\r\n', '\n')
+        assert pomText.contains(buildStart)
+        pom.text = pomText.replace(buildStart, configuredBuildStart)
     }
 
     private static void assertResourcePatterns(File configFile, List<String> expectedPatterns) {

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
@@ -69,7 +69,7 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         outputContains "Hello, from reflection!"
         // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
         outputContains "Using GraalVM reachability metadata repository from " +
-                file("config-directory").toURI().toASCIIString()
+                file("config-directory").canonicalFile.toURI().toASCIIString()
 
         and: "it doesn't find a configuration directory for the current version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory not found. Trying latest version."
@@ -126,7 +126,7 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration is forced to version 2"
         // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
         outputContains "Using GraalVM reachability metadata repository from " +
-                file("config-directory").toURI().toASCIIString()
+                file("config-directory").canonicalFile.toURI().toASCIIString()
         outputContains "Reflection failed"
     }
 
@@ -142,7 +142,7 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         outputContains "Hello, from reflection!"
         // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
         outputContains "Using GraalVM reachability metadata repository from " +
-                file("target/repo.zip").toURI().toASCIIString()
+                file("target/repo.zip").canonicalFile.toURI().toASCIIString()
 
         and: "it doesn't find a configuration directory for the current version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory not found. Trying latest version."

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/MetadataRepositoryFunctionalTest.groovy
@@ -68,8 +68,9 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         buildSucceeded
         outputContains "Hello, from reflection!"
         // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
-        outputContains "Using GraalVM reachability metadata repository from " +
-                file("config-directory").canonicalFile.toURI().toASCIIString()
+        outputContainsAbsoluteOrCanonicalUri(
+                "Using GraalVM reachability metadata repository from ",
+                file("config-directory"))
 
         and: "it doesn't find a configuration directory for the current version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory not found. Trying latest version."
@@ -125,8 +126,9 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         buildSucceeded
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration is forced to version 2"
         // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
-        outputContains "Using GraalVM reachability metadata repository from " +
-                file("config-directory").canonicalFile.toURI().toASCIIString()
+        outputContainsAbsoluteOrCanonicalUri(
+                "Using GraalVM reachability metadata repository from ",
+                file("config-directory"))
         outputContains "Reflection failed"
     }
 
@@ -141,8 +143,9 @@ class MetadataRepositoryFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         buildSucceeded
         outputContains "Hello, from reflection!"
         // Maven output identifies the selected metadata repository source. §FS-resources-and-metadata.2.
-        outputContains "Using GraalVM reachability metadata repository from " +
-                file("target/repo.zip").canonicalFile.toURI().toASCIIString()
+        outputContainsAbsoluteOrCanonicalUri(
+                "Using GraalVM reachability metadata repository from ",
+                file("target/repo.zip"))
 
         and: "it doesn't find a configuration directory for the current version"
         outputContains "[graalvm reachability metadata repository for org.graalvm.internal:library-with-reflection:1.5]: Configuration directory not found. Trying latest version."

--- a/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/AbstractGraalVMMavenFunctionalTest.groovy
+++ b/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/AbstractGraalVMMavenFunctionalTest.groovy
@@ -218,6 +218,18 @@ abstract class AbstractGraalVMMavenFunctionalTest extends Specification {
         normalizeString(result.stdOut).contains(normalizeString(text))
     }
 
+    // Temp directories can be reported through equivalent aliases (macOS symlinks or Windows 8.3 paths).
+    // §E2E-functional-tests.3.5 §E2E-functional-tests.3.6
+    boolean outputContainsAbsoluteOrCanonicalPath(String prefix, File location) {
+        [location.absolutePath, location.canonicalPath].any { path -> outputContains(prefix + path) }
+    }
+
+    boolean outputContainsAbsoluteOrCanonicalUri(String prefix, File location) {
+        [location.absoluteFile, location.canonicalFile]
+                .collect { file -> file.toURI().toASCIIString() }
+                .any { uri -> outputContains(prefix + uri) }
+    }
+
     boolean outputContainsPattern(String pattern) {
         def normalizedOutput = normalizeString(result.stdOut)
         def lines = normalizedOutput.split('\n')


### PR DESCRIPTION
## Problem

This PR addresses two cross-platform problems:

1. **Windows resource autodetection produced invalid resource names.** Classpath-directory scanning passed `Path.toString()` directly to resource-pattern generation, producing backslash-separated names such as `org\\graalvm\\demo\\expected.txt`. Native Image resource names use portable `/` separators, so nested resources could be missing from Windows native images.
2. **Functional tests assumed one textual representation of paths and arguments.** Equivalent temporary locations are reported differently across platforms—for example `/var/...` versus `/private/var/...` on macOS and `RUNNER~1` versus `runneradmin` on Windows. Windows also defaults to Native Image argument files, and checked-out Maven samples use CRLF. The builds succeeded, but exact string assertions failed.

## Fix

### Portable resource discovery

- route directory resource names through the existing separator-normalization helper before generating resource patterns
- add regression coverage proving nested directory resources use names such as `org/graalvm/demo/expected.txt`

### Portable functional tests

- accept equivalent absolute and canonical temporary-path representations in Maven agent-output assertions
- construct metadata-repository expectations from equivalent file URI representations
- use normalized separators in path-bearing assertions
- explicitly use and inspect a Native Image `@args` file for the Gradle console-color scenario on every operating system
- inspect Gradle argument-file contents when validating custom binary metadata exclusions
- normalize CRLF before the Maven resource fixture matches and modifies its sample POM

## Testing

Validation performed during initial development:

- `grund check`
- `./gradlew :utils:test :utils:checkstyleMain :utils:checkstyleTest :native-gradle-plugin:compileFunctionalTestGroovy :native-maven-plugin:compileFunctionalTestGroovy`
- affected Gradle functional scenarios with GraalVM 25.0.3 (6 passed)
- affected Maven functional scenarios with GraalVM 25.0.3 (5 passed)

Cross-platform validation:

- exercised the generated Gradle and Maven functional-test matrices on `ubuntu-22.04`, `windows-latest`, and `macos-latest` using a temporary test-only commit
- fixed the platform-specific path, line-ending, and argument-file assertions exposed by that matrix
- all CI tests passed before removing the temporary test-only commit from this PR
- `grund check`
- `git diff --check`

Closes #973
Closes #974
