### PR TITLE
Deprecate fallback plugin options

### DIFF
--- a/common/docs/functional-spec.md
+++ b/common/docs/functional-spec.md
@@ -27,9 +27,10 @@ required by [§REQ-no-buildtool-apis](requirements.md#req-no-buildtool-apis-comm
 Common utilities keep Gradle and Maven command-line handling consistent. They must preserve
 whitespace, quotes, backslashes, and platform paths when escaping arguments; write Native Image
 argument files and return the corresponding `@...` argument ([§root/GLOSS-argument-file](../../docs/spec/glossary.md#gloss-argument-file-native-image-argument-file)); distinguish the GraalVM release from the JDK version in Native Image version output well enough to
-choose version-specific behavior, retaining compatibility behavior when the GraalVM release cannot
-be identified; and centralize Native Image configuration file names and metadata directory names
-used by plugins and tests.
+choose version-specific behavior, using the first dotted release on a runtime-environment line
+regardless of its vendor label and retaining compatibility behavior when that release cannot be
+identified; and centralize Native Image configuration file names and metadata directory names used
+by plugins and tests.
 
 ## 2. Resource configuration
 

--- a/common/docs/functional-spec.md
+++ b/common/docs/functional-spec.md
@@ -26,9 +26,10 @@ required by [§REQ-no-buildtool-apis](requirements.md#req-no-buildtool-apis-comm
 
 Common utilities keep Gradle and Maven command-line handling consistent. They must preserve
 whitespace, quotes, backslashes, and platform paths when escaping arguments; write Native Image
-argument files and return the corresponding `@...` argument ([§root/GLOSS-argument-file](../../docs/spec/glossary.md#gloss-argument-file-native-image-argument-file)); parse Native
-Image and JDK versions well enough to choose version-specific behavior; and centralize Native
-Image configuration file names and metadata directory names used by plugins and tests.
+argument files and return the corresponding `@...` argument ([§root/GLOSS-argument-file](../../docs/spec/glossary.md#gloss-argument-file-native-image-argument-file)); distinguish the GraalVM release from the JDK version in Native Image version output well enough to
+choose version-specific behavior, retaining compatibility behavior when the GraalVM release cannot
+be identified; and centralize Native Image configuration file names and metadata directory names
+used by plugins and tests.
 
 ## 2. Resource configuration
 

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
@@ -65,8 +65,8 @@ public class NativeImageUtils {
     private static final Pattern javaVersionPattern = Pattern.compile("^native-image ([0-9]+).*", Pattern.DOTALL);
     private static final Pattern javaVersionLegacyPattern = Pattern.compile(".* \\(Java Version ([0-9]+)\\.([0-9]+)\\.([0-9]+).*");
 
-    private static final Pattern graalvmRuntimeVersionPattern = Pattern.compile(
-            "^GraalVM Runtime Environment .*?\\b([0-9]+)\\.([0-9]+)(?:\\.[0-9]+)?(?:[-+\\s].*)?$",
+    private static final Pattern runtimeVersionPattern = Pattern.compile(
+            "^[^\\r\\n]*Runtime Environment\\s+.*?\\b([0-9]+)\\.([0-9]+)(?:\\.[0-9]+)*\\b",
             Pattern.MULTILINE);
 
 
@@ -196,9 +196,10 @@ public class NativeImageUtils {
     }
 
     /**
-     * Checks the GraalVM release reported by {@code native-image --version}, which may differ from
-     * the JDK version on the first output line. Unknown formats are treated conservatively as not
-     * satisfying the requested version. §FS-common-libraries.1.
+     * Checks the GraalVM release reported on the runtime-environment line of
+     * {@code native-image --version}, which may differ from the JDK version on the first output
+     * line. Unknown formats are treated conservatively as not satisfying the requested version.
+     * §FS-common-libraries.1.
      *
      * @param versionString output returned by {@code native-image --version}
      * @param requiredMajor required GraalVM release major version
@@ -206,7 +207,7 @@ public class NativeImageUtils {
      * @return whether a recognized GraalVM release is at least the requested major and minor
      */
     public static boolean isGraalVMVersionAtLeast(String versionString, int requiredMajor, int requiredMinor) {
-        Matcher matcher = graalvmRuntimeVersionPattern.matcher(versionString.trim());
+        Matcher matcher = runtimeVersionPattern.matcher(versionString.trim());
         if (!matcher.find()) {
             return false;
         }

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
@@ -65,6 +65,10 @@ public class NativeImageUtils {
     private static final Pattern javaVersionPattern = Pattern.compile("^native-image ([0-9]+).*", Pattern.DOTALL);
     private static final Pattern javaVersionLegacyPattern = Pattern.compile(".* \\(Java Version ([0-9]+)\\.([0-9]+)\\.([0-9]+).*");
 
+    private static final Pattern graalvmRuntimeVersionPattern = Pattern.compile(
+            "^GraalVM Runtime Environment .*?\\b([0-9]+)\\.([0-9]+)(?:\\.[0-9]+)?(?:[-+\\s].*)?$",
+            Pattern.MULTILINE);
+
 
     private static final Pattern SAFE_SHELL_ARG = Pattern.compile("[A-Za-z0-9@%_\\-+=:,./]+");
 
@@ -189,5 +193,25 @@ public class NativeImageUtils {
             return Integer.parseInt(legacyMatcher.group(1));
         }
         return -1;
+    }
+
+    /**
+     * Checks the GraalVM release reported by {@code native-image --version}, which may differ from
+     * the JDK version on the first output line. Unknown formats are treated conservatively as not
+     * satisfying the requested version. §FS-common-libraries.1.
+     *
+     * @param versionString output returned by {@code native-image --version}
+     * @param requiredMajor required GraalVM release major version
+     * @param requiredMinor required GraalVM release minor version
+     * @return whether a recognized GraalVM release is at least the requested major and minor
+     */
+    public static boolean isGraalVMVersionAtLeast(String versionString, int requiredMajor, int requiredMinor) {
+        Matcher matcher = graalvmRuntimeVersionPattern.matcher(versionString.trim());
+        if (!matcher.find()) {
+            return false;
+        }
+        int major = Integer.parseInt(matcher.group(1));
+        int minor = Integer.parseInt(matcher.group(2));
+        return major > requiredMajor || major == requiredMajor && minor >= requiredMinor;
     }
 }

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageUtilsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageUtilsTest.java
@@ -185,6 +185,29 @@ class NativeImageUtilsTest {
     }
 
     @Test
+    void recognizesRuntimeReleaseAcrossDistributions() {
+        String oracleGraalVM250 = "native-image 25.0.3 2026-04-21\n" +
+                "GraalVM Runtime Environment Oracle GraalVM 25.0.3+9.1 (build 25.0.3+9-LTS-jvmci-b01)\n" +
+                "Substrate VM Oracle GraalVM 25.0.3+9.1 (build 25.0.3+9-LTS, serial gc, compressed references)";
+        String mandrel250 = "native-image 25.0.3 2026-04-21\n" +
+                "OpenJDK Runtime Environment Mandrel-25.0.3.0-Final (build 25.0.3+9-LTS)\n" +
+                "OpenJDK 64-Bit Server VM Mandrel-25.0.3.0-Final (build 25.0.3+9-LTS, mixed mode)";
+        String liberica250 = "native-image 25.0.3 2026-04-21\n" +
+                "GraalVM Runtime Environment Liberica-NIK-25.0.3-2 (build 25.0.3+12-LTS)\n" +
+                "Substrate VM Liberica-NIK-25.0.3-2 (build 25.0.3+12-LTS, serial gc)";
+
+        Assertions.assertFalse(NativeImageUtils.isGraalVMVersionAtLeast(oracleGraalVM250, 25, 1));
+        Assertions.assertFalse(NativeImageUtils.isGraalVMVersionAtLeast(mandrel250, 25, 1));
+        Assertions.assertFalse(NativeImageUtils.isGraalVMVersionAtLeast(liberica250, 25, 1));
+        Assertions.assertTrue(NativeImageUtils.isGraalVMVersionAtLeast(
+                oracleGraalVM250.replace("Oracle GraalVM 25.0.3", "Oracle GraalVM 25.1.0"), 25, 1));
+        Assertions.assertTrue(NativeImageUtils.isGraalVMVersionAtLeast(
+                mandrel250.replace("Mandrel-25.0.3.0-Final", "Mandrel-25.1.0.0-Final"), 25, 1));
+        Assertions.assertTrue(NativeImageUtils.isGraalVMVersionAtLeast(
+                liberica250.replace("Liberica-NIK-25.0.3-2", "Liberica-NIK-25.1.0-1"), 25, 1));
+    }
+
+    @Test
     void treatsUnknownGraalVMReleaseAsOlder() {
         Assertions.assertFalse(NativeImageUtils.isGraalVMVersionAtLeast("native-image 25.0.3", 25, 1));
         Assertions.assertFalse(NativeImageUtils.isGraalVMVersionAtLeast("invalid", 25, 1));

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageUtilsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageUtilsTest.java
@@ -171,6 +171,26 @@ class NativeImageUtilsTest {
     }
 
     @Test
+    void distinguishesGraalVMReleaseFromJDKVersion() {
+        String graalVM250 = "native-image 25.0.3 2026-04-21\n" +
+                "GraalVM Runtime Environment Oracle GraalVM 25.0.3+9.1 (build 25.0.3+9-LTS-jvmci-b01)";
+        String graalVM251 = "native-image 25.0.3 2026-04-21\n" +
+                "GraalVM Runtime Environment Oracle GraalVM 25.1.3+9.1 (build 25.0.3+9-LTS-jvmci-25.1-b19)";
+        String graalVMCE251 = "native-image 25.0.3 2026-04-21\n" +
+                "GraalVM Runtime Environment GraalVM CE 25.1.3+9.1 (build 25.0.3+9-jvmci-25.1-b19)";
+
+        Assertions.assertFalse(NativeImageUtils.isGraalVMVersionAtLeast(graalVM250, 25, 1));
+        Assertions.assertTrue(NativeImageUtils.isGraalVMVersionAtLeast(graalVM251, 25, 1));
+        Assertions.assertTrue(NativeImageUtils.isGraalVMVersionAtLeast(graalVMCE251, 25, 1));
+    }
+
+    @Test
+    void treatsUnknownGraalVMReleaseAsOlder() {
+        Assertions.assertFalse(NativeImageUtils.isGraalVMVersionAtLeast("native-image 25.0.3", 25, 1));
+        Assertions.assertFalse(NativeImageUtils.isGraalVMVersionAtLeast("invalid", 25, 1));
+    }
+
+    @Test
     void checkLowerVersion() {
         Assertions.assertThrows(IllegalStateException.class, () ->
             NativeImageUtils.checkVersion("23", "GraalVM 22.2.1")

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -30,6 +30,11 @@ When Gradle uses its plain console, the Native Image invocation must explicitly 
 build output. Otherwise, the `richOutput` option controls Native Image's color-enabled argument,
 adapting [§root/FS-native-builds.2](../../../docs/spec/functional/native-image-builds.md#2-command-line-construction).
 
+When fallback is disabled, the invocation must include `--no-fallback` before GraalVM 25.1 but
+omit the plugin-generated argument when GraalVM 25.1 or later is positively identified. If the
+GraalVM release cannot be identified, the invocation must retain the argument for compatibility.
+Explicit user build arguments remain unchanged.
+
 For a layer created from declared JARs, the command line must use those JARs as its classpath so
 the layer input remains limited to the declaration. A layer created from packages must instead
 retain the binary classpath, which supplies the classes selected by those package names.

--- a/native-gradle-plugin/docs/functional/native-image-tasks.md
+++ b/native-gradle-plugin/docs/functional/native-image-tasks.md
@@ -45,8 +45,8 @@ same option objects as the DSL, keeping command-line experimentation aligned wit
 [§root/FS-option-precedence](../../../docs/spec/functional/option-precedence.md#fs-option-precedence-command-line-input-and-durable-configuration-produce-one-option-state).
 
 The fallback option is deprecated because Native Image removed fallback support in GraalVM 25.1.
-It remains available for compatibility with older GraalVM versions, where disabling fallback still
-produces the `--no-fallback` argument.
+It remains available for compatibility: disabling fallback produces `--no-fallback` before 25.1
+and when the GraalVM release cannot be identified, while 25.1 and later omit the generated flag.
 
 ```bash
 ./gradlew nativeCompile --quick-build-native --verbose --image-name demo-dev

--- a/native-gradle-plugin/docs/functional/native-image-tasks.md
+++ b/native-gradle-plugin/docs/functional/native-image-tasks.md
@@ -44,6 +44,10 @@ properties, environment variables, JVM args, and forced JVM args. These one-off 
 same option objects as the DSL, keeping command-line experimentation aligned with
 [§root/FS-option-precedence](../../../docs/spec/functional/option-precedence.md#fs-option-precedence-command-line-input-and-durable-configuration-produce-one-option-state).
 
+The fallback option is deprecated because Native Image removed fallback support in GraalVM 25.1.
+It remains available for compatibility with older GraalVM versions, where disabling fallback still
+produces the `--no-fallback` argument.
+
 ```bash
 ./gradlew nativeCompile --quick-build-native --verbose --image-name demo-dev
 ./gradlew nativeCompile --build-args=--initialize-at-build-time=com.example

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageCompileOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageCompileOptions.java
@@ -135,9 +135,14 @@ public interface NativeImageCompileOptions {
     Property<Boolean> getDebug();
 
     /**
+     * Native Image fallback support was removed in GraalVM 25.1, making this option a no-op there.
+     * The option remains functional with older GraalVM versions. §FS-native-tasks.4.
+     *
+     * @deprecated Native Image fallback support was removed in GraalVM 25.1.
      * @return Whether to enable fallbacks (defaults to false).
      */
     @Input
+    @Deprecated
     Property<Boolean> getFallback();
 
     /**

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -84,6 +84,7 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
     private final Provider<RegularFile> classpathJar;
     private final Provider<Boolean> useArgFile;
     private final Provider<Integer> majorJDKVersion;
+    private final Provider<Boolean> fallbackRemoved;
     private final Provider<Boolean> plainConsole;
 
     public NativeImageCommandLineProvider(Provider<NativeImageOptions> options,
@@ -93,6 +94,7 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
                                           Provider<RegularFile> classpathJar,
                                           Provider<Boolean> useArgFile,
                                           Provider<Integer> majorJDKVersion,
+                                          Provider<Boolean> fallbackRemoved,
                                           Provider<Boolean> plainConsole) {
         this.options = options;
         this.executableName = executableName;
@@ -101,6 +103,7 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         this.classpathJar = classpathJar;
         this.useArgFile = useArgFile;
         this.majorJDKVersion = majorJDKVersion;
+        this.fallbackRemoved = fallbackRemoved;
         this.plainConsole = plainConsole;
     }
 
@@ -188,7 +191,10 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
             cliArgs.add(classpathString);
         }
         appendBooleanOption(cliArgs, options.getDebug(), "-g");
-        appendBooleanOption(cliArgs, options.getFallback().map(NEGATE), NativeImageFlags.NO_FALLBACK);
+        if (!fallbackRemoved.getOrElse(false)) {
+            // GraalVM 25.1 removed fallback; unknown releases retain the compatibility flag. §FS-native-invocation.3.
+            appendBooleanOption(cliArgs, options.getFallback().map(NEGATE), NativeImageFlags.NO_FALLBACK);
+        }
         appendBooleanOption(cliArgs, options.getVerbose(), NativeImageFlags.VERBOSE);
         appendBooleanOption(cliArgs, options.getSharedLibrary(), NativeImageFlags.SHARED);
         appendBooleanOption(cliArgs, options.getQuickBuild(), NativeImageFlags.QUICK_BUILD);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -276,7 +276,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         getDisableToolchainDetection().convention(false);
     }
 
-    private List<String> buildActualCommandLineArgs(int majorJDKVersion) {
+    private List<String> buildActualCommandLineArgs(int majorJDKVersion, boolean fallbackRemoved) {
         getOptions().finalizeValue();
         return new NativeImageCommandLineProvider(
             getOptions(),
@@ -288,6 +288,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
             getClasspathJar(),
             getUseArgFile(),
             getProviders().provider(() -> majorJDKVersion),
+            getProviders().provider(() -> fallbackRemoved),
             getProviders().provider(() -> plainConsole))
             .asArguments();
     }
@@ -323,7 +324,8 @@ public abstract class BuildNativeImageTask extends DefaultTask {
             NativeImageUtils.checkVersion(options.getRequiredVersion().get(), versionString);
         }
         int majorJDKVersion = NativeImageUtils.getMajorJDKVersion(versionString);
-        List<String> args = buildActualCommandLineArgs(majorJDKVersion);
+        boolean fallbackRemoved = NativeImageUtils.isGraalVMVersionAtLeast(versionString, 25, 1);
+        List<String> args = buildActualCommandLineArgs(majorJDKVersion, fallbackRemoved);
         if (options.getVerbose().get()) {
             logger.lifecycle("Args are: " + args);
         }

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -2,6 +2,7 @@ package org.graalvm.buildtools.gradle
 
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension
 import org.graalvm.buildtools.gradle.dsl.GraalVMReachabilityMetadataRepositoryExtension
+import org.graalvm.buildtools.gradle.dsl.NativeImageCompileOptions
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
@@ -31,6 +32,13 @@ class NativeImagePluginTest extends Specification {
                 .findByType(GraalVMExtension)
                 .extensions
                 .findByType(GraalVMReachabilityMetadataRepositoryExtension)
+    }
+
+    // Protects the deprecated Gradle fallback DSL surface. §FS-native-tasks.4.
+    @Issue("https://github.com/graalvm/native-build-tools/issues/991")
+    def "marks the fallback DSL option as deprecated"() {
+        expect:
+        NativeImageCompileOptions.getMethod("getFallback").isAnnotationPresent(Deprecated)
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/424")

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -71,6 +71,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
                 project.objects.fileProperty(),
                 project.provider { false },
                 project.provider { 25 },
+                project.provider { false },
                 project.provider { false }
         ).asArguments()
 
@@ -79,6 +80,66 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
         args.contains("-DspacedProperty=value with spaces")
         !args.contains('-DpropertyName="value"')
         !args.contains('-DspacedProperty="value with spaces"')
+    }
+
+    // GraalVM 25.1 removes only the plugin-generated compatibility flag. §FS-native-invocation.3.
+    @Issue("https://github.com/graalvm/native-build-tools/issues/991")
+    def "#label the generated no-fallback argument"() {
+        given:
+        def project = newProject()
+        project.plugins.apply(ApplicationPlugin)
+        project.plugins.apply(NativeImagePlugin)
+        def options = project.extensions.getByType(GraalVMExtension).binaries.getByName("main")
+        options.excludeConfigArgs.set([])
+        options.configurationFileDirectories.setFrom([])
+
+        when:
+        def args = new NativeImageCommandLineProvider(
+                project.provider { options },
+                project.provider { "main" },
+                project.provider { testDirectory.toString() },
+                project.provider { testDirectory.toString() },
+                project.objects.fileProperty(),
+                project.provider { false },
+                project.provider { 25 },
+                project.provider { fallbackRemoved },
+                project.provider { false }
+        ).asArguments()
+
+        then:
+        args.contains(NativeImageFlags.NO_FALLBACK) == expected
+
+        where:
+        label       | fallbackRemoved | expected
+        "retains"   | false           | true
+        "suppresses" | true            | false
+    }
+
+    def "retains an explicit no-fallback argument after fallback removal"() {
+        given:
+        def project = newProject()
+        project.plugins.apply(ApplicationPlugin)
+        project.plugins.apply(NativeImagePlugin)
+        def options = project.extensions.getByType(GraalVMExtension).binaries.getByName("main")
+        options.buildArgs.add(NativeImageFlags.NO_FALLBACK)
+        options.excludeConfigArgs.set([])
+        options.configurationFileDirectories.setFrom([])
+
+        when:
+        def args = new NativeImageCommandLineProvider(
+                project.provider { options },
+                project.provider { "main" },
+                project.provider { testDirectory.toString() },
+                project.provider { testDirectory.toString() },
+                project.objects.fileProperty(),
+                project.provider { false },
+                project.provider { 25 },
+                project.provider { true },
+                project.provider { false }
+        ).asArguments()
+
+        then:
+        args.count { it == NativeImageFlags.NO_FALLBACK } == 1
     }
 
     @Issue("https://github.com/graalvm/native-build-tools/issues/892")
@@ -103,6 +164,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
                 project.objects.fileProperty(),
                 project.provider { false },
                 project.provider { 25 },
+                project.provider { false },
                 project.provider { false }
         ).asArguments()
 
@@ -141,6 +203,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
                 project.objects.fileProperty(),
                 project.provider { false },
                 project.provider { 25 },
+                project.provider { false },
                 project.provider { false }
         ).asArguments()
 
@@ -177,6 +240,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
                 project.objects.fileProperty(),
                 project.provider { false },
                 project.provider { 25 },
+                project.provider { false },
                 project.provider { false }
         ).asArguments()
 
@@ -207,6 +271,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
                 project.objects.fileProperty(),
                 project.provider { false },
                 project.provider { nativeImageVersion },
+                project.provider { false },
                 project.provider { true }
         ).asArguments()
 
@@ -241,6 +306,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
                 project.objects.fileProperty(),
                 project.provider { false },
                 project.provider { nativeImageVersion },
+                project.provider { false },
                 project.provider { false }
         ).asArguments()
 

--- a/native-maven-plugin/docs/functional/configuration-model.md
+++ b/native-maven-plugin/docs/functional/configuration-model.md
@@ -12,8 +12,9 @@ exclusions, environment variables, system properties, JVM args, configuration fi
 metadata repository settings, required Native Image version, and agent configuration.
 
 The fallback parameter is deprecated because Native Image removed fallback support in GraalVM
-25.1. It remains available for compatibility with older GraalVM versions, where setting it to
-`false` still produces the `--no-fallback` argument.
+25.1. It remains available for compatibility: setting it to `false` produces `--no-fallback`
+before 25.1 and when the GraalVM release cannot be identified, while 25.1 and later omit the
+generated flag. Explicit user build arguments remain unchanged.
 
 ## 2. Command-line properties
 

--- a/native-maven-plugin/docs/functional/configuration-model.md
+++ b/native-maven-plugin/docs/functional/configuration-model.md
@@ -11,6 +11,10 @@ shared-library output, quick build, argument-file usage, classpath, classes dire
 exclusions, environment variables, system properties, JVM args, configuration file directories,
 metadata repository settings, required Native Image version, and agent configuration.
 
+The fallback parameter is deprecated because Native Image removed fallback support in GraalVM
+25.1. It remains available for compatibility with older GraalVM versions, where setting it to
+`false` still produces the `--no-fallback` argument.
+
 ## 2. Command-line properties
 
 Configuration values documented as Maven command-line properties must be overridable through

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/JavaApplicationFunctionalTest.groovy
@@ -62,8 +62,15 @@ class JavaApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
         buildSucceeded
         outputContains NATIVE_IMAGE_EXE
         outputContains "-cp " // actual path is OS-specific (/ vs C:\)
-        outputContains "-g --no-fallback --verbose --shared -Ob"
-        def majorVersion = NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString())
+        def versionInformation = GraalVMSupport.getGraalVMHomeVersionString()
+        // GraalVM 25.1+ omits the plugin-generated compatibility flag. §FS-config-model.1.
+        if (NativeImageUtils.isGraalVMVersionAtLeast(versionInformation, 25, 1)) {
+            outputContains "-g --verbose --shared -Ob"
+            outputDoesNotContain "--no-fallback"
+        } else {
+            outputContains "-g --no-fallback --verbose --shared -Ob"
+        }
+        def majorVersion = NativeImageUtils.getMajorJDKVersion(versionInformation)
         outputContains(majorVersion >= 21 ? "--color=never" : "-H:-BuildOutputColorful")
     }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -232,7 +232,8 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
         if (debug) {
             cliArgs.add("-g");
         }
-        if (!fallback) {
+        // GraalVM 25.1 removed fallback; unknown releases retain the compatibility flag. §FS-config-model.1.
+        if (!fallback && !isFallbackRemoved()) {
             cliArgs.add("--no-fallback");
         }
         if (verbose) {
@@ -355,6 +356,12 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
         Path executable = NativeImageConfigurationUtils.getNativeImageSupportingToolchain(
                 logger, toolchainManager, session, enforceToolchain);
         return NativeImageUtils.getMajorJDKVersion(getVersionInformation(logger, executable));
+    }
+
+    protected boolean isFallbackRemoved() throws MojoExecutionException {
+        Path executable = NativeImageConfigurationUtils.getNativeImageSupportingToolchain(
+                logger, toolchainManager, session, enforceToolchain);
+        return NativeImageUtils.isGraalVMVersionAtLeast(getVersionInformation(logger, executable), 25, 1);
     }
 
     static List<String> processBuildArgs(List<String> buildArgs) {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -138,7 +138,14 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     @Parameter(property = "debug", defaultValue = "false")
     protected boolean debug;
 
+    /**
+     * Native Image fallback support was removed in GraalVM 25.1, making this parameter a no-op
+     * there. The parameter remains functional with older GraalVM versions. §FS-config-model.1.
+     *
+     * @deprecated Native Image fallback support was removed in GraalVM 25.1.
+     */
     @Parameter(property = "fallback", defaultValue = "false")
+    @Deprecated
     protected boolean fallback;
 
     @Parameter(property = "verbose", defaultValue = "false")

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
@@ -125,6 +125,39 @@ class AbstractNativeImageMojoTest extends Specification {
         args.indexOf("--color=always") < args.lastIndexOf("--color=never")
     }
 
+    // GraalVM 25.1 removes only the plugin-generated compatibility flag. §FS-config-model.1.
+    @Issue("https://github.com/graalvm/native-build-tools/issues/991")
+    def "#label the generated no-fallback argument"() {
+        given:
+        def mojo = newMojo([])
+        mojo.imageClasspath.add(testDirectory.resolve("application.jar"))
+        mojo.fallbackRemoved = fallbackRemoved
+
+        when:
+        def args = mojo.getBuildArgs()
+
+        then:
+        args.contains(NativeImageFlags.NO_FALLBACK) == expected
+
+        where:
+        label        | fallbackRemoved | expected
+        "retains"    | false           | true
+        "suppresses" | true            | false
+    }
+
+    def "retains an explicit no-fallback argument after fallback removal"() {
+        given:
+        def mojo = newMojo([NativeImageFlags.NO_FALLBACK])
+        mojo.imageClasspath.add(testDirectory.resolve("application.jar"))
+        mojo.fallbackRemoved = true
+
+        when:
+        def args = mojo.getBuildArgs()
+
+        then:
+        args.count { it == NativeImageFlags.NO_FALLBACK } == 1
+    }
+
     void "it allows empty classpath for layer-create builds"() {
         given:
         def mojo = newMojo([layerCreateArg])
@@ -174,6 +207,7 @@ class AbstractNativeImageMojoTest extends Specification {
     }
 
     private static class TestNativeImageMojo extends AbstractNativeImageMojo {
+        boolean fallbackRemoved
         int nativeImageMajorVersion = 25
 
         @Override
@@ -192,6 +226,11 @@ class AbstractNativeImageMojoTest extends Specification {
         @Override
         protected int getNativeImageMajorVersion() {
             nativeImageMajorVersion
+        }
+
+        @Override
+        protected boolean isFallbackRemoved() {
+            fallbackRemoved
         }
     }
 }

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
@@ -16,6 +16,13 @@ class AbstractNativeImageMojoTest extends Specification {
     @TempDir
     Path testDirectory
 
+    // Protects the deprecated Maven fallback parameter surface. §FS-config-model.1.
+    @Issue("https://github.com/graalvm/native-build-tools/issues/991")
+    def "marks the fallback parameter as deprecated"() {
+        expect:
+        AbstractNativeImageMojo.getDeclaredField("fallback").isAnnotationPresent(Deprecated)
+    }
+
     void "it can process build args"() {
         given:
         def buildArgs = [


### PR DESCRIPTION
## What changed

The Gradle `fallback` DSL option and Maven `<fallback>` parameter are now marked deprecated. Both remain available for compatibility.

The plugins now distinguish the GraalVM release from the JDK version reported by `native-image --version`:

- Before GraalVM 25.1, disabling fallback continues to generate `--no-fallback`.
- On positively identified GraalVM 25.1+ releases, the plugins omit the generated `--no-fallback` flag.
- Runtime-environment lines are parsed independently of vendor labels, covering Oracle GraalVM, Mandrel, and BellSoft Liberica NIK formats.
- If the GraalVM release cannot be identified, the plugins conservatively retain the flag.
- Explicit user-supplied `--no-fallback` build arguments remain unchanged.

## Why

Native Image removed the fallback feature in GraalVM 25.1, so `--no-fallback` is deprecated and has no effect there. Suppressing the plugin-generated flag avoids a deprecation warning on every build while preserving behavior for older GraalVM releases.

Both GraalVM 25.0 and 25.1 use JDK 25, so the existing JDK-major check cannot distinguish them. The implementation reads the first dotted release from a runtime-environment line in the existing `native-image --version` output, regardless of the distribution's vendor label, and does not add another version-check process.

## Example

Existing configurations continue to work while showing the deprecation in API documentation:

```groovy
nativeImage {
    fallback = false // deprecated on GraalVM 25.1+
}
```

```xml
<configuration>
  <fallback>false</fallback> <!-- deprecated on GraalVM 25.1+ -->
</configuration>
```

## Implementation summary

- Added deprecation annotations and GraalVM 25.1 guidance to the Gradle and Maven option surfaces.
- Added shared, vendor-neutral GraalVM release detection independent of the JDK version.
- Suppressed plugin-generated `--no-fallback` on confirmed GraalVM 25.1+ releases in both plugins.
- Preserved compatibility behavior for older and unrecognized releases and preserved explicit build arguments.
- Updated the common, Gradle, and Maven functional specs.
- Added exact Oracle GraalVM, Mandrel, and BellSoft Liberica NIK parser fixtures, including same-format 25.1 cases.
- Added Gradle/Maven command-line regression tests.

## Validation

- `grund check`
- `grund fmt . --marker --cross-refs --check`
- `./gradlew :utils:check`
- Focused Gradle and Maven argument regression tests
- Maven invocation functional test against real Oracle GraalVM 25.0.3, Mandrel 25.0.3.0-Final, and BellSoft Liberica NIK 25.0.3-2 installations
- Verified real current outputs are identified as pre-25.1 and same-format 25.1 transformations are identified as 25.1+ for all three distributions
- `./gradlew :native-gradle-plugin:inspections :native-maven-plugin:inspections :utils:check`
- `git diff --check`
- A complete Maven unit run was attempted for the original deprecation change; it has one unrelated reproducible `NativeExtensionTest` failure because this environment lacks a Spock class-mocking backend. The changed Maven tests and module inspections passed.

Fixes #991
