### PR TITLE
Preserve test runner argLine when configuring agent

### DIFF
--- a/native-maven-plugin/docs/functional/tracing-agent.md
+++ b/native-maven-plugin/docs/functional/tracing-agent.md
@@ -25,7 +25,8 @@ the destination. Application agent runs are attached to the `exec-maven-plugin` 
 the native plugin's `<agentExecutionId>` configuration value; the default execution ID is
 `java-agent` so existing POMs keep working. Generated test-agent arguments derived from project paths
 must remain a single JVM argument when passed through Maven test runners, including when those paths
-contain spaces.
+contain spaces. When adding that argument, Maven must preserve the test runner's existing `argLine`
+options.
 When Maven configures an instrumented test or application execution, normal build
 output must report the Maven-managed agent output directory so users can find collected metadata
 without debug logging, aligning with

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeExtension.java
@@ -141,6 +141,13 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
         return agentArgument;
     }
 
+    static String appendAgentArgument(String existingArgLine, String agentArgument) {
+        String quotedAgentArgument = quoteAgentArgumentForArgLine(agentArgument);
+        return existingArgLine == null || existingArgLine.isBlank()
+                ? quotedAgentArgument
+                : existingArgLine + " " + quotedAgentArgument;
+    }
+
     static String agentOutputDirectoryFor(String baseDir, Context context) {
         return (baseDir + "/native/agent-output/" + context).replace('/', File.separatorChar);
     }
@@ -309,11 +316,10 @@ public class NativeExtension extends AbstractMavenLifecycleParticipant implement
             Xpp3Dom systemPropertyVariables = findOrAppend(configuration, SYSTEM_PROPERTY_VARIABLES);
             Xpp3Dom agent = findOrAppend(systemPropertyVariables, NATIVEIMAGE_IMAGECODE);
             agent.setValue("agent");
-            Xpp3Dom argLine = new Xpp3Dom("argLine");
+            Xpp3Dom argLine = findOrAppend(configuration, "argLine");
             // Surefire/Failsafe parse argLine as one command-line string.
-            // Keep spaced output paths as one JVM argument. §FS-tracing-agent.3.
-            argLine.setValue(quoteAgentArgumentForArgLine(agentArgument));
-            configuration.addChild(argLine);
+            // Preserve user-supplied JVM options while keeping spaced output paths as one argument. §FS-tracing-agent.3.
+            argLine.setValue(appendAgentArgument(argLine.getValue(), agentArgument));
             findOrAppend(configuration, "jvm").setValue(getGraalvmJava());
         });
         return true;

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
@@ -158,6 +158,15 @@ class NativeExtensionTest extends Specification {
         execution
     }
 
+    def "appends the test agent argument to an existing test runner argLine"() {
+        given:
+        def agentArgument = "-agentlib:native-image-agent=config-output-dir=target/native/agent-output/test"
+
+        expect:
+        NativeExtension.appendAgentArgument("-javaagent:existing-agent.jar", agentArgument) ==
+                "-javaagent:existing-agent.jar " + agentArgument
+    }
+
     private static Plugin plugin(String artifactId) {
         def plugin = new Plugin()
         plugin.artifactId = artifactId


### PR DESCRIPTION
Preserves a configured Surefire or Failsafe `argLine` when the Native Image tracing agent is added.

Includes a regression test and Maven tracing-agent specification update.

Supersedes #615. The original implementation and intent are credited to @AndreyChukhlebov. This replacement PR is authored by @jormundur00 because the original contributor has not signed the Oracle Contributor Agreement.