### PR TITLE
Replace deprecated Kotlin DSL delegated accessors

### DIFF
--- a/build-logic/aggregator/src/main/kotlin/org.graalvm.build.aggregator.gradle.kts
+++ b/build-logic/aggregator/src/main/kotlin/org.graalvm.build.aggregator.gradle.kts
@@ -132,7 +132,7 @@ tasks.register<Zip>("releaseZip") {
     }
 }
 
-val updateSamples by tasks.registering
+val updateSamples = tasks.register("updateSamples")
 
 mapOf(
     "updateSamplesDir" to "samples",

--- a/build-logic/common-plugins/src/main/kotlin/org.graalvm.build.java.gradle.kts
+++ b/build-logic/common-plugins/src/main/kotlin/org.graalvm.build.java.gradle.kts
@@ -90,6 +90,6 @@ tasks.withType<Test>().configureEach {
 }
 
 // Maintainer inspections aggregate Checkstyle. §FS-build-infrastructure.1.1.
-val inspections by tasks.registering {
+val inspections = tasks.register("inspections") {
     dependsOn(tasks.withType<Checkstyle>())
 }

--- a/build-logic/common-plugins/src/main/kotlin/org.graalvm.build.publishing.gradle.kts
+++ b/build-logic/common-plugins/src/main/kotlin/org.graalvm.build.publishing.gradle.kts
@@ -62,7 +62,7 @@ val mavenExtension = project.extensions.create<MavenExtension>("maven").also {
 val publishingTasks = tasks.withType<AbstractPublishToMaven>()
         .matching { it.name.endsWith("ToCommonRepository") }
 
-val repositoryElements by configurations.creating {
+val repositoryElements = configurations.create("repositoryElements") {
     // Configure an outgoing configuration which artifact
     // is going to be the local Maven repository we generate
     isCanBeConsumed = true
@@ -156,7 +156,7 @@ val publicationCoordinatesCollector = gradle.sharedServices.registerIfAbsent("pu
 }
 
 // Module-local coordinate reporting is aggregated by the root build. §FS-build-infrastructure.1.2.
-val showPublications by tasks.registering {
+val showPublications = tasks.register("showPublications") {
     usesService(publicationCoordinatesCollector)
     doLast {
         publishing.publications.all {

--- a/build-logic/documentation-plugins/src/main/kotlin/org.graalvm.build.documentation.gradle.kts
+++ b/build-logic/documentation-plugins/src/main/kotlin/org.graalvm.build.documentation.gradle.kts
@@ -60,7 +60,7 @@ plugins {
     java
 }
 
-val javadocs by configurations.creating {
+val javadocs = configurations.create("javadocs") {
     isCanBeConsumed = false
     isCanBeResolved = true
     attributes {

--- a/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
+++ b/docs/src/docs/snippets/gradle/kotlin/build.gradle.kts
@@ -156,7 +156,7 @@ graalvmNative {
 }
 // end::disable-test-support[]
 
-val integTest by sourceSets.creating
+sourceSets.create("integTest")
 val integTest = tasks.register<Test>("integTest")
 
 // tag::custom-binary[]

--- a/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-embedder.gradle.kts
+++ b/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-embedder.gradle.kts
@@ -1,7 +1,3 @@
-import org.gradle.kotlin.dsl.creating
-import org.gradle.kotlin.dsl.getValue
-import org.gradle.kotlin.dsl.invoke
-
 /*
  * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -43,7 +39,8 @@ import org.gradle.kotlin.dsl.invoke
  * SOFTWARE.
  */
 
-val mavenEmbedder by configurations.creating
-val testFixturesImplementation by configurations.getting
+// Shared maintainer-facing build configurations are convention-plugin behavior. §root/FS-build-infrastructure.2.1
+val mavenEmbedder = configurations.create("mavenEmbedder")
+val testFixturesImplementation = configurations.getByName("testFixturesImplementation")
 
 testFixturesImplementation.extendsFrom(mavenEmbedder)

--- a/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-functional-testing.gradle.kts
+++ b/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-functional-testing.gradle.kts
@@ -45,9 +45,10 @@ plugins {
     id("org.graalvm.build.maven-embedder")
 }
 
-val functionalTest by sourceSets.creating
+// Shared functional-test wiring is convention-plugin behavior. §root/FS-build-infrastructure.2.1
+val functionalTest = sourceSets.create("functionalTest")
 
-val functionalTestCommonRepository by configurations.creating {
+val functionalTestCommonRepository = configurations.create("functionalTestCommonRepository") {
     // This configuration will trigger the composite build
     // which builds the JUnit native library, and publish it to a repository
     // which can then be injected into tests

--- a/samples/java-application-with-extra-sourceset/build.gradle.kts
+++ b/samples/java-application-with-extra-sourceset/build.gradle.kts
@@ -53,7 +53,7 @@ repositories {
 }
 
 // tag::extra-sourceset[]
-val graal by sourceSets.creating
+val graal = sourceSets.create("graal")
 
 dependencies {
     "graalCompileOnly"("org.graalvm.nativeimage:svm:21.2.0")


### PR DESCRIPTION
## What changed

Updated the repository’s Kotlin Gradle scripts to use explicit Gradle APIs instead of delegated accessors deprecated in Gradle 9.6.1 and removed in Gradle 10. Tasks now use `register`, configurations use `create` or `getByName`, and source sets use `create`.

## Why

This removes the issue-983 deprecation warnings and keeps the build logic, Maven build plugins, documentation examples, and sample projects compatible with Gradle 10.

## Example

Before:

```kotlin
val graal by sourceSets.creating
```

After:

```kotlin
val graal = sourceSets.create("graal")
```

The same explicit style is now used for task and configuration declarations, for example `tasks.register("inspections")` and `configurations.getByName("testFixturesImplementation")`.

## Implementation summary

- Replaced all four reported delegated-accessor forms across the eight affected Kotlin Gradle scripts.
- Preserved declaration names and lazy task registration behavior.
- Updated the public Kotlin DSL documentation snippet and extra-source-set sample so they no longer teach deprecated syntax.

Fixes #983

## Validation

Passed:

- `/home/jovan/.local/bin/grund check`
- `/home/jovan/.local/bin/grund fmt . --marker --cross-refs --check`
- `git diff --check`
- `if git grep -n -E 'by[[:space:]]+(tasks\\.registering|configurations\\.(creating|getting)|sourceSets\\.creating)' -- '*.gradle.kts'; then exit 1; fi` — no deprecated forms remain.
- `./gradlew help --warning-mode=all --console=plain`
- `./gradlew :common-plugins:compileKotlin :documentation-plugins:compileKotlin :native-maven-plugin:build-plugins:compileKotlin :aggregator:compileKotlin --rerun-tasks --warning-mode=all --console=plain` — 77 tasks succeeded with no issue-983 warning.
- `./gradlew -p /tmp/native-build-tools-983-focused.auUJdr verifyExtraSourceSet --rerun-tasks --warning-mode=all --console=plain` — focused source-set check succeeded.

The full `./gradlew build --warning-mode=all` run was not green because of an unrelated existing `:native-gradle-plugin:validatePlugins` failure and was stopped during lengthy native functional tests. Maven and Gradle inspections, full functional-test/native-image matrices, and documentation rendering were not run; they should be covered by CI or rerun before merge. The complete sample also retains an unrelated existing `nativeImageClasspath.extendsFrom(...)` Kotlin DSL compilation failure; the isolated check above validates the changed declaration directly.

## AI workflow

Generated by [Rhei](https://github.com/vjovanov/rhei)’s `github-issue-fix` workflow using 16 completed AI-assisted steps, 3 OpenAI models, and 2 review cycles.
<details>
<summary>View AI workflow details</summary>

1. **Issue intake and routing** — `openai:gpt-5.6-sol` via Codex  
   Tokens: 641,998 total · 633,786 input (561,920 cached) · 8,212 output  
   Fetched issue #983, found all 11 deprecated delegated-accessor occurrences, checked repository and grounding rules, confirmed specification fit, and routed the issue directly to implementation.

2. **Fix implementation** — `openai:gpt-5.6-sol` via Codex  
   Tokens: 1,818,619 total · 1,811,625 input (1,696,000 cached) · 6,994 output  
   Replaced the deprecated task, configuration, and source-set accessors across eight Kotlin Gradle scripts while preserving names, creation semantics, and lazy task registration.

3. **Focused validation, cycle 1** — `openai:gpt-5.6-sol` via Codex  
   Tokens: 815,976 total · 804,139 input (736,512 cached) · 11,837 output  
   Verified the repository-wide cleanup and affected build-plugin compilation, but recorded a blocking focused sample check caused by an unchanged Kotlin DSL error.

4. **Requirements review, cycle 1** — `openai:gpt-5.6-terra` via Codex  
   Tokens: 136,686 total · 134,310 input (104,704 cached) · 2,376 output  
   Checked the replacements against issue #983’s requested APIs, repository scope, and Gradle 10 compatibility objective.

5. **Specification review, cycle 1** — `openai:gpt-5.6-terra` via Codex  
   Tokens: 210,411 total · 206,673 input (163,840 cached) · 3,738 output  
   Checked repository instructions and grounding, identifying missing most-specific citations in two changed Maven build-plugin scripts.

6. **Implementation review, cycle 1** — `openai:gpt-5.6-terra` via Codex  
   Tokens: 228,899 total · 225,673 input (184,064 cached) · 3,226 output  
   Reviewed API equivalence, lazy task behavior, exact declaration names, documentation updates, and unintended changes.

7. **Validation review, cycle 1** — `openai:gpt-5.6-terra` via Codex  
   Tokens: 191,321 total · 187,780 input (163,072 cached) · 3,541 output  
   Assessed the command evidence and treated the red focused sample invocation as a publication blocker despite its pre-existing cause.

8. **Review aggregation, cycle 1** — `openai:gpt-5.6-sol` via Codex  
   Tokens: 350,723 total · 346,342 input (294,400 cached) · 4,381 output  
   Combined the focused findings and routed the change to repair for the missing citations and focused-validation blocker.

9. **Address review findings** — `openai:gpt-5.6-sol` via Codex  
   Tokens: 588,292 total · 580,965 input (528,896 cached) · 7,327 output  
   Added the governing citations and created a green isolated Gradle fixture that directly exercised the changed source-set declaration without changing unrelated sample behavior.

10. **Focused validation, cycle 2** — `openai:gpt-5.6-sol` via Codex  
    Tokens: 927,027 total · 918,127 input (829,184 cached) · 8,900 output  
    Repeated grounding, source scanning, build-plugin compilation, root configuration, and focused sample validation; all targeted checks passed.

11. **Requirements review, cycle 2** — `openai:gpt-5.6-terra` via Codex  
    Tokens: 234,353 total · 230,504 input (154,880 cached) · 3,849 output  
    Confirmed that the repaired change still covered every reported accessor form and remained within the issue scope.

12. **Specification review, cycle 2** — `openai:gpt-5.6-terra` via Codex  
    Tokens: 271,707 total · 267,520 input (230,912 cached) · 4,187 output  
    Confirmed the new Maven build-plugin citations were specific, valid, and absent from public documentation and samples.

13. **Implementation review, cycle 2** — `openai:gpt-5.6-terra` via Codex  
    Tokens: 339,184 total · 335,793 input (301,056 cached) · 3,391 output  
    Rechecked correctness, API semantics, repair scope, documentation consistency, and maintainability after the review changes.

14. **Validation review, cycle 2** — `openai:gpt-5.6-terra` via Codex  
    Tokens: 204,445 total · 200,229 input (148,480 cached) · 4,216 output  
    Accepted the green isolated source-set fixture and recorded the full-build and broader CI checks that remained outstanding.

15. **Review aggregation, cycle 2** — `openai:gpt-5.6-sol` via Codex  
    Tokens: 387,721 total · 384,377 input (332,288 cached) · 3,344 output  
    Found no remaining blockers and approved the change for draft publication with the broader validation gaps disclosed.

16. **PR publication** — `openai:gpt-5.6-luna` via Codex  
    Tokens: 367,877 total · 363,742 input (321,280 cached) · 4,135 output  
    Pushed the reviewed branch, opened draft PR #998, applied the `rhei` label, and recorded the remaining maintainer actions.

**Aggregate token usage:** 7,715,239 total · 7,631,585 input (6,751,488 cached) · 83,654 output

Deterministic implementation and review routing was performed by Rhei without an AI model.

**Execution summary:** 2 focused review cycles · 1 review-repair cycle

Token accounting covers the 16 completed steps above. One additional requirements-review attempt emitted no usage data and is excluded. Cached tokens are included in the input and total counts; cache-write and output-cache metrics were unsupported.

</details>
