### PR TITLE
Decouple Maven plugin unit tests from remote bootstrap tasks

### DIFF
--- a/native-maven-plugin/build-plugins/build.gradle.kts
+++ b/native-maven-plugin/build-plugins/build.gradle.kts
@@ -48,3 +48,15 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
 }
+
+dependencies {
+    // Build-logic regressions protect the unit/assembly and seeded functional boundaries.
+    // §AR-maven-plugin.6, §E2E-functional-tests.4
+    testImplementation(gradleTestKit())
+    testImplementation("org.junit.jupiter:junit-jupiter:5.14.1")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/MavenRepositorySeedState.java
+++ b/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/MavenRepositorySeedState.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and in any patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and the
+ * Larger Work(s), and to make, use, sell, offer for sale, import, export, have
+ * made, and have sold the Software and the Larger Work(s), and to sublicense
+ * the foregoing rights on either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.build.maven;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * Records and validates the keyed inventory for a reusable Maven repository seed. §E2E-functional-tests.4
+ */
+final class MavenRepositorySeedState {
+    static final String INVALID_SEED_MESSAGE =
+            "The seeded Maven repository is missing or stale; run prepareMavenLocalRepo online.";
+    static final String MANIFEST_NAME = ".native-build-tools-seed.properties";
+    static final String SCHEMA_VERSION = "1";
+    private static final String INPUT_KEY = "inputKey";
+    private static final String SCHEMA_KEY = "schema";
+    private static final String FILE_PREFIX = "file.";
+
+    private MavenRepositorySeedState() {
+    }
+
+    static String inputKey(Map<String, String> values, Map<String, Path> files) throws IOException {
+        MessageDigest digest = digest();
+        update(digest, "schema", SCHEMA_VERSION);
+        values.entrySet().stream().sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> update(digest, entry.getKey(), entry.getValue()));
+        for (Map.Entry<String, Path> entry : new TreeMap<>(files).entrySet()) {
+            Path path = entry.getValue();
+            update(digest, entry.getKey(), Files.exists(path) ? hash(path) : "<missing>");
+        }
+        return hex(digest.digest());
+    }
+
+    static void write(Path repository, String inputKey) throws IOException {
+        List<String> lines = new ArrayList<>();
+        lines.add(SCHEMA_KEY + "=" + SCHEMA_VERSION);
+        lines.add(INPUT_KEY + "=" + inputKey);
+        for (Map.Entry<String, String> entry : inventory(repository).entrySet()) {
+            String encodedPath = Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(entry.getKey().getBytes(StandardCharsets.UTF_8));
+            lines.add(FILE_PREFIX + encodedPath + "=" + entry.getValue());
+        }
+        Files.write(repository.resolve(MANIFEST_NAME), lines, StandardCharsets.UTF_8);
+    }
+
+    static boolean isValid(Path repository, String expectedInputKey) {
+        Path manifest = repository.resolve(MANIFEST_NAME);
+        if (!Files.isRegularFile(manifest)) {
+            return false;
+        }
+        Properties properties = new Properties();
+        try (InputStream input = new BufferedInputStream(Files.newInputStream(manifest))) {
+            properties.load(input);
+            if (!SCHEMA_VERSION.equals(properties.getProperty(SCHEMA_KEY))
+                    || !expectedInputKey.equals(properties.getProperty(INPUT_KEY))) {
+                return false;
+            }
+            Map<String, String> recorded = new TreeMap<>();
+            for (String name : properties.stringPropertyNames()) {
+                if (name.startsWith(FILE_PREFIX)) {
+                    String encodedPath = name.substring(FILE_PREFIX.length());
+                    String path = new String(Base64.getUrlDecoder().decode(encodedPath), StandardCharsets.UTF_8);
+                    recorded.put(path, properties.getProperty(name));
+                }
+            }
+            return recorded.equals(inventory(repository));
+        } catch (IllegalArgumentException | IOException ex) {
+            return false;
+        }
+    }
+
+    private static Map<String, String> inventory(Path repository) throws IOException {
+        Map<String, String> files = new TreeMap<>();
+        if (!Files.isDirectory(repository)) {
+            return files;
+        }
+        try (Stream<Path> paths = Files.walk(repository)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(stableRepositoryFile())
+                    .forEach(path -> {
+                        try {
+                            files.put(repository.relativize(path).toString().replace('\\', '/'), hash(path));
+                        } catch (IOException ex) {
+                            throw new SeedStateIOException(ex);
+                        }
+                    });
+        } catch (SeedStateIOException ex) {
+            throw ex.getCause();
+        }
+        return files;
+    }
+
+    private static Predicate<Path> stableRepositoryFile() {
+        return path -> {
+            String name = path.getFileName().toString();
+            boolean lockDirectory = false;
+            for (Path element : path) {
+                if (element.toString().equals(".locks")) {
+                    lockDirectory = true;
+                    break;
+                }
+            }
+            return !name.equals(MANIFEST_NAME)
+                    && !lockDirectory
+                    && !name.equals("_remote.repositories")
+                    && !name.equals("resolver-status.properties")
+                    && !name.endsWith(".lastUpdated")
+                    && !name.endsWith(".lock")
+                    && !name.endsWith(".tmp")
+                    && !name.endsWith(".part");
+        };
+    }
+
+    private static String hash(Path path) throws IOException {
+        MessageDigest digest = digest();
+        if (Files.isDirectory(path)) {
+            try (Stream<Path> paths = Files.walk(path)) {
+                for (Path file : paths.filter(Files::isRegularFile).sorted().toList()) {
+                    update(digest, path.relativize(file).toString().replace('\\', '/'), hash(file));
+                }
+            }
+        } else {
+            try (InputStream input = new BufferedInputStream(Files.newInputStream(path))) {
+                byte[] buffer = new byte[8192];
+                int read;
+                while ((read = input.read(buffer)) >= 0) {
+                    digest.update(buffer, 0, read);
+                }
+            }
+        }
+        return hex(digest.digest());
+    }
+
+    private static MessageDigest digest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private static void update(MessageDigest digest, String key, String value) {
+        digest.update(key.getBytes(StandardCharsets.UTF_8));
+        digest.update((byte) 0);
+        digest.update(value.getBytes(StandardCharsets.UTF_8));
+        digest.update((byte) 0);
+    }
+
+    private static String hex(byte[] bytes) {
+        StringBuilder result = new StringBuilder(bytes.length * 2);
+        for (byte value : bytes) {
+            result.append(String.format("%02x", value));
+        }
+        return result.toString();
+    }
+
+    private static final class SeedStateIOException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        SeedStateIOException(IOException cause) {
+            super(cause);
+        }
+
+        @Override
+        public synchronized IOException getCause() {
+            return (IOException) super.getCause();
+        }
+    }
+}

