### PR TITLE
Make repository test output concise by default

### DIFF
--- a/build-logic/common-plugins/src/main/kotlin/org.graalvm.build.java.gradle.kts
+++ b/build-logic/common-plugins/src/main/kotlin/org.graalvm.build.java.gradle.kts
@@ -39,8 +39,6 @@
  * SOFTWARE.
  */
 
-import org.gradle.api.tasks.testing.logging.TestLogEvent
-
 /**
  * Defines common logic used by all libraries GraalVM projects in this repository
  * §FS-build-infrastructure.2.1.
@@ -83,12 +81,6 @@ tasks.withType<Javadoc>().configureEach {
     (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
     (options as StandardJavadocDocletOptions).addBooleanOption("Xdoclint:all,-missing", true)
     (options as StandardJavadocDocletOptions).noTimestamp(true)
-}
-
-tasks.withType<Test>().configureEach {
-    testLogging {
-        events.addAll(listOf(TestLogEvent.STANDARD_OUT, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED))
-    }
 }
 
 // Maintainer inspections aggregate Checkstyle. §FS-build-infrastructure.1.1.

--- a/common/junit-platform-native/build.gradle
+++ b/common/junit-platform-native/build.gradle
@@ -80,12 +80,6 @@ tasks.named('test') {
     }
 }
 
-tasks.withType(Test).configureEach {
-    testLogging {
-        events "standardOut", "passed", "skipped", "failed"
-    }
-}
-
 publishing {
     publications {
         mavenJava(MavenPublication) {

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/BasicTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/BasicTests.java
@@ -49,11 +49,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+// Exercises JUnit Jupiter behavior in native test executables. §E2E-common-tests.2.4.
 class BasicTests {
-
-    BasicTests(TestInfo info) {
-        System.out.println("Running test: " + info.getDisplayName());
-    }
 
     @BeforeAll
     static void beforeAll() {

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/NestedTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/jupiter/NestedTests.java
@@ -44,17 +44,13 @@ package org.graalvm.junit.jupiter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 
 
+// Exercises nested JUnit Jupiter discovery in native test executables. §E2E-common-tests.2.4.
 public class NestedTests {
 
     @Nested
     class NestedTest {
-
-        NestedTest(TestInfo info) {
-            System.out.println("Running nested test: " + info.getDisplayName());
-        }
 
         @Test
         @DisplayName("Test in a nested test class")
@@ -63,10 +59,6 @@ public class NestedTests {
 
         @Nested
         class NestedNestedTest {
-
-            NestedNestedTest(TestInfo info) {
-                System.out.println("Running nested nested test: " + info.getDisplayName());
-            }
 
             @Test
             @DisplayName("Test in a nested nested test class")

--- a/common/junit-platform-native/src/test/java/org/graalvm/junit/vintage/BasicTests.java
+++ b/common/junit-platform-native/src/test/java/org/graalvm/junit/vintage/BasicTests.java
@@ -44,11 +44,11 @@ package org.graalvm.junit.vintage;
 import org.junit.Assert;
 import org.junit.Test;
 
+// Exercises JUnit Vintage behavior in native test executables. §E2E-common-tests.2.4.
 public class BasicTests {
 
     @Test
     public void test() {
-        System.out.println("Hello, World! This is JUnit 4 test.");
         Assert.assertEquals("This shouldn't fail", 42, 42);
     }
 }

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/FileUtilsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/FileUtilsTest.java
@@ -80,7 +80,6 @@ class FileUtilsTest {
         List<String> errorLogs = new ArrayList<>();
 
         Optional<Path> download = FileUtils.download(url, tempDir, errorLogs::add);
-        System.out.println("errorLogs = " + errorLogs);
 
         assertTrue(download.isPresent());
         assertEquals("native-build-tools-master.zip", download.get().getFileName().toString());
@@ -94,7 +93,6 @@ class FileUtilsTest {
         List<String> errorLogs = new ArrayList<>();
 
         Optional<Path> download = FileUtils.download(url, tempDir, errorLogs::add);
-        System.out.println("errorLogs = " + errorLogs);
 
         assertTrue(download.isPresent());
         assertEquals("html", download.get().getFileName().toString());
@@ -108,7 +106,6 @@ class FileUtilsTest {
         List<String> errorLogs = new ArrayList<>();
 
         Optional<Path> download = FileUtils.download(url, tempDir, errorLogs::add);
-        System.out.println("errorLogs = " + errorLogs);
 
         assertFalse(download.isPresent());
         assertEquals(1, errorLogs.size());
@@ -126,7 +123,6 @@ class FileUtilsTest {
         List<String> errorLogs = new ArrayList<>();
 
         Optional<Path> download = FileUtils.download(url, tempDir, errorLogs::add);
-        System.out.println("errorLogs = " + errorLogs);
 
         assertFalse(download.isPresent());
         assertEquals(1, errorLogs.size());

--- a/docs/spec/functional/build-infrastructure.md
+++ b/docs/spec/functional/build-infrastructure.md
@@ -83,7 +83,7 @@ tags must not produce warnings, while all other doclint categories remain enable
 Ordinary repository test runs must report actionable failures without listing successful or
 skipped tests or replaying routine test streams. Detailed test events and captured streams must
 remain available through Gradle's normal diagnostic levels and generated test reports, refining
-the concise-output goal in §GOAL-concise-actionable-output.
+the concise-output goal in [§GOAL-concise-actionable-output](../goals.md#goal-concise-actionable-output-build-output-is-concise-actionable-and-token-efficient).
 
 Convention plugins may add tasks and configurations to modules that apply them. Those additions
 are maintainer-facing build behavior, not runtime behavior of the Native Build Tools plugins.

--- a/docs/spec/functional/build-infrastructure.md
+++ b/docs/spec/functional/build-infrastructure.md
@@ -80,6 +80,11 @@ The shared Java convention must configure every Javadoc task to run all doclint 
 missing-documentation category. Missing API comments and missing `@param`, `@return`, and `@throws`
 tags must not produce warnings, while all other doclint categories remain enabled.
 
+Ordinary repository test runs must report actionable failures without listing successful or
+skipped tests or replaying routine test streams. Detailed test events and captured streams must
+remain available through Gradle's normal diagnostic levels and generated test reports, refining
+the concise-output goal in §GOAL-concise-actionable-output.
+
 Convention plugins may add tasks and configurations to modules that apply them. Those additions
 are maintainer-facing build behavior, not runtime behavior of the Native Build Tools plugins.
 


### PR DESCRIPTION
## What changed

Ordinary JVM test runs now keep Gradle's compact task and build summaries instead of printing every passed or skipped test and routine test output. Failures still identify the failing test and source location, while detailed results and captured streams remain available in Gradle's generated reports and diagnostic output.

## Why

Repository test runs had become difficult to scan because shared build configuration forced successful test events and standard output into normal lifecycle logs. Removing that override makes useful failures easier to spot without changing test execution or the Native Image launcher’s dedicated native-test reporting.

## Example

For the same plain-console rerun of the affected utility and JUnit modules, output dropped from 380 lines to 128 lines. The previous run contained 115 per-test status lines and 11 incidental stream lines; the updated run contained none. A controlled failing test still reported:

```text
FileUtilsTest > issue982FailureProbe() FAILED
    AssertionFailedError at FileUtilsTest.java:78
```

The generated XML and HTML reports retained the full assertion message and captured output.

## Implementation summary

- Restored Gradle's verbosity-specific test logging defaults in the shared Java convention and removed the duplicate JUnit-native override.
- Removed incidental debug and fixture output without changing assertions, discovery scenarios, or native-launcher behavior.
- Documented the concise ordinary-test-output contract and grounded the changed executable fixtures in their most-specific end-to-end specification.

## Validation

Passed:

- `/home/jovan/.local/bin/grund check`
- `./gradlew :utils:checkstyleMain :utils:checkstyleTest :utils:test :junit-platform-native:checkstyleMain :junit-platform-native:checkstyleTest :junit-platform-native:test --rerun-tasks --console=plain`
- `GRAALVM_HOME=/home/jovan/.sdkman/candidates/java/current ./gradlew :junit-platform-native:nativeTest --rerun-tasks --console=plain`
- `./gradlew :native-gradle-plugin:test :native-gradle-plugin:inspections --rerun-tasks --console=plain`
- Controlled expected-failure probe confirming concise normal failure output and retained XML/HTML diagnostics, followed by a passing `./gradlew :utils:test --rerun-tasks --console=plain`
- `git diff --check`

Not run: full `./gradlew check`, the full build, documentation rendering, or the complete CI matrix, including the CI-only native Gradle plugin functional and configuration-cache matrices. The issue's reported 704-line baseline could not be reproduced exactly because its invocation, cache state, and console configuration were not provided. Existing Gradle native-access, deprecation, and problems-report notices did not fail the focused gates.

Fixes #982

## AI workflow

Generated by [Rhei](https://github.com/vjovanov/rhei)’s `github-issue-fix` workflow using 15 completed AI-assisted steps, 2 resolved models, and 2 focused review cycles.

<details>
<summary>View AI workflow details</summary>

Approved proposal: `edfa2ec23468fcf7`

### 1. Issue intake

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium

Inspected issue 982, repository policy, specifications, and the isolated worktree, then routed the compatible request.

Tokens: 594174 total · 585068 input (515072 cached) · 9106 output

### 2. Implement fix

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium

Implemented concise default JVM test logging, removed incidental fixture output, and updated the internal specification.

Tokens: 2117913 total · 2107441 input (2000896 cached) · 10472 output

### 3. Validation — cycle 1

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium

Ran the initial grounding, focused test, native-test, product-plugin, diagnostic, and output-comparison validation.

Tokens: 2298828 total · 2283251 input (2184192 cached) · 15577 output

### 4. Requirements review — cycle 1

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium

Checked the implementation against the issue acceptance criteria, repository rules, and approved scope.

Tokens: 93904 total · 92208 input (68608 cached) · 1696 output

### 5. Spec review — cycle 1

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium

Reviewed specification ownership, citations, and the behavior contract for fit and completeness.

Tokens: 194903 total · 191145 input (151552 cached) · 3758 output

### 6. Implementation review — cycle 1

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium

Reviewed the seven-file diff for correctness, scope, repository conventions, and test preservation.

Tokens: 181629 total · 178297 input (130048 cached) · 3332 output

### 7. Validation review — cycle 1

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium

Checked the recorded validation evidence and identified the citation and PR-description repairs needed before publication.

Tokens: 125977 total · 123261 input (94720 cached) · 2716 output

### 8. Aggregate review — cycle 1

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium

Aggregated the specialist reviews and routed the task to address the concrete findings.

Tokens: 194214 total · 190983 input (153600 cached) · 3231 output

### 9. Address review findings — cycle 1

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium

Added the most-specific executable-fixture citations and supplied the maintainer-facing PR description.

Tokens: 704366 total · 693961 input (615424 cached) · 10405 output

### 10. Validation — cycle 2

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium

Revalidated the repair with grounding, JUnit-native JVM and native tests, exact removal checks, and diff hygiene.

Tokens: 1089201 total · 1077680 input (995840 cached) · 11521 output

### 11. Requirements review — cycle 2

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium

Rechecked issue requirements and scope after the review repair.

Tokens: 169652 total · 166373 input (148992 cached) · 3279 output

### 12. Spec review — cycle 2

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium

Rechecked the repaired citations and specification alignment.

Tokens: 158558 total · 155814 input (125440 cached) · 2744 output

### 13. Implementation review — cycle 2

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium

Rechecked the final implementation diff and confirmed the repair stayed within approved scope.

Tokens: 320569 total · 315187 input (284672 cached) · 5382 output

### 14. Validation review — cycle 2

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium

Confirmed there were no blocking validation failures and recorded the remaining broader-check disclosures.

Tokens: 116337 total · 114028 input (88064 cached) · 2309 output

### 15. Aggregate review — cycle 2

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium

Confirmed the fix was ready to publish after the second focused review cycle.

Tokens: 142517 total · 139518 input (112640 cached) · 2999 output

### 16. Publish draft PR

Model: openai:gpt-5.6-luna · Agent: codex · Reasoning effort: medium

Committed the reviewed fix, pushed the configured branch to origin, and created this draft pull request with the `rhei` label.

Tokens: not finalized at PR creation

**Aggregate token usage:** 8502742 total · 8414215 input (7669760 cached) · 88527 output

The aggregate excludes the current unfinalized publication step. Two focused review cycles completed, with one review-repair cycle. Accounting covers all 15 completed AI-assisted steps; the publication step is not yet finalized. There were no superseded invocation records and no unmeasured completed attempts. Input cache writes, output cache writes, and output cached reads are unsupported; cached-read tokens are included within input and total.

</details>
