### PR TITLE
Fix Maven plugin unit-test mock maker and SLF4J setup

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ junitPlatform = "1.13.0"
 junitJupiter = "5.13.0"
 jimfs = "1.3.0"
 slf4j = "1.7.9"
+slf4jTest = "2.0.13"
 groovy = "3.0.11"
 jetty = "11.0.11"
 plexusUtils = "4.0.2"
@@ -56,6 +57,7 @@ maven-resolver-transport-http = { module = "org.apache.maven.resolver:maven-reso
 maven-resolver-transport-file = { module = "org.apache.maven.resolver:maven-resolver-transport-file", version.ref = "mavenResolver"}
 
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+slf4j-simple-test = { module = "org.slf4j:slf4j-simple", version.ref = "slf4jTest" }
 
 jetty-server = { module = "org.eclipse.jetty:jetty-server", version.ref = "jetty" }
 

--- a/native-maven-plugin/build.gradle.kts
+++ b/native-maven-plugin/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     testImplementation(libs.maven.artifact)
     testImplementation(libs.jetty.server)
     testRuntimeOnly(libs.test.junit.platform.launcher)
+    testRuntimeOnly(libs.slf4j.simple.test)
 
     testFixturesImplementation(libs.test.spock)
     testFixturesImplementation(libs.jetty.server)
@@ -95,7 +96,7 @@ dependencies {
 
     functionalTestImplementation(libs.test.spock)
     functionalTestRuntimeOnly(libs.test.junit.platform.launcher)
-    functionalTestRuntimeOnly(libs.slf4j.simple)
+    functionalTestRuntimeOnly(libs.slf4j.simple.test)
 }
 
 publishing {

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/NativeExtensionTest.groovy
@@ -41,6 +41,8 @@
 
 package org.graalvm.buildtools.maven
 
+import org.apache.maven.execution.DefaultMavenExecutionRequest
+import org.apache.maven.execution.DefaultMavenExecutionResult
 import org.apache.maven.execution.MavenSession
 import org.apache.maven.model.Build
 import org.apache.maven.model.Plugin
@@ -58,6 +60,7 @@ class NativeExtensionTest extends Specification {
     private static final String JUNIT_TRACKING_ENABLED = "junit.platform.listeners.uid.tracking.enabled"
     private static final String JUNIT_TRACKING_OUTPUT_DIR = "junit.platform.listeners.uid.tracking.output.dir"
 
+    // Surefire and Failsafe use separate test-ID directories configured through system properties. §FS-native-tests.6
     def "configures JUnit listener properties through non-deprecated systemPropertyVariables"() {
         given:
         def build = new Build()
@@ -71,10 +74,9 @@ class NativeExtensionTest extends Specification {
         def project = new MavenProject()
         project.build = build
 
-        def session = Stub(MavenSession) {
-            getProjects() >> [project]
-            getSystemProperties() >> new Properties()
-        }
+        def request = new DefaultMavenExecutionRequest()
+        request.systemProperties = new Properties()
+        def session = new MavenSession(null, request, new DefaultMavenExecutionResult(), [project])
 
         when:
         new NativeExtension().afterProjectsRead(session)


### PR DESCRIPTION
## What changed

- Construct a real `MavenSession` in `NativeExtensionTest` instead of requiring a class-capable Spock mock maker.
- Add an SLF4J 2.0 test-runtime provider while preserving the Maven Embedder SLF4J 1.7 binding.
- Align the Maven functional-test runtime with the resolved SLF4J API.

## Why

The Maven plugin unit suite failed because Spock could not stub the concrete `MavenSession`. Its test runtime also selected SLF4J API 2.x while providing an incompatible 1.7-era binding.

Fixes #984.

## Implementation summary

The test now uses Maven concrete execution request and result objects to create its session. Test and functional-test configurations use an SLF4J provider compatible with their resolved API without changing the Maven Embedder configuration.

## Validation

- Exact `NativeExtensionTest` regression passed.
- Complete `:native-maven-plugin:test` suite passed: 30 tests, no failures.
- Captured test results contain no SLF4J provider or binding warnings.
- Test and functional-test runtime dependency resolution selects `slf4j-simple:2.0.13`.
- `grund check`, citation formatting, and `git diff --check` passed.

Not run locally: the Maven functional-test matrix, Maven inspection/publication gate, full repository build, and documentation rendering.

## AI workflow

This PR was produced with Rhei's `github-issue-fix` workflow.

1. **Issue intake and routing**  
   Model: `openai:gpt-5.6-sol` · Agent: `codex`  
   Fetched issue #984, reproduced the reported Maven test and SLF4J symptoms, inspected repository and grounding rules, confirmed the change fit the specification, and routed it directly to implementation.

2. **Fix implementation**  
   Model: `openai:gpt-5.6-sol` · Agent: `codex`  
   Replaced the unsupported `MavenSession` stub with a real session and aligned the unit and functional-test SLF4J providers while preserving the Maven Embedder binding.

3. **Focused validation**  
   Model: `openai:gpt-5.6-sol` · Agent: `codex`  
   Ran the exact regression, the complete Maven plugin unit suite, SLF4J warning scans, dependency-resolution checks, grounding checks, and diff hygiene checks.

4. **Requirements review**  
   Model: `openai:gpt-5.6-terra` · Agent: `codex`  
   Verified that the implementation addressed both reported failures and stayed within the issue's acceptance criteria.

5. **Specification review**  
   Model: `openai:gpt-5.6-terra` · Agent: `codex`  
   Checked repository instructions, specification compatibility, grounding references, documentation impact, and scope.

6. **Implementation review**  
   Model: `openai:gpt-5.6-terra` · Agent: `codex`  
   Reviewed the three-file change for correctness, dependency scoping, maintainability, behavioral test coverage, and unintended changes.

7. **Validation review**  
   Model: `openai:gpt-5.6-terra` · Agent: `codex`  
   Assessed the recorded test evidence, reran the focused regression and hygiene checks, and documented the broader CI gates that were not run locally.

8. **Review aggregation**  
   Model: `openai:gpt-5.6-sol` · Agent: `codex`  
   Combined the four focused reviews, found no publication blockers, and marked the change ready for a draft PR after one review cycle.

9. **Publication handoff**  
   Model: `openai:gpt-5.6-luna` · Agent: `codex`  
   Prepared the publication record. The workflow did not push or open the PR because the configured remote did not match the requested head owner; publication was completed separately.

Deterministic implementation and review routing was performed by Rhei without an AI model.

**Execution summary:** 1 focused review cycle · 0 review-repair cycles