--- a/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/MavenTask.java
+++ b/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/MavenTask.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -40,6 +41,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Runs embedded Maven with explicit offline and snapshot-update policy. §E2E-functional-tests.4
+ */
 @CacheableTask
 public abstract class MavenTask extends DefaultTask {
     @Inject
@@ -67,8 +71,19 @@ public abstract class MavenTask extends DefaultTask {
     @Input
     public abstract ListProperty<String> getArguments();
 
+    @Input
+    public abstract Property<Boolean> getOffline();
+
+    @Input
+    public abstract Property<Boolean> getUpdateSnapshots();
+
     @OutputDirectory
     public abstract DirectoryProperty getOutputDirectory();
+
+    public MavenTask() {
+        getOffline().convention(false);
+        getUpdateSnapshots().convention(false);
+    }
 
     protected void extractOutput(File tmpDir, File outputDirectory) {
         getFileSystemOperations().copy(spec -> {
@@ -93,17 +108,25 @@ public abstract class MavenTask extends DefaultTask {
             spec.systemProperty("org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener", "warn");
             prepareSpec(spec);
             List<String> arguments = new ArrayList<>();
+            arguments.add("--errors");
+            if (getUpdateSnapshots().get()) {
+                arguments.add("-U");
+            }
+            if (getOffline().get()) {
+                arguments.add("--offline");
+            }
             arguments.addAll(Arrays.asList(
-                    "--errors",
-                    "-U",
                     "--batch-mode",
                     "--settings", settingsFile.getAbsolutePath(),
-                    "--file", pomFile.getAbsolutePath()
-            ));
+                    "--file", pomFile.getAbsolutePath()));
             arguments.addAll(getArguments().get());
+            prepareArguments(arguments);
             spec.args(arguments);
             getLogger().lifecycle("Invoking Maven with arguments " + arguments);
         });
         extractOutput(projectdir, outputDirectory);
+    }
+
+    protected void prepareArguments(List<String> arguments) {
     }
 }

--- a/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/SeedMavenRepository.java
+++ b/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/SeedMavenRepository.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and in any patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and the
+ * Larger Work(s), and to make, use, sell, offer for sale, import, export, have
+ * made, and have sold the Software and the Larger Work(s), and to sublicense
+ * the foregoing rights on either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.build.maven;
+
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.tasks.Input;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Produces the reusable Maven seed without replacing a previous valid seed until Maven succeeds.
+ * §E2E-functional-tests.4
+ */
+public abstract class SeedMavenRepository extends MavenTask {
+    public SeedMavenRepository() {
+        getOutputs().upToDateWhen(task -> hasValidSeed());
+    }
+
+    @Input
+    public abstract MapProperty<String, String> getSeedProperties();
+
+    @Override
+    protected void prepareArguments(List<String> arguments) {
+        File staging = stagingDirectory();
+        getFileSystemOperations().delete(spec -> spec.delete(staging));
+        arguments.add("-Dproject.build.directory=" + new File(staging, "target").getAbsolutePath());
+        arguments.add("-Dmaven.repo.local=" + new File(staging, "repository").getAbsolutePath());
+    }
+
+    @Override
+    protected void extractOutput(File projectDirectory, File outputDirectory) {
+        Path stagingRoot = stagingDirectory().toPath();
+        Path stagingRepository = stagingRoot.resolve("repository");
+        getFileSystemOperations().copy(spec ->
+                spec.from(stagingRoot.resolve("target")).into(stagingRepository));
+        try {
+            MavenRepositorySeedState.write(stagingRepository, currentInputKey());
+            replace(stagingRepository, outputDirectory.toPath());
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not publish the seeded Maven repository", ex);
+        }
+    }
+
+    String currentInputKey() throws IOException {
+        Map<String, String> values = new LinkedHashMap<>(getSeedProperties().get());
+        values.put("arguments", String.join("\n", getArguments().get()));
+        values.put("offline", getOffline().get().toString());
+        values.put("updateSnapshots", getUpdateSnapshots().get().toString());
+        Map<String, Path> files = new LinkedHashMap<>();
+        files.put("projectDirectory", getProjectDirectory().getAsFile().get().toPath());
+        files.put("settingsFile", getSettingsFile().getAsFile().get().toPath());
+        int index = 0;
+        for (File file : getMavenEmbedderClasspath().getFiles()) {
+            files.put("mavenEmbedderClasspath." + index++, file.toPath());
+        }
+        return MavenRepositorySeedState.inputKey(values, files);
+    }
+
+    private boolean hasValidSeed() {
+        try {
+            return MavenRepositorySeedState.isValid(
+                    getOutputDirectory().getAsFile().get().toPath(),
+                    currentInputKey());
+        } catch (IOException ex) {
+            return false;
+        }
+    }
+
+    private File stagingDirectory() {
+        return new File(getTemporaryDir(), "staging");
+    }
+
+    private void replace(Path staging, Path target) throws IOException {
+        Path backup = target.resolveSibling(target.getFileName() + ".previous");
+        getFileSystemOperations().delete(spec -> spec.delete(backup));
+        if (Files.exists(target)) {
+            move(target, backup);
+        }
+        try {
+            move(staging, target);
+            getFileSystemOperations().delete(spec -> spec.delete(backup));
+        } catch (IOException ex) {
+            if (Files.exists(backup) && !Files.exists(target)) {
+                move(backup, target);
+            }
+            throw ex;
+        }
+    }
+
+    private static void move(Path source, Path target) throws IOException {
+        Files.createDirectories(target.getParent());
+        try {
+            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException ex) {
+            Files.move(source, target);
+        }
+    }
+}

