### PR TITLE
Avoid Maven internal API for console colors

### DIFF
--- a/native-maven-plugin/docs/functional/native-image-builds.md
+++ b/native-maven-plugin/docs/functional/native-image-builds.md
@@ -69,7 +69,10 @@ mvn -Pnative native:list-libraries-missing-metadata
 
 ## 9. Console colors
 
-The native-image invocation must follow Maven's detected console color state. It must use
+When Maven's `style.color` property explicitly selects a colored or colorless mode, or when Maven
+runs non-interactively, the native-image invocation must follow that selection. It must use
 `--color=always` or `--color=never` on JDK 21 and later, and `-H:+BuildOutputColorful` or
-`-H:-BuildOutputColorful` on older versions. Explicit user build arguments come later and may
-override this detected default, adapting [§root/FS-native-builds.2](../../../docs/spec/functional/native-image-builds.md#2-command-line-construction).
+`-H:-BuildOutputColorful` on older versions. When the Maven plugin API does not expose a resolved
+console mode, the invocation must omit a color argument and let Native Image detect its output
+mode. Explicit user build arguments come later and may override Maven's exposed mode, adapting
+[§root/FS-native-builds.2](../../../docs/spec/functional/native-image-builds.md#2-command-line-construction).

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -51,7 +51,6 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.ToolchainManager;
-import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.codehaus.plexus.logging.Logger;
 import org.graalvm.buildtools.maven.config.ExcludeConfigConfiguration;
 import org.graalvm.buildtools.model.resources.NativeImageFlags;
@@ -300,18 +299,49 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
         return Collections.unmodifiableList(actualCliArgs);
     }
 
-    // Maven's detected console mode controls version-appropriate Native Image color flags. §FS-native-builds.9.
+    // Maven-exposed console modes control version-appropriate Native Image color flags. §FS-native-builds.9.
     private void addConsoleColorArgument(List<String> cliArgs) throws MojoExecutionException {
-        boolean colorEnabled = isColorEnabled();
+        Optional<Boolean> colorEnabled = getMavenColorSetting();
+        if (colorEnabled.isEmpty()) {
+            return;
+        }
         if (getNativeImageMajorVersion() >= 21) {
-            cliArgs.add(NativeImageFlags.COLOR + (colorEnabled ? "=always" : "=never"));
+            cliArgs.add(NativeImageFlags.COLOR + (colorEnabled.get() ? "=always" : "=never"));
         } else {
-            cliArgs.add(colorEnabled ? NativeImageFlags.BUILD_OUTPUT_COLORFUL : NativeImageFlags.BUILD_OUTPUT_COLORLESS);
+            cliArgs.add(colorEnabled.get()
+                    ? NativeImageFlags.BUILD_OUTPUT_COLORFUL
+                    : NativeImageFlags.BUILD_OUTPUT_COLORLESS);
         }
     }
 
-    protected boolean isColorEnabled() {
-        return MessageUtils.isColorEnabled();
+    protected Optional<Boolean> getMavenColorSetting() {
+        String styleColor = session.getUserProperties().getProperty("style.color");
+        if (styleColor == null) {
+            styleColor = session.getSystemProperties().getProperty("style.color");
+        }
+        Optional<Boolean> explicitStyleColor = parseMavenColorMode(styleColor);
+        if (explicitStyleColor.isPresent()) {
+            return explicitStyleColor;
+        }
+
+        if (!session.getRequest().isInteractiveMode()) {
+            return Optional.of(false);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Boolean> parseMavenColorMode(String colorMode) {
+        if ("always".equalsIgnoreCase(colorMode)
+                || "yes".equalsIgnoreCase(colorMode)
+                || "force".equalsIgnoreCase(colorMode)) {
+            return Optional.of(true);
+        }
+        if ("never".equalsIgnoreCase(colorMode)
+                || "no".equalsIgnoreCase(colorMode)
+                || "none".equalsIgnoreCase(colorMode)) {
+            return Optional.of(false);
+        }
+        return Optional.empty();
     }
 
     protected int getNativeImageMajorVersion() throws MojoExecutionException {

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
@@ -1,5 +1,8 @@
 package org.graalvm.buildtools.maven
 
+import org.apache.maven.execution.DefaultMavenExecutionRequest
+import org.apache.maven.execution.DefaultMavenExecutionResult
+import org.apache.maven.execution.MavenSession
 import org.apache.maven.plugin.MojoExecutionException
 import org.graalvm.buildtools.model.resources.NativeImageFlags
 import spock.lang.Issue
@@ -37,13 +40,14 @@ class AbstractNativeImageMojoTest extends Specification {
         ]
     }
 
-    // Maven console mode selects the Native Image version's color argument. §FS-native-builds.9.
-    @Issue("https://github.com/graalvm/native-build-tools/issues/366")
-    def "uses Maven's #label console color mode with JDK #nativeImageMajorVersion"() {
+    // An explicit Maven style selects the Native Image version's color argument. §FS-native-builds.9.
+    @Issue(["https://github.com/graalvm/native-build-tools/issues/366",
+            "https://github.com/graalvm/native-build-tools/issues/1000"])
+    def "uses Maven's explicit #styleColor style with JDK #nativeImageMajorVersion"() {
         given:
         def mojo = newMojo([])
         mojo.imageClasspath.add(testDirectory.resolve("application.jar"))
-        mojo.colorEnabled = colorEnabled
+        mojo.session.userProperties.setProperty("style.color", styleColor)
         mojo.nativeImageMajorVersion = nativeImageMajorVersion
 
         when:
@@ -53,20 +57,58 @@ class AbstractNativeImageMojoTest extends Specification {
         args.contains(expectedColorArgument)
 
         where:
-        label      | colorEnabled | nativeImageMajorVersion | expectedColorArgument
-        "disabled" | false        | 17                      | NativeImageFlags.BUILD_OUTPUT_COLORLESS
-        "disabled" | false        | 21                      | "--color=never"
-        "enabled"  | true         | 17                      | NativeImageFlags.BUILD_OUTPUT_COLORFUL
-        "enabled"  | true         | 21                      | "--color=always"
+        styleColor | nativeImageMajorVersion | expectedColorArgument
+        "never"    | 17                      | NativeImageFlags.BUILD_OUTPUT_COLORLESS
+        "never"    | 21                      | "--color=never"
+        "always"   | 17                      | NativeImageFlags.BUILD_OUTPUT_COLORFUL
+        "always"   | 21                      | "--color=always"
+        "none"     | 21                      | "--color=never"
+        "force"    | 21                      | "--color=always"
     }
 
-    // Explicit build arguments retain precedence over Maven's detected color mode. §FS-native-builds.9.
+    // Maven batch mode disables Native Image colors even when no color property is present. §FS-native-builds.9.
+    def "disables colors for Maven batch mode"() {
+        given:
+        def mojo = newMojo([])
+        mojo.imageClasspath.add(testDirectory.resolve("application.jar"))
+        mojo.session.request.interactiveMode = false
+        mojo.nativeImageMajorVersion = 21
+
+        expect:
+        mojo.getBuildArgs().contains("--color=never")
+    }
+
+    // Unresolved color selection remains Native Image's responsibility without Maven implementation classes. §FS-native-builds.9.
+    @Issue("https://github.com/graalvm/native-build-tools/issues/1000")
+    def "omits a color argument when Maven color mode is #styleColor"() {
+        given:
+        def mojo = newMojo([])
+        mojo.imageClasspath.add(testDirectory.resolve("application.jar"))
+        if (styleColor != null) {
+            mojo.session.userProperties.setProperty("style.color", styleColor)
+        }
+
+        when:
+        def args = mojo.getBuildArgs()
+
+        then:
+        !args.any {
+            it.startsWith(NativeImageFlags.COLOR) ||
+                    it == NativeImageFlags.BUILD_OUTPUT_COLORFUL ||
+                    it == NativeImageFlags.BUILD_OUTPUT_COLORLESS
+        }
+
+        where:
+        styleColor << [null, "auto"]
+    }
+
+    // Explicit build arguments retain precedence over Maven's explicit color mode. §FS-native-builds.9.
     @Issue("https://github.com/graalvm/native-build-tools/issues/366")
-    def "places explicit color build arguments after Maven's detected default"() {
+    def "places explicit color build arguments after Maven's explicit selection"() {
         given:
         def mojo = newMojo(["--color=never"])
         mojo.imageClasspath.add(testDirectory.resolve("application.jar"))
-        mojo.colorEnabled = true
+        mojo.session.userProperties.setProperty("style.color", "always")
         mojo.nativeImageMajorVersion = 21
 
         when:
@@ -114,11 +156,17 @@ class AbstractNativeImageMojoTest extends Specification {
         mojo.buildArgs = buildArgs
         mojo.configFiles = []
         mojo.useArgFile = false
+        def userProperties = new Properties()
+        def systemProperties = new Properties()
+        def request = new DefaultMavenExecutionRequest()
+                .setUserProperties(userProperties)
+                .setSystemProperties(systemProperties)
+                .setInteractiveMode(true)
+        mojo.session = new MavenSession(null, null, request, new DefaultMavenExecutionResult())
         mojo
     }
 
     private static class TestNativeImageMojo extends AbstractNativeImageMojo {
-        boolean colorEnabled
         int nativeImageMajorVersion = 25
 
         @Override
@@ -132,11 +180,6 @@ class AbstractNativeImageMojoTest extends Specification {
 
         @Override
         protected void populateClasspath() {
-        }
-
-        @Override
-        protected boolean isColorEnabled() {
-            colorEnabled
         }
 
         @Override


### PR DESCRIPTION
Fixes #1000.

`native-maven-plugin` 1.1.6 used `org.apache.maven.shared.utils.logging.MessageUtils` to detect Maven console colors. That class is not part of Maven's plugin API and is not available from every Maven plugin realm, causing `compile-no-fork` to fail before invoking Native Image.

This change:

- removes the `MessageUtils` dependency
- maps explicit `-Dstyle.color=always|never` selections to the version-appropriate Native Image color argument
- leaves `auto` and unspecified color modes to Native Image's own output detection
- keeps explicit Native Image build arguments last so they retain precedence
- adds regression coverage linked to #1000

Validation:

- focused Maven plugin unit tests
- Checkstyle and `grund check`
- published-plugin Maven functional test
- `./mvnw -Pnative package -DskipTests=true` in Spring Petclinic using local `1.1.6-SNAPSHOT` with Maven 3.9.11 and Oracle GraalVM 25.0.3; native image completed successfully