### PR TITLE
Suppress missing Javadoc diagnostics across convention tasks

### DIFF
--- a/build-logic/common-plugins/src/main/kotlin/org.graalvm.build.java.gradle.kts
+++ b/build-logic/common-plugins/src/main/kotlin/org.graalvm.build.java.gradle.kts
@@ -78,8 +78,10 @@ extensions.findByType<VersionCatalogsExtension>()?.also { catalogs ->
     }
 }
 
-tasks.javadoc {
+// Shared Javadoc validation keeps every non-missing doclint check enabled. §FS-build-infrastructure.2.1.
+tasks.withType<Javadoc>().configureEach {
     (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
+    (options as StandardJavadocDocletOptions).addBooleanOption("Xdoclint:all,-missing", true)
     (options as StandardJavadocDocletOptions).noTimestamp(true)
 }
 

--- a/docs/spec/functional/build-infrastructure.md
+++ b/docs/spec/functional/build-infrastructure.md
@@ -76,6 +76,10 @@ settings, Maven publication repositories and POM metadata, shared version catalo
 Checkstyle configuration, documentation rendering, Gradle functional-test wiring, and common local
 repository exposure for composite builds.
 
+The shared Java convention must configure every Javadoc task to run all doclint checks except the
+missing-documentation category. Missing API comments and missing `@param`, `@return`, and `@throws`
+tags must not produce warnings, while all other doclint categories remain enabled.
+
 Convention plugins may add tasks and configurations to modules that apply them. Those additions
 are maintainer-facing build behavior, not runtime behavior of the Native Build Tools plugins.
 


### PR DESCRIPTION
## What changed

Javadoc tasks configured by the shared Java convention now suppress only missing-documentation diagnostics. Missing API comments and missing `@param`, `@return`, and `@throws` tags no longer flood Maven preparation output, while the other doclint checks remain enabled.

## Why

Running Maven test preparation could reach Javadoc's warning display cap, making useful build output difficult to find. This keeps routine output concise without disabling meaningful Javadoc validation or adding API prose solely to silence warnings.

## Example

Before, `:utils:javadoc` could report 93 `no comment` warnings and additional incomplete-tag warnings before reaching Javadoc's 100-warning cap. With this change, those missing-documentation diagnostics are suppressed, while other doclint failures still fail or report normally.

## Implementation summary

- Applied the shared policy to every `Javadoc` task configured through `org.graalvm.build.java`.
- Configured `-Xdoclint:all,-missing`, preserving all non-missing doclint checks.
- Documented the policy in the build-infrastructure specification.

## Validation

- `./gradlew publishToMavenLocal --no-parallel` — passed on Gradle JDK 17.0.12.
- Focused Javadoc-output checks — confirmed no `no comment`, missing `@param`, missing `@return`, or missing `@throws` diagnostics, and audited generated option files for `-Xdoclint:all,-missing`.
- `:utils:javadoc` was force-rerun; the wider publication run also included cached or up-to-date Javadoc tasks.
- Full `assemble`, `test`, and `build` suites, documentation rendering, and the complete CI OS/JDK matrix were not run; CI should cover those remaining environments.

Fixes #987