--- a/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/ValidateMavenRepositorySeed.java
+++ b/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/ValidateMavenRepositorySeed.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and in any patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and the
+ * Larger Work(s), and to make, use, sell, offer for sale, import, export, have
+ * made, and have sold the Software and the Larger Work(s), and to sublicense
+ * the foregoing rights on either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.build.maven;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+/**
+ * Performs the read-only offline seed preflight before embedded or external Maven can run.
+ * §E2E-functional-tests.4
+ */
+public abstract class ValidateMavenRepositorySeed extends DefaultTask {
+    private final SeedMavenRepository seedTask;
+
+    @Inject
+    public ValidateMavenRepositorySeed(SeedMavenRepository seedTask) {
+        this.seedTask = seedTask;
+        getOutputs().upToDateWhen(task -> false);
+    }
+
+    @Internal
+    public SeedMavenRepository getSeedTask() {
+        return seedTask;
+    }
+
+    @TaskAction
+    public void validate() {
+        try {
+            if (!MavenRepositorySeedState.isValid(
+                    seedTask.getOutputDirectory().getAsFile().get().toPath(),
+                    seedTask.currentInputKey())) {
+                throw new GradleException(MavenRepositorySeedState.INVALID_SEED_MESSAGE);
+            }
+        } catch (IOException ex) {
+            throw new GradleException(MavenRepositorySeedState.INVALID_SEED_MESSAGE, ex);
+        }
+    }
+}

--- a/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-plugin.gradle.kts
+++ b/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-plugin.gradle.kts
@@ -2,6 +2,7 @@ import org.graalvm.build.maven.GeneratePluginDescriptor
 import org.graalvm.build.maven.GenerateRuntimeMetadata
 import org.gradle.api.publish.maven.tasks.GenerateMavenPom
 import org.gradle.api.tasks.Copy
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 
@@ -85,11 +86,46 @@ val writeConstants = tasks.register<GenerateRuntimeMetadata>("writeRuntimeMetada
     metadata.put("JUNIT_PLATFORM_NATIVE_ARTIFACT_ID", "junit-platform-native")
 }
 
+val currentBuildTreePath = when {
+    gradle.buildPath == ":" -> project.path
+    project.path == ":" -> gradle.buildPath
+    else -> gradle.buildPath + project.path
+}
+
 sourceSets {
     main {
         java {
             srcDir(writeConstants)
         }
+    }
+    // Unit tests use class directories, while assembly and publication retain the packaged descriptor boundary. §AR-maven-plugin.6
+    testFixtures {
+        val externalCompileClasspath = configurations.testFixturesCompileClasspath.get().incoming.artifactView {
+            componentFilter { identifier ->
+                identifier !is ProjectComponentIdentifier || identifier.buildTreePath != currentBuildTreePath
+            }
+        }.files
+        val externalRuntimeClasspath = configurations.testFixturesRuntimeClasspath.get().incoming.artifactView {
+            componentFilter { identifier ->
+                identifier !is ProjectComponentIdentifier || identifier.buildTreePath != currentBuildTreePath
+            }
+        }.files
+        compileClasspath = sourceSets.main.get().output + externalCompileClasspath
+        runtimeClasspath = output + sourceSets.main.get().output + externalRuntimeClasspath
+    }
+    test {
+        val externalCompileClasspath = configurations.testCompileClasspath.get().incoming.artifactView {
+            componentFilter { identifier ->
+                identifier !is ProjectComponentIdentifier || identifier.buildTreePath != currentBuildTreePath
+            }
+        }.files
+        val externalRuntimeClasspath = configurations.testRuntimeClasspath.get().incoming.artifactView {
+            componentFilter { identifier ->
+                identifier !is ProjectComponentIdentifier || identifier.buildTreePath != currentBuildTreePath
+            }
+        }.files
+        compileClasspath = sourceSets.main.get().output + sourceSets.testFixtures.get().output + externalCompileClasspath
+        runtimeClasspath = output + sourceSets.main.get().output + sourceSets.testFixtures.get().output + externalRuntimeClasspath
     }
 }
 

--- a/native-maven-plugin/build-plugins/src/test/java/org/graalvm/build/maven/MavenPluginConventionTest.java
+++ b/native-maven-plugin/build-plugins/src/test/java/org/graalvm/build/maven/MavenPluginConventionTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and in any patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and the
+ * Larger Work(s), and to make, use, sell, offer for sale, import, export, have
+ * made, and have sold the Software and the Larger Work(s), and to sublicense
+ * the foregoing rights on either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.build.maven;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Protects the unit-test class-directory and assembly descriptor boundaries. §AR-maven-plugin.6
+ */
+class MavenPluginConventionTest {
+    @TempDir
+    Path projectDirectory;
+
+    @Test
+    void unitTestsDoNotBuildThePluginJarButAssemblyDoes() throws IOException {
+        writeFixture(projectDirectory);
+
+        BuildResult test = runner("test", "--dry-run").build();
+        assertTrue(test.getOutput().contains(":test SKIPPED"));
+        assertFalse(test.getOutput().contains(":jar SKIPPED"));
+        assertFalse(test.getOutput().contains(":generatePluginDescriptor SKIPPED"));
+
+        BuildResult assemble = runner("assemble", "--dry-run").build();
+        assertTrue(assemble.getOutput().contains(":jar SKIPPED"));
+        assertTrue(assemble.getOutput().contains(":generatePluginDescriptor SKIPPED"));
+    }
+
+    @Test
+    void includedBuildUnitTestsAlsoUseClassDirectories() throws IOException {
+        Path includedBuild = projectDirectory.resolve("plugin");
+        writeFixture(includedBuild);
+        Files.writeString(projectDirectory.resolve("settings.gradle.kts"), """
+                rootProject.name = "workspace"
+                includeBuild("plugin")
+                """);
+
+        BuildResult test = runner(":plugin:test", "--dry-run").build();
+        assertTrue(test.getOutput().contains(":plugin:test SKIPPED"));
+        assertFalse(test.getOutput().contains(":plugin:jar SKIPPED"));
+        assertFalse(test.getOutput().contains(":plugin:generatePluginDescriptor SKIPPED"));
+    }
+
+    private GradleRunner runner(String... arguments) {
+        return GradleRunner.create()
+                .withProjectDir(projectDirectory.toFile())
+                .withPluginClasspath()
+                .withArguments(arguments);
+    }
+
+    private void writeFixture(Path fixtureDirectory) throws IOException {
+        Files.createDirectories(fixtureDirectory);
+        Files.writeString(fixtureDirectory.resolve("settings.gradle.kts"), """
+                rootProject.name = "fixture"
+                includeBuild("utils")
+                """);
+        Files.writeString(fixtureDirectory.resolve("build.gradle.kts"), """
+                plugins {
+                    `maven-publish`
+                    id("org.graalvm.build.maven-plugin")
+                }
+
+                group = "example"
+                version = "1.0"
+
+                publishing {
+                    publications {
+                        create<MavenPublication>("mavenPlugin") {
+                            from(components["java"])
+                        }
+                    }
+                }
+                """);
+        Files.createDirectories(fixtureDirectory.resolve("config"));
+        Files.writeString(fixtureDirectory.resolve("config/settings.xml"), "<settings/>");
+        Path utils = fixtureDirectory.resolve("utils");
+        Files.createDirectories(utils);
+        Files.writeString(utils.resolve("settings.gradle.kts"), "rootProject.name = \"utils\"");
+        Files.writeString(utils.resolve("build.gradle.kts"), """
+                tasks.register("publishAllPublicationsToCommonRepository")
+                """);
+        writeJava(fixtureDirectory, "src/main/java/example/Main.java", "Main");
+        writeJava(fixtureDirectory, "src/testFixtures/java/example/Fixture.java", "Fixture");
+        writeJava(fixtureDirectory, "src/test/java/example/MainTest.java", "MainTest");
+    }
+
+    private void writeJava(Path fixtureDirectory, String path, String className) throws IOException {
+        Path file = fixtureDirectory.resolve(path);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, "package example; public class " + className + " {}");
+    }
+}

--- a/native-maven-plugin/build-plugins/src/test/java/org/graalvm/build/maven/MavenRepositorySeedStateTest.java
+++ b/native-maven-plugin/build-plugins/src/test/java/org/graalvm/build/maven/MavenRepositorySeedStateTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and in any patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and the
+ * Larger Work(s), and to make, use, sell, offer for sale, import, export, have
+ * made, and have sold the Software and the Larger Work(s), and to sublicense
+ * the foregoing rights on either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.build.maven;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Protects keyed, complete, read-only Maven seed validation. §E2E-functional-tests.4
+ */
+class MavenRepositorySeedStateTest {
+    @TempDir
+    Path temporaryDirectory;
+    private Path repository;
+    private String inputKey;
+
+    @BeforeEach
+    void createSeed() throws IOException {
+        repository = temporaryDirectory.resolve("repository");
+        Files.createDirectories(repository.resolve("example/artifact/1.0"));
+        Files.writeString(repository.resolve("example/artifact/1.0/artifact-1.0.jar"), "artifact");
+        inputKey = MavenRepositorySeedState.inputKey(Map.of("argument", "value"), Map.of());
+        MavenRepositorySeedState.write(repository, inputKey);
+    }
+
+    @Test
+    void acceptsACompleteMatchingSeed() {
+        assertTrue(MavenRepositorySeedState.isValid(repository, inputKey));
+    }
+
+    @Test
+    void rejectsMissingStaleTruncatedAndCorruptedSeeds() throws IOException {
+        assertFalse(MavenRepositorySeedState.isValid(temporaryDirectory.resolve("missing"), inputKey));
+        assertFalse(MavenRepositorySeedState.isValid(repository, "different-input-key"));
+
+        Path artifact = repository.resolve("example/artifact/1.0/artifact-1.0.jar");
+        Files.writeString(artifact, "corrupt");
+        assertFalse(MavenRepositorySeedState.isValid(repository, inputKey));
+
+        Files.writeString(artifact, "artifact");
+        Files.writeString(repository.resolve("unexpected.jar"), "unexpected");
+        assertFalse(MavenRepositorySeedState.isValid(repository, inputKey));
+    }
+
+    @Test
+    void ignoresTransientResolverFiles() throws IOException {
+        Files.writeString(repository.resolve("resolver-status.properties"), "transient");
+        Files.writeString(repository.resolve("artifact.lastUpdated"), "transient");
+        assertTrue(MavenRepositorySeedState.isValid(repository, inputKey));
+    }
+
+    @Test
+    void exposesTheStableOfflinePrerequisiteDiagnostic() {
+        assertEquals(
+                "The seeded Maven repository is missing or stale; run prepareMavenLocalRepo online.",
+                MavenRepositorySeedState.INVALID_SEED_MESSAGE);
+    }
+}

--- a/native-maven-plugin/build-plugins/src/test/java/org/graalvm/build/maven/MavenRepositorySeedTaskTest.java
+++ b/native-maven-plugin/build-plugins/src/test/java/org/graalvm/build/maven/MavenRepositorySeedTaskTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and in any patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and the
+ * Larger Work(s), and to make, use, sell, offer for sale, import, export, have
+ * made, and have sold the Software and the Larger Work(s), and to sublicense
+ * the foregoing rights on either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.build.maven;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Protects staged seed publication, failed-refresh preservation, and offline preflight. §E2E-functional-tests.4
+ */
+class MavenRepositorySeedTaskTest {
+    @TempDir
+    Path projectDirectory;
+    private Path repository;
+
+    @BeforeEach
+    void writeFixture() throws IOException {
+        repository = projectDirectory.resolve("build/seed");
+        Files.writeString(projectDirectory.resolve("settings.gradle"), "rootProject.name = 'seed-fixture'");
+        Files.writeString(projectDirectory.resolve("build.gradle"), """
+                import org.graalvm.build.maven.SeedMavenRepository
+                import org.graalvm.build.maven.ValidateMavenRepositorySeed
+
+                plugins {
+                    id 'java'
+                    id 'java-test-fixtures'
+                    id 'org.graalvm.build.maven-embedder'
+                }
+
+                def seed = tasks.register('seed', SeedMavenRepository) {
+                    dependsOn(tasks.classes)
+                    projectDirectory.set(layout.projectDirectory.dir('seed-project'))
+                    settingsFile.set(layout.projectDirectory.file('seed-project/settings.xml'))
+                    pomFile.set(layout.projectDirectory.file('seed-project/pom.xml'))
+                    mavenEmbedderClasspath.from(sourceSets.main.output)
+                    outputDirectory.set(layout.buildDirectory.dir('seed'))
+                    seedProperties.put('key', providers.gradleProperty('key').orElse('current'))
+                    arguments.set(providers.gradleProperty('fail').map { ['-Dfail=true'] }.orElse([]))
+                }
+
+                tasks.register('validateSeed', ValidateMavenRepositorySeed, seed.get())
+                """);
+        Path seedProject = projectDirectory.resolve("seed-project");
+        Files.createDirectories(seedProject);
+        Files.writeString(seedProject.resolve("settings.xml"), "<settings/>");
+        Files.writeString(seedProject.resolve("pom.xml"), "<project/>");
+        Path source = projectDirectory.resolve("src/main/java/org/apache/maven/cli/MavenCli.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, """
+                package org.apache.maven.cli;
+
+                import java.nio.file.Files;
+                import java.nio.file.Path;
+
+                public class MavenCli {
+                    public static void main(String[] args) throws Exception {
+                        for (String argument : args) {
+                            if ("-Dfail=true".equals(argument)) {
+                                System.exit(1);
+                            }
+                            if (argument.startsWith("-Dmaven.repo.local=")) {
+                                Path repository = Path.of(argument.substring("-Dmaven.repo.local=".length()));
+                                Files.createDirectories(repository);
+                                Files.writeString(repository.resolve("artifact.jar"), "complete");
+                            }
+                        }
+                    }
+                }
+                """);
+    }
+
+    @Test
+    void failedRefreshPreservesThePreviousSeed() throws IOException {
+        runner("seed").build();
+        Path artifact = repository.resolve("artifact.jar");
+        Path manifest = repository.resolve(MavenRepositorySeedState.MANIFEST_NAME);
+        byte[] artifactBefore = Files.readAllBytes(artifact);
+        byte[] manifestBefore = Files.readAllBytes(manifest);
+
+        runner("seed", "-Pfail=true", "--rerun-tasks").buildAndFail();
+
+        assertArrayEquals(artifactBefore, Files.readAllBytes(artifact));
+        assertArrayEquals(manifestBefore, Files.readAllBytes(manifest));
+    }
+
+    @Test
+    void validatorAcceptsCurrentStateAndRejectsStaleAndCorruptState() throws IOException {
+        runner("seed").build();
+        runner("validateSeed").build();
+
+        BuildResult stale = runner("validateSeed", "-Pkey=changed").buildAndFail();
+        assertTrue(stale.getOutput().contains(MavenRepositorySeedState.INVALID_SEED_MESSAGE));
+
+        Files.writeString(repository.resolve("artifact.jar"), "corrupt");
+        BuildResult corrupt = runner("validateSeed").buildAndFail();
+        assertTrue(corrupt.getOutput().contains(MavenRepositorySeedState.INVALID_SEED_MESSAGE));
+    }
+
+    @Test
+    void normalOnlineSeedTaskRepairsAnInvalidSeed() throws IOException {
+        runner("seed").build();
+        Files.writeString(repository.resolve("artifact.jar"), "corrupt");
+
+        BuildResult repaired = runner("seed").build();
+
+        assertNotNull(repaired.task(":seed"));
+        assertEquals(TaskOutcome.SUCCESS, repaired.task(":seed").getOutcome());
+        assertEquals("complete", Files.readString(repository.resolve("artifact.jar")));
+        runner("validateSeed").build();
+    }
+
+    @Test
+    void validatorRejectsMissingStateWithTheStableDiagnostic() {
+        BuildResult missing = runner("validateSeed").buildAndFail();
+        assertTrue(missing.getOutput().contains(MavenRepositorySeedState.INVALID_SEED_MESSAGE));
+        assertFalse(Files.exists(repository));
+    }
+
+    private GradleRunner runner(String... arguments) {
+        return GradleRunner.create()
+                .withProjectDir(projectDirectory.toFile())
+                .withPluginClasspath()
+                .withArguments(arguments);
+    }
+}

--- a/native-maven-plugin/build.gradle.kts
+++ b/native-maven-plugin/build.gradle.kts
@@ -39,7 +39,8 @@
  * SOFTWARE.
  */
 
-import org.graalvm.build.maven.MavenTask
+import org.graalvm.build.maven.SeedMavenRepository
+import org.graalvm.build.maven.ValidateMavenRepositorySeed
 
 plugins {
     `java-library`
@@ -112,14 +113,6 @@ publishing {
 
 val localRepositoryDir = project.layout.buildDirectory.dir("maven-seeded-repo")
 
-tasks {
-    generatePluginDescriptor {
-        dependsOn(prepareMavenLocalRepo)
-        commonRepository.set(repoDirectory)
-        localRepository.set(localRepositoryDir)
-    }
-}
-
 val seedingDir = project.layout.buildDirectory.dir("maven-seeding")
 
 val prepareSeedingProject = tasks.register<Sync>("prepareSeedingProject") {
@@ -128,30 +121,57 @@ val prepareSeedingProject = tasks.register<Sync>("prepareSeedingProject") {
     outputs.upToDateWhen { false }
 }
 
-val prepareMavenLocalRepo = tasks.register<MavenTask>("prepareMavenLocalRepo") {
+// Online seed production stages and atomically publishes a complete repository. §E2E-functional-tests.4
+val prepareMavenLocalRepo = tasks.register<SeedMavenRepository>("prepareMavenLocalRepo") {
     dependsOn(prepareSeedingProject)
     projectDirectory.set(prepareSeedingProject.map { seedingDir.get() })
     settingsFile.set(layout.projectDirectory.file("config/settings.xml"))
     pomFile.set(seedingDir.map { it.file("pom.xml") })
     mavenEmbedderClasspath.from(configurations.mavenEmbedder)
     outputDirectory.set(localRepositoryDir)
+    updateSnapshots.set(true)
+    seedProperties.put("junit.jupiter.version", libs.versions.junitJupiter)
+    seedProperties.put("native.maven.plugin.version", libs.versions.nativeBuildTools)
+    seedProperties.put("junit.platform.native.version", libs.versions.nativeBuildTools)
+    seedProperties.put("exec.mainClass", "org.graalvm.demo.Application")
+    seedProperties.put("openjson.version", libs.versions.openjson)
+    seedProperties.put("cyclonedx.maven.version", libs.versions.cyclonedxMaven)
+    seedProperties.put("plugin.executor.maven.version", libs.versions.pluginExecutorMaven)
     arguments.set(listOf(
             "-q",
-            "-Dproject.build.directory=${File(temporaryDir, "target")}",
-            "-Dmaven.repo.local=${localRepositoryDir.get().asFile.absolutePath}",
             "-Djunit.jupiter.version=${libs.versions.junitJupiter.get()}",
             "-Dnative.maven.plugin.version=${libs.versions.nativeBuildTools.get()}",
             "-Djunit.platform.native.version=${libs.versions.nativeBuildTools.get()}",
             "-Dexec.mainClass=org.graalvm.demo.Application",
+            "-Dopenjson.version=${libs.versions.openjson.get()}",
+            "-Dcyclonedx.maven.version=${libs.versions.cyclonedxMaven.get()}",
+            "-Dplugin.executor.maven.version=${libs.versions.pluginExecutorMaven.get()}",
             "package",
             "test",
             "install",
-            "exec:java"
+            "exec:java",
+            "help:effective-pom"
     )
     )
+}
 
-    doFirst {
-        delete { delete { localRepositoryDir.get().asFile } }
+// Offline prerequisites validate the existing seed without writes or Maven execution. §E2E-functional-tests.4
+val validateMavenLocalRepo = tasks.register<ValidateMavenRepositorySeed>(
+    "validateMavenLocalRepo",
+    prepareMavenLocalRepo.get()
+)
+val mavenRepositoryPrerequisite = if (gradle.startParameter.isOffline) {
+    validateMavenLocalRepo
+} else {
+    prepareMavenLocalRepo
+}
+
+tasks {
+    generatePluginDescriptor {
+        dependsOn(mavenRepositoryPrerequisite)
+        commonRepository.set(repoDirectory)
+        localRepository.set(localRepositoryDir)
+        offline.set(gradle.startParameter.isOffline)
     }
 }
 
@@ -168,7 +188,7 @@ val launcher = javaToolchains.launcherFor {
 tasks {
     functionalTest {
         javaLauncher.set(launcher)
-        dependsOn(prepareMavenLocalRepo, publishAllPublicationsToCommonRepository)
+        dependsOn(mavenRepositoryPrerequisite, publishAllPublicationsToCommonRepository)
         systemProperty("graalvm.version", libs.versions.graalvm.get())
         systemProperty("junit.jupiter.version", libs.versions.junitJupiter.get())
         systemProperty("native.maven.plugin.version", libs.versions.nativeBuildTools.get())
@@ -176,6 +196,7 @@ tasks {
         systemProperty("common.repo.uri", repoDirectory.get().asFile.toURI().toASCIIString())
         systemProperty("seed.repo.uri", localRepositoryDir.get().asFile.toURI().toASCIIString())
         systemProperty("maven.settings", layout.projectDirectory.file("config/settings.xml").asFile.absolutePath)
+        systemProperty("maven.offline", gradle.startParameter.isOffline)
         systemProperty("java.executable", javaLauncher.get().executablePath.asFile.absolutePath)
         inputs.files(configurations.mavenEmbedder)
         doFirst {

--- a/native-maven-plugin/docs/architecture.md
+++ b/native-maven-plugin/docs/architecture.md
@@ -83,6 +83,14 @@ The module owns Maven-specific functional test infrastructure and reproducers. F
 seed a local Maven repository so sample projects can resolve the plugin and support artifacts
 without depending on external publication.
 
+Ordinary unit tests consume the main and test-fixture class and resource directories directly.
+They do not assemble the Maven plugin JAR or generate its descriptor. Assembly, publication, and
+functional tests retain the artifact boundary: the JAR includes the embedded-Maven-generated
+descriptor, and real Maven functional tests resolve the published artifact through repository-
+controlled repositories. This separation keeps unit feedback independent of Maven repository
+bootstrap work while preserving the packaged-plugin integration path
+[§root/GOAL-fast-feedback](../../docs/spec/goals.md#goal-fast-feedback-native-build-workflows-provide-feedback-as-fast-as-practical).
+
 Samples under `samples/` provide cross-plugin Maven scenarios when possible. Dedicated
 `native-maven-plugin/reproducers/` projects are appropriate for Maven-specific regressions whose
 shape would not make sense as a shared sample.

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -94,6 +94,21 @@ keeps tests independent from external publication and protects the Maven-specifi
 The local repository is part of the test contract: tests should resolve the plugin exactly as a
 sample project would, rather than reaching into compiled classes directly.
 
+Online `prepareMavenLocalRepo` builds a replacement seed in staging and publishes it only after
+Maven succeeds. Its seed-state manifest keys the prepared seeding project, Maven settings,
+embedder classpath, goals, flags, supplied version/system-property values, and seed schema. The
+manifest inventories every stable repository file by relative path and content hash; transient
+locks, temporary downloads, and resolver-status files are excluded.
+
+Offline descriptor and functional-test prerequisites validate that manifest without invoking
+Maven or modifying the repository. Validation requires the current input key and the complete
+inventoried file set with matching hashes. Missing, stale, truncated, or corrupted state fails
+with: `The seeded Maven repository is missing or stale; run prepareMavenLocalRepo online.` A
+failed online refresh or offline validation must leave the previous repository unchanged. Offline
+functional tests copy the validated seed and current common publication repository into their
+isolated local repository and invoke Maven offline, so they neither alter the seed nor contact
+remote repositories.
+
 ## 5. CI coverage
 
 `test-native-maven-plugin.yml` runs generated Maven functional-test matrices, Maven plugin

--- a/native-maven-plugin/src/seeding-build/pom.xml
+++ b/native-maven-plugin/src/seeding-build/pom.xml
@@ -53,6 +53,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.jupiter.version>5.8.1</junit.jupiter.version>
         <graalvm.version>22.0.0</graalvm.version>
+        <openjson.version>1.0.13</openjson.version>
+        <cyclonedx.maven.version>2.9.1</cyclonedx.maven.version>
+        <plugin.executor.maven.version>2.4.1</plugin.executor.maven.version>
         <mainClass>org.graalvm.demo.Application</mainClass>
     </properties>
 
@@ -69,6 +72,22 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Seed Maven plugin runtime dependencies for read-only offline functional tests. §E2E-functional-tests.4 -->
+        <dependency>
+            <groupId>com.github.openjson</groupId>
+            <artifactId>openjson</artifactId>
+            <version>${openjson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <version>${cyclonedx.maven.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.twdata.maven</groupId>
+            <artifactId>mojo-executor</artifactId>
+            <version>${plugin.executor.maven.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/AbstractGraalVMMavenFunctionalTest.groovy
+++ b/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/AbstractGraalVMMavenFunctionalTest.groovy
@@ -50,8 +50,10 @@ import spock.lang.TempDir
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 
+// Real Maven fixtures reuse validated repositories without remote access in offline mode. §E2E-functional-tests.4
 abstract class AbstractGraalVMMavenFunctionalTest extends Specification {
     @TempDir
     Path testDirectory
@@ -159,7 +161,13 @@ abstract class AbstractGraalVMMavenFunctionalTest extends Specification {
                 "seed.repo.uri": System.getProperty("seed.repo.uri"),
         ]
         if (System.getProperty("noTestIsolation") == null) {
-            resultingSystemProperties.put("maven.repo.local", testDirectory.resolve("local-repo").toFile().absolutePath)
+            Path localRepository = testDirectory.resolve("local-repo")
+            if (Boolean.getBoolean("maven.offline")) {
+                copyRepository(System.getProperty("seed.repo.uri"), localRepository)
+                copyRepository(System.getProperty("common.repo.uri"), localRepository)
+                materializeLocalSnapshots(localRepository)
+            }
+            resultingSystemProperties.put("maven.repo.local", localRepository.toFile().absolutePath)
         }
         resultingSystemProperties.putAll(systemProperties)
         if (resultingSystemProperties.containsKey("maven.repo.local")) {
@@ -171,11 +179,54 @@ abstract class AbstractGraalVMMavenFunctionalTest extends Specification {
         result = executor.execute(
                 testDirectory.toFile(),
                 resultingSystemProperties,
-                [*injectedSystemProperties,
+                [*(Boolean.getBoolean("maven.offline") ? ["--offline"] : []),
+                 *injectedSystemProperties,
                  *args],
                 new File(System.getProperty("maven.settings"))
         )
         println "Exit code is ${result.exitCode}"
+    }
+
+    private static void copyRepository(String repositoryUri, Path target) {
+        Path source = Paths.get(URI.create(repositoryUri))
+        Files.walk(source).forEach(sourcePath -> {
+            Path targetPath = target.resolve(source.relativize(sourcePath))
+            if (Files.isDirectory(sourcePath)) {
+                Files.createDirectories(targetPath)
+            } else {
+                Files.createDirectories(targetPath.parent)
+                Files.copy(sourcePath, targetPath, StandardCopyOption.REPLACE_EXISTING)
+            }
+        })
+    }
+
+    private static void materializeLocalSnapshots(Path repository) {
+        Files.walk(repository)
+                .filter { it.fileName.toString() == "maven-metadata.xml" }
+                .forEach { metadataFile ->
+                    String metadata = Files.readString(metadataFile)
+                    String artifactId = xmlValue(metadata, "artifactId")
+                    String version = xmlValue(metadata, "version")
+                    if (artifactId && version.endsWith("-SNAPSHOT")) {
+                        (metadata =~ /(?s)<snapshotVersion>(.*?)<\/snapshotVersion>/).each { match ->
+                            String snapshot = match[1]
+                            String extension = xmlValue(snapshot, "extension")
+                            String value = xmlValue(snapshot, "value")
+                            String classifier = xmlValue(snapshot, "classifier")
+                            String classified = classifier ? "-${classifier}" : ""
+                            Path source = metadataFile.parent.resolve("${artifactId}-${value}${classified}.${extension}")
+                            Path target = metadataFile.parent.resolve("${artifactId}-${version}${classified}.${extension}")
+                            if (Files.isRegularFile(source)) {
+                                Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING)
+                            }
+                        }
+                    }
+                }
+    }
+
+    private static String xmlValue(String xml, String element) {
+        def matcher = xml =~ /(?s)<${element}>(.*?)<\/${element}>/
+        matcher.find() ? matcher.group(1).trim() : ""
     }
 
     void mvnDebug(String... args) {


### PR DESCRIPTION
## What changed

`./gradlew -p native-maven-plugin test` now runs Maven plugin unit tests without building the plugin JAR, generating its Maven descriptor, preparing a Maven local repository, or launching embedded Maven. Unit tests use compiled class and resource directories directly.

Descriptor generation, publication, inspections, and functional tests still use the packaged plugin descriptor and controlled Maven repositories. Offline functional work now validates a keyed, complete seed without modifying it and reports the recovery command when the seed is missing or stale.

## Why

Transient Maven repository failures should not prevent ordinary unit tests from running after Gradle dependencies are available. Network-dependent repository seeding remains part of the integration boundary, while offline failures are deterministic and actionable when that prerequisite is genuinely required.

Fixes #985

## Example

```text
./gradlew -p native-maven-plugin test
```

The unit-test task graph no longer schedules `jar`, `generatePluginDescriptor`, `prepareMavenLocalRepo`, or `validateMavenLocalRepo`. For offline integration work with an invalid seed, validation fails before Maven starts with:

```text
The seeded Maven repository is missing or stale; run prepareMavenLocalRepo online.
```

## Implementation summary

- Replaced the Maven module's unit-test self-artifact dependencies with main and test-fixture class/resource outputs for standalone and included-build layouts.
- Made Maven offline mode and snapshot updates explicit task inputs instead of applying unconditional updates to every Maven invocation.
- Added schema-versioned, input-keyed seed manifests with complete file inventories and SHA-256 validation.
- Added staged, failure-safe online seed replacement and read-only offline preflight; normal `prepareMavenLocalRepo` now rebuilds a seed rejected by validation.
- Preserved packaged descriptor generation and real Maven functional coverage, including offline descriptor loading.

## Validation

The following checks passed:

- `grund check`
- `grund fmt . --marker --cross-refs --check`
- `git diff --check`
- `./gradlew -p native-maven-plugin/build-plugins test`
- `./gradlew -p native-maven-plugin --offline test --rerun-tasks`
- `./gradlew :native-maven-plugin:inspections`
- `./gradlew -p native-maven-plugin prepareMavenLocalRepo`
- `./gradlew -p native-maven-plugin --offline validateMavenLocalRepo`
- `./gradlew -p native-maven-plugin --offline validateMavenLocalRepo assemble`
- `./gradlew -p native-maven-plugin publishAllPublicationsToCommonRepository`
- standalone and workspace `test --dry-run` task-graph assertions excluding the module JAR, descriptor, seed, and validation tasks
- targeted Maven descriptor inspection confirming `META-INF/maven/plugin.xml` and `plugin-help.xml`
- offline seed rejection and normal online recovery after adding an unexpected seed file
- online and offline `JavaApplicationFunctionalTest` `help:describe` descriptor-loading scenario

The full Maven functional matrix, full repository build, exact CI matrix, documentation render, and GraalVM/native-image jobs were not run in this environment. The external-Maven descriptor-loading scenario was not rerun during review cycle 2, and validation did not use a fresh isolated Gradle user home; the affected unit lifecycle was instead run offline with `--rerun-tasks`.

## AI workflow

Generated by [Rhei](https://github.com/vjovanov/rhei)’s `github-issue-fix` workflow using 16 completed AI-assisted steps, 3 resolved models, and 2 focused review cycles.

<details>
<summary>View AI workflow details</summary>

Approved proposal: `16eeea21f028a2e1`.

1. Issue intake and repository grounding

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 869285 total · 855888 input (785536 cached) · 13397 output

Captured the issue, repository rules, specifications, and implementation scope.

2. Implement approved fix

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 14701992 total · 14655788 input (14356736 cached) · 46204 output

Implemented the class-directory unit-test boundary and failure-safe Maven seed lifecycle.

3. Validate implementation — visit 1

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 2765066 total · 2750625 input (2645376 cached) · 14441 output

Ran the initial grounding, build, task-graph, seed, descriptor, and functional validation.

4. Requirements review — cycle 1

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 258674 total · 256091 input (213504 cached) · 2583 output

Checked the implementation against issue acceptance criteria and preserved CI coverage.

5. Spec review — cycle 1

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 255517 total · 252001 input (211456 cached) · 3516 output

Checked the amended architecture and end-to-end specifications and their citations.

6. Implementation review — cycle 1

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 238414 total · 234116 input (191488 cached) · 4298 output

Inspected the implementation for behavior, safety, and regression coverage.

7. Validation review — cycle 1

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 164509 total · 161112 input (129280 cached) · 3397 output

Reviewed validation evidence and identified the seed up-to-date recovery blocker.

8. Aggregate review — cycle 1

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 238584 total · 236278 input (206208 cached) · 2306 output

Aggregated the first review cycle and routed the repair.

9. Address review findings — repair cycle 1

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 578339 total · 573207 input (523264 cached) · 5132 output

Added seed validity to the task up-to-date predicate and a TestKit recovery regression.

10. Validate repaired implementation — visit 2

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 2772229 total · 2758101 input (2651776 cached) · 14128 output

Verified invalid-seed rejection, normal online recovery, offline reuse, and assembly.

11. Requirements review — cycle 2

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 261272 total · 258782 input (218112 cached) · 2490 output

Rechecked issue fit after the repair with no requirements blockers.

12. Spec review — cycle 2

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 229933 total · 227607 input (183936 cached) · 2326 output

Rechecked strict grounding and the amended specification points with no blockers.

13. Implementation review — cycle 2

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 565495 total · 558965 input (506240 cached) · 6530 output

Re-reviewed the repaired code and regression coverage with no implementation blockers.

14. Validation review — cycle 2

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 229414 total · 224250 input (188928 cached) · 5164 output

Re-reviewed focused validation and recorded the remaining environment-dependent checks.

15. Aggregate review — cycle 2

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 199023 total · 197091 input (172416 cached) · 1932 output

Confirmed no blockers and approved publication with the validation limitations disclosed above.

16. Publish ready PR

Model: openai:gpt-5.6-luna · Agent: codex · Reasoning effort: medium  
Tokens: not finalized at PR creation

Committed the reviewed fix, pushed `graalvm:rhei/issue-985` to `origin`, opened the ready-for-review PR, and applied existing configured labels.

**Aggregate token usage:** 24327746 total · 24199902 input (23184256 cached) · 127844 output

The aggregate excludes the current unfinalized publication step. Deterministic program routing is non-model work. Focused review cycles: 2. Review-repair cycles: 1. Accounting coverage: 15 finalized of 16 listed steps. Superseded attempts: none. Unmeasured attempts: none. Unsupported cache dimensions: input cache write, output cached read, and output cache write.

</details>
