### PR TITLE
Uplift the Native Image layer configuration model

### DIFF
--- a/common/docs/architecture.md
+++ b/common/docs/architecture.md
@@ -21,8 +21,10 @@ behavior, and JUnit configuration providers.
 ## 2. Utility architecture
 
 Utilities must remain Java libraries with plain inputs and outputs. Native Image utilities accept
-strings, paths, versions, and option collections; they must not know whether a caller is Gradle,
-Maven, a unit test, or another tool.
+strings, paths, versions, and option collections; layer selection is represented by immutable
+plain Java values whose rendering is shared by both plugins. Utilities must not know whether a
+caller is Gradle, Maven, a unit test, or another tool.
+[§FS-common-libraries.1](functional-spec.md#1-shared-native-image-utilities).
 
 Resource analyzers operate on classpath directories and JAR files. Build-tool integrations are
 responsible for selecting classpath entries; analyzers are responsible for interpreting those

--- a/common/docs/functional-spec.md
+++ b/common/docs/functional-spec.md
@@ -32,6 +32,15 @@ regardless of its vendor label and retaining compatibility behavior when that re
 identified; and centralize Native Image configuration file names and metadata directory names used
 by plugins and tests.
 
+Layer creation uses an immutable, build-tool-neutral artifact selection containing an `all`
+selection, ordered module names, ordered package names, and ordered resolved paths. The shared
+renderer owns the complete `-H:LayerCreate` grammar: `all` renders as an unqualified layer-create
+argument whose contents come from the plugin-supplied classpath, while narrower selections render
+`module=`, `package=`, and `path=` selectors. It rejects blank names and selector values, rejects
+`all` combined with narrower selectors, and preserves selector order. Gradle and Maven must
+resolve their dependency models to paths before calling it.
+[§REQ-no-buildtool-apis](requirements.md#req-no-buildtool-apis-common-runtime-libraries-do-not-depend-on-gradle-or-maven-apis).
+
 ## 2. Resource configuration
 
 Resource detection helps users include non-classpath resources without hand-written
@@ -141,7 +150,7 @@ produce a later, less actionable native-image failure.
 ## 8. Verification surface
 
 Common utility and reachability metadata modules must have unit tests for argument conversion,
-resource scanning, agent mode command lines, repository index parsing, metadata lookup, missing
-metadata support, schema validation, and Native Image version behavior. Product plugin functional
-tests cover these shared behaviors through Gradle and Maven sample projects as part of
+layer selection and rendering, resource scanning, agent mode command lines, repository index
+parsing, metadata lookup, missing metadata support, schema validation, and Native Image version
+behavior. Product plugin functional tests cover these shared behaviors through Gradle and Maven sample projects as part of
 [§root/FS-plugin-common.2](../../docs/spec/functional/plugin-common.md#2-verification-surface) and [§E2E-common-tests](e2e.md#e2e-common-tests-common-library-tests-exercise-shared-native-image-support-behavior).

--- a/common/docs/functional-spec.md
+++ b/common/docs/functional-spec.md
@@ -37,7 +37,10 @@ selection, ordered module names, ordered package names, and ordered resolved pat
 renderer owns the complete `-H:LayerCreate` grammar: `all` renders as an unqualified layer-create
 argument whose contents come from the plugin-supplied classpath, while narrower selections render
 `module=`, `package=`, and `path=` selectors. It rejects blank names and selector values, rejects
-`all` combined with narrower selectors, and preserves selector order. Gradle and Maven must
+names outside `[A-Za-z0-9._-]+`, and preserves selector order. `all` may be combined with module or
+package selectors; the plugin-supplied classpath still represents the complete dependency graph.
+Native Image version detection recognizes vendor suffixes when applying layer-consumption gates.
+Gradle and Maven must
 resolve their dependency models to paths before calling it.
 [§REQ-no-buildtool-apis](requirements.md#req-no-buildtool-apis-common-runtime-libraries-do-not-depend-on-gradle-or-maven-apis).
 

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/ArtifactSelection.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/ArtifactSelection.java
@@ -62,9 +62,6 @@ public final class ArtifactSelection {
         if (this.paths.stream().anyMatch(Objects::isNull)) {
             throw new IllegalArgumentException("Layer paths must not contain null values");
         }
-        if (all && (!this.modules.isEmpty() || !this.packages.isEmpty() || !this.paths.isEmpty())) {
-            throw new IllegalArgumentException("The 'all' layer selector cannot be combined with modules, packages, or paths");
-        }
     }
 
     public static ArtifactSelection empty() {

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/ArtifactSelection.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/ArtifactSelection.java
@@ -94,4 +94,8 @@ public final class ArtifactSelection {
     public List<Path> getPaths() {
         return paths;
     }
+
+    public boolean isEmpty() {
+        return !all && modules.isEmpty() && packages.isEmpty() && paths.isEmpty();
+    }
 }

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/ArtifactSelection.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/ArtifactSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,52 +38,60 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.graalvm.buildtools.utils;
 
-plugins {
-    id 'application'
-    id 'org.graalvm.buildtools.native'
-}
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
 
-repositories {
-    mavenCentral()
-}
+/**
+ * Immutable build-tool-neutral selection of artifacts for a Native Image layer.
+ * §FS-common-libraries.1.
+ */
+public final class ArtifactSelection {
+    private final boolean all;
+    private final List<String> modules;
+    private final List<String> packages;
+    private final List<Path> paths;
 
-application {
-    mainClass.set('org.graalvm.demo.Application')
-}
-
-def junitVersion = providers.gradleProperty('junit.jupiter.version')
-        .get()
-
-dependencies {
-    implementation("org.slf4j:slf4j-api:2.0.17")
-    runtimeOnly("ch.qos.logback:logback-classic:1.5.6")
-    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
-}
-
-test {
-    useJUnitPlatform()
-}
-
-tasks.named("nativeRun") {
-    runtimeArgs.add(providers.gradleProperty("message").orElse("default message"))
-}
-
-graalvmNative {
-    // Named layers are built independently from application binaries. §gradle/FS-plugin-model.2.
-    layers {
-        dependencies {
-            contents {
-                modules("java.base")
-                fromConfiguration(configurations.runtimeClasspath)
-            }
+    public ArtifactSelection(boolean all, List<String> modules, List<String> packages, List<Path> paths) {
+        this.all = all;
+        this.modules = validatedStrings("module", modules);
+        this.packages = validatedStrings("package", packages);
+        this.paths = List.copyOf(Objects.requireNonNull(paths, "paths"));
+        if (this.paths.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException("Layer paths must not contain null values");
+        }
+        if (all && (!this.modules.isEmpty() || !this.packages.isEmpty() || !this.paths.isEmpty())) {
+            throw new IllegalArgumentException("The 'all' layer selector cannot be combined with modules, packages, or paths");
         }
     }
-    binaries {
-        main {
-            layer = graalvmNative.layers.dependencies
+
+    public static ArtifactSelection empty() {
+        return new ArtifactSelection(false, List.of(), List.of(), List.of());
+    }
+
+    private static List<String> validatedStrings(String kind, List<String> values) {
+        List<String> copy = List.copyOf(Objects.requireNonNull(values, kind + "s"));
+        if (copy.stream().anyMatch(value -> value == null || value.isBlank())) {
+            throw new IllegalArgumentException("Layer " + kind + " selectors must not be blank");
         }
+        return copy;
+    }
+
+    public boolean isAll() {
+        return all;
+    }
+
+    public List<String> getModules() {
+        return modules;
+    }
+
+    public List<String> getPackages() {
+        return packages;
+    }
+
+    public List<Path> getPaths() {
+        return paths;
     }
 }

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageLayerArguments.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageLayerArguments.java
@@ -52,7 +52,8 @@ import java.util.regex.Pattern;
  * Shared rendering of Native Image layer arguments. §FS-common-libraries.1.
  */
 public final class NativeImageLayerArguments {
-    private static final Pattern NATIVE_IMAGE_25_0_3 = Pattern.compile("(?m)^native-image\\s+25\\.0\\.3(?:\\s|$)");
+    private static final Pattern UNSUPPORTED_LAYER_CONSUMPTION_VERSION =
+        Pattern.compile("(?m)^native-image\\s+25\\.0\\.[34](?:\\s|$)");
 
     private NativeImageLayerArguments() {
     }
@@ -77,7 +78,9 @@ public final class NativeImageLayerArguments {
     }
 
     public static boolean isLayerConsumptionUnsupported(String versionInformation) {
-        return NATIVE_IMAGE_25_0_3.matcher(Objects.requireNonNull(versionInformation, "versionInformation")).find();
+        return UNSUPPORTED_LAYER_CONSUMPTION_VERSION
+            .matcher(Objects.requireNonNull(versionInformation, "versionInformation"))
+            .find();
     }
 
     private static void validateLayerName(String layerName) {

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageLayerArguments.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageLayerArguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,52 +38,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.graalvm.buildtools.utils;
 
-plugins {
-    id 'application'
-    id 'org.graalvm.buildtools.native'
-}
+import org.graalvm.buildtools.model.resources.NativeImageFlags;
 
-repositories {
-    mavenCentral()
-}
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
-application {
-    mainClass.set('org.graalvm.demo.Application')
-}
-
-def junitVersion = providers.gradleProperty('junit.jupiter.version')
-        .get()
-
-dependencies {
-    implementation("org.slf4j:slf4j-api:2.0.17")
-    runtimeOnly("ch.qos.logback:logback-classic:1.5.6")
-    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
-}
-
-test {
-    useJUnitPlatform()
-}
-
-tasks.named("nativeRun") {
-    runtimeArgs.add(providers.gradleProperty("message").orElse("default message"))
-}
-
-graalvmNative {
-    // Named layers are built independently from application binaries. §gradle/FS-plugin-model.2.
-    layers {
-        dependencies {
-            contents {
-                modules("java.base")
-                fromConfiguration(configurations.runtimeClasspath)
-            }
-        }
+/**
+ * Shared rendering of Native Image layer arguments. §FS-common-libraries.1.
+ */
+public final class NativeImageLayerArguments {
+    private NativeImageLayerArguments() {
     }
-    binaries {
-        main {
-            layer = graalvmNative.layers.dependencies
+
+    public static String renderLayerCreate(String layerName, ArtifactSelection selection) {
+        validateLayerName(layerName);
+        Objects.requireNonNull(selection, "selection");
+        List<String> selectors = new ArrayList<>();
+        selection.getModules().forEach(module -> selectors.add("module=" + module));
+        selection.getPackages().forEach(packageName -> selectors.add("package=" + packageName));
+        selection.getPaths().forEach(path -> selectors.add("path=" + path));
+        String argument = NativeImageFlags.LAYER_CREATE + "=" + layerName + ".nil";
+        return selectors.isEmpty() ? argument : argument + "," + String.join(",", selectors);
+    }
+
+    public static String renderLayerUse(Path layerFile) {
+        Objects.requireNonNull(layerFile, "layerFile");
+        return NativeImageFlags.LAYER_USE + "=" + layerFile.toAbsolutePath();
+    }
+
+    private static void validateLayerName(String layerName) {
+        if (layerName == null || layerName.isBlank()) {
+            throw new IllegalArgumentException("Layer name must not be blank");
         }
     }
 }

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageLayerArguments.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageLayerArguments.java
@@ -52,12 +52,6 @@ import java.util.regex.Pattern;
  * Shared rendering of Native Image layer arguments. §FS-common-libraries.1.
  */
 public final class NativeImageLayerArguments {
-    private static final Pattern GRAALVM_RUNTIME_VERSION = Pattern.compile(
-        "(?m)^GraalVM Runtime Environment .*\\s(\\d+\\.\\d+\\.\\d+(?:[.+-][^\\s]*)?)\\s+\\(build");
-    private static final Pattern NATIVE_IMAGE_VERSION = Pattern.compile(
-        "(?m)^native-image\\s+(\\d+\\.\\d+\\.\\d+(?:[.+-][^\\s]*)?)(?:\\s|$)");
-    private static final Pattern UNSUPPORTED_LAYER_CONSUMPTION_VERSION =
-        Pattern.compile("25\\.0\\.[34](?:[.+-].*)?");
     private static final Pattern VALID_LAYER_NAME = Pattern.compile("[A-Za-z0-9._-]+");
 
     private NativeImageLayerArguments() {
@@ -80,17 +74,6 @@ public final class NativeImageLayerArguments {
     public static String renderLayerUse(Path layerFile) {
         Objects.requireNonNull(layerFile, "layerFile");
         return NativeImageFlags.LAYER_USE + "=" + layerFile.toAbsolutePath();
-    }
-
-    public static boolean isLayerConsumptionUnsupported(String versionInformation) {
-        String information = Objects.requireNonNull(versionInformation, "versionInformation");
-        var runtimeVersion = GRAALVM_RUNTIME_VERSION.matcher(information);
-        if (runtimeVersion.find()) {
-            return UNSUPPORTED_LAYER_CONSUMPTION_VERSION.matcher(runtimeVersion.group(1)).matches();
-        }
-        var nativeImageVersion = NATIVE_IMAGE_VERSION.matcher(information);
-        return nativeImageVersion.find()
-            && UNSUPPORTED_LAYER_CONSUMPTION_VERSION.matcher(nativeImageVersion.group(1)).matches();
     }
 
     public static void validateLayerName(String layerName) {

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageLayerArguments.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageLayerArguments.java
@@ -52,8 +52,13 @@ import java.util.regex.Pattern;
  * Shared rendering of Native Image layer arguments. §FS-common-libraries.1.
  */
 public final class NativeImageLayerArguments {
+    private static final Pattern GRAALVM_RUNTIME_VERSION = Pattern.compile(
+        "(?m)^GraalVM Runtime Environment .*\\s(\\d+\\.\\d+\\.\\d+(?:[.+-][^\\s]*)?)\\s+\\(build");
+    private static final Pattern NATIVE_IMAGE_VERSION = Pattern.compile(
+        "(?m)^native-image\\s+(\\d+\\.\\d+\\.\\d+(?:[.+-][^\\s]*)?)(?:\\s|$)");
     private static final Pattern UNSUPPORTED_LAYER_CONSUMPTION_VERSION =
-        Pattern.compile("(?m)^native-image\\s+25\\.0\\.[34](?:\\s|$)");
+        Pattern.compile("25\\.0\\.[34](?:[.+-].*)?");
+    private static final Pattern VALID_LAYER_NAME = Pattern.compile("[A-Za-z0-9._-]+");
 
     private NativeImageLayerArguments() {
     }
@@ -78,14 +83,23 @@ public final class NativeImageLayerArguments {
     }
 
     public static boolean isLayerConsumptionUnsupported(String versionInformation) {
-        return UNSUPPORTED_LAYER_CONSUMPTION_VERSION
-            .matcher(Objects.requireNonNull(versionInformation, "versionInformation"))
-            .find();
+        String information = Objects.requireNonNull(versionInformation, "versionInformation");
+        var runtimeVersion = GRAALVM_RUNTIME_VERSION.matcher(information);
+        if (runtimeVersion.find()) {
+            return UNSUPPORTED_LAYER_CONSUMPTION_VERSION.matcher(runtimeVersion.group(1)).matches();
+        }
+        var nativeImageVersion = NATIVE_IMAGE_VERSION.matcher(information);
+        return nativeImageVersion.find()
+            && UNSUPPORTED_LAYER_CONSUMPTION_VERSION.matcher(nativeImageVersion.group(1)).matches();
     }
 
-    private static void validateLayerName(String layerName) {
+    public static void validateLayerName(String layerName) {
         if (layerName == null || layerName.isBlank()) {
             throw new IllegalArgumentException("Layer name must not be blank");
+        }
+        if (!VALID_LAYER_NAME.matcher(layerName).matches()) {
+            throw new IllegalArgumentException(
+                "Layer name '" + layerName + "' must contain only letters, digits, dots, underscores, or hyphens");
         }
     }
 }

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageLayerRuntime.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageLayerRuntime.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Discovers, packages, and stages the platform runtime files emitted with a Native Image layer.
+ * §root/FS-native-builds.6.
+ */
+public final class NativeImageLayerRuntime {
+    public static final String ARCHIVE_TYPE = "zip";
+    private static final String CLASSIFIER_PREFIX = "layer-runtime-";
+    private static final String CONTENT_MARKER = ".archive-sha256";
+
+    private NativeImageLayerRuntime() {
+    }
+
+    public static String classifier(List<String> buildArgs) {
+        String os = normalizedOs(System.getProperty("os.name", ""));
+        String arch = normalizedArch(System.getProperty("os.arch", ""));
+        String libc = configuredLibc(buildArgs).filter(value -> !"glibc".equals(value)).orElse(null);
+        return CLASSIFIER_PREFIX + os + "-" + arch + (libc == null ? "" : "-" + libc);
+    }
+
+    public static List<Path> discoverRuntimeFiles(Path outputDirectory) throws IOException {
+        if (!Files.isDirectory(outputDirectory)) {
+            return List.of();
+        }
+        try (var files = Files.walk(outputDirectory)) {
+            return files.filter(Files::isRegularFile)
+                .filter(path -> isRuntimeLibrary(path.getFileName().toString()))
+                .sorted(Comparator.comparing(path -> FileUtils.normalizePathSeparators(
+                    outputDirectory.relativize(path).toString())))
+                .toList();
+        }
+    }
+
+    public static boolean containsPrimaryRuntimeLibrary(List<Path> runtimeFiles, String imageName) {
+        String os = normalizedOs(System.getProperty("os.name", ""));
+        String expected = switch (os) {
+            case "windows" -> imageName + ".dll";
+            case "macos" -> imageName + ".dylib";
+            default -> imageName + ".so";
+        };
+        return runtimeFiles.stream().anyMatch(path -> path.getFileName().toString().equals(expected));
+    }
+
+    public static void createArchive(Path outputDirectory, List<Path> runtimeFiles, Path archive) throws IOException {
+        Files.createDirectories(archive.toAbsolutePath().getParent());
+        try (OutputStream output = Files.newOutputStream(archive);
+             ZipOutputStream zip = new ZipOutputStream(output)) {
+            for (Path runtimeFile : runtimeFiles) {
+                String entryName = FileUtils.normalizePathSeparators(outputDirectory.relativize(runtimeFile).toString());
+                ZipEntry entry = new ZipEntry(entryName);
+                entry.setTime(0L);
+                zip.putNextEntry(entry);
+                Files.copy(runtimeFile, zip);
+                zip.closeEntry();
+            }
+        }
+    }
+
+    public static void extractArchive(Path archive, Path destination, Consumer<String> warning) throws IOException {
+        String archiveHash = sha256(archive);
+        Path marker = destination.resolve(CONTENT_MARKER);
+        if (Files.isRegularFile(marker) && archiveHash.equals(Files.readString(marker))) {
+            return;
+        }
+        clearDestination(destination);
+        Files.createDirectories(destination);
+        try (InputStream input = Files.newInputStream(archive);
+             ZipInputStream zip = new ZipInputStream(input)) {
+            for (ZipEntry entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
+                Path extracted = destination.resolve(entry.getName()).normalize();
+                if (!extracted.startsWith(destination)) {
+                    warning.accept("Ignoring unsafe layer runtime archive entry " + entry.getName());
+                    continue;
+                }
+                if (entry.isDirectory()) {
+                    Files.createDirectories(extracted);
+                } else {
+                    Files.createDirectories(extracted.getParent());
+                    Files.copy(zip, extracted, StandardCopyOption.REPLACE_EXISTING);
+                }
+                zip.closeEntry();
+            }
+        }
+        Files.writeString(marker, archiveHash);
+    }
+
+    public static boolean isRuntimeLibrary(String fileName) {
+        String lower = fileName.toLowerCase(Locale.ROOT);
+        return lower.endsWith(".dll") || lower.endsWith(".dylib") || lower.endsWith(".so")
+            || lower.contains(".so.");
+    }
+
+    private static Optional<String> configuredLibc(List<String> buildArgs) {
+        if (buildArgs == null) {
+            return Optional.empty();
+        }
+        for (int i = 0; i < buildArgs.size(); i++) {
+            String argument = buildArgs.get(i);
+            if (argument == null) {
+                continue;
+            }
+            if (argument.startsWith("--libc=")) {
+                return Optional.of(normalizeToken(argument.substring("--libc=".length())));
+            }
+            if (argument.startsWith("-H:LibC=")) {
+                return Optional.of(normalizeToken(argument.substring("-H:LibC=".length())));
+            }
+            if ("--libc".equals(argument) && i + 1 < buildArgs.size()) {
+                return Optional.of(normalizeToken(buildArgs.get(i + 1)));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static String normalizedOs(String value) {
+        String os = value.toLowerCase(Locale.ROOT);
+        if (os.contains("win")) {
+            return "windows";
+        }
+        if (os.contains("mac") || os.contains("darwin")) {
+            return "macos";
+        }
+        if (os.contains("linux")) {
+            return "linux";
+        }
+        return normalizeToken(os);
+    }
+
+    private static String normalizedArch(String value) {
+        String arch = value.toLowerCase(Locale.ROOT);
+        if ("x86_64".equals(arch) || "x64".equals(arch)) {
+            return "amd64";
+        }
+        if ("aarch64".equals(arch)) {
+            return "arm64";
+        }
+        return normalizeToken(arch);
+    }
+
+    private static String normalizeToken(String value) {
+        return value.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", "-").replaceAll("(^-|-$)", "");
+    }
+
+    private static String sha256(Path file) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (InputStream input = Files.newInputStream(file)) {
+                byte[] buffer = new byte[8192];
+                for (int read = input.read(buffer); read >= 0; read = input.read(buffer)) {
+                    digest.update(buffer, 0, read);
+                }
+            }
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 is unavailable", ex);
+        }
+    }
+
+    private static void clearDestination(Path destination) throws IOException {
+        if (!Files.exists(destination)) {
+            return;
+        }
+        try (var paths = Files.walk(destination)) {
+            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.delete(path);
+            }
+        }
+    }
+}

--- a/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
+++ b/common/utils/src/main/java/org/graalvm/buildtools/utils/NativeImageUtils.java
@@ -215,4 +215,18 @@ public class NativeImageUtils {
         int minor = Integer.parseInt(matcher.group(2));
         return major > requiredMajor || major == requiredMajor && minor >= requiredMinor;
     }
+
+    public static boolean isGraalVMVersion(String versionString, int expectedMajor, int expectedMinor) {
+        Matcher matcher = runtimeVersionPattern.matcher(versionString.trim());
+        return matcher.find()
+            && Integer.parseInt(matcher.group(1)) == expectedMajor
+            && Integer.parseInt(matcher.group(2)) == expectedMinor;
+    }
+
+    /**
+     * Applies the layered-image support policy to a Native Image invocation. §root/FS-native-builds.6.
+     */
+    public static boolean shouldWarnAboutUnsupportedLayerConsumption(String versionString, boolean consumesLayer) {
+        return consumesLayer && isGraalVMVersion(versionString, 25, 0);
+    }
 }

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageLayerArgumentsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageLayerArgumentsTest.java
@@ -99,10 +99,14 @@ class NativeImageLayerArgumentsTest {
     }
 
     @Test
-    void identifiesTheUnsupportedLayerConsumptionRelease() {
+    void identifiesUnsupportedLayerConsumptionReleases() {
         assertTrue(NativeImageLayerArguments.isLayerConsumptionUnsupported(
             "native-image 25.0.3 2026-04-21\nGraalVM Runtime Environment Oracle GraalVM 25.0.3+9.1"));
-        assertEquals(false, NativeImageLayerArguments.isLayerConsumptionUnsupported(
+        assertTrue(NativeImageLayerArguments.isLayerConsumptionUnsupported(
             "native-image 25.0.4 2026-07-21"));
+        assertEquals(false, NativeImageLayerArguments.isLayerConsumptionUnsupported(
+            "native-image 25.0.2 2026-01-20"));
+        assertEquals(false, NativeImageLayerArguments.isLayerConsumptionUnsupported(
+            "native-image 25.0.5 2026-10-20"));
     }
 }

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageLayerArgumentsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageLayerArgumentsTest.java
@@ -80,13 +80,20 @@ class NativeImageLayerArgumentsTest {
     void validatesNamesSelectorsAndCombinations() {
         assertThrows(IllegalArgumentException.class,
             () -> NativeImageLayerArguments.renderLayerCreate(" ", ArtifactSelection.empty()));
+        IllegalArgumentException invalidName = assertThrows(IllegalArgumentException.class,
+            () -> NativeImageLayerArguments.renderLayerCreate("my,base layer",
+                new ArtifactSelection(false, List.of("java.base"), List.of(), List.of())));
+        assertTrue(invalidName.getMessage().contains("letters, digits, dots, underscores, or hyphens"));
         IllegalArgumentException empty = assertThrows(IllegalArgumentException.class,
             () -> NativeImageLayerArguments.renderLayerCreate("base", ArtifactSelection.empty()));
         assertTrue(empty.getMessage().contains("Layer 'base' has no contents"));
         assertThrows(IllegalArgumentException.class,
             () -> new ArtifactSelection(false, List.of(""), List.of(), List.of()));
-        assertThrows(IllegalArgumentException.class,
-            () -> new ArtifactSelection(true, List.of("java.base"), List.of(), List.of()));
+        assertEquals(List.of("java.base"),
+            new ArtifactSelection(true, List.of("java.base"), List.of(), List.of()).getModules());
+        assertEquals("-H:LayerCreate=base.nil,module=java.base",
+            NativeImageLayerArguments.renderLayerCreate("base",
+                new ArtifactSelection(true, List.of("java.base"), List.of(), List.of())));
     }
 
     @Test
@@ -104,6 +111,11 @@ class NativeImageLayerArgumentsTest {
             "native-image 25.0.3 2026-04-21\nGraalVM Runtime Environment Oracle GraalVM 25.0.3+9.1"));
         assertTrue(NativeImageLayerArguments.isLayerConsumptionUnsupported(
             "native-image 25.0.4 2026-07-21"));
+        assertTrue(NativeImageLayerArguments.isLayerConsumptionUnsupported(
+            "native-image 25.0.4.1 Mandrel-25.0.4.1-Final"));
+        assertEquals(false, NativeImageLayerArguments.isLayerConsumptionUnsupported(
+            "native-image 25.0.3 2026-04-21\n"
+                + "GraalVM Runtime Environment GraalVM CE 25.1.3+9.1 (build 25.0.3+9-jvmci-25.1-b19)"));
         assertEquals(false, NativeImageLayerArguments.isLayerConsumptionUnsupported(
             "native-image 25.0.2 2026-01-20"));
         assertEquals(false, NativeImageLayerArguments.isLayerConsumptionUnsupported(

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageLayerArgumentsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageLayerArgumentsTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the shared layer selection and rendering contract.
+ * §FS-common-libraries.1. §FS-common-libraries.8.
+ */
+class NativeImageLayerArgumentsTest {
+    @Test
+    void rendersEmptyAndMixedSelectionsDeterministically() {
+        assertEquals("-H:LayerCreate=base.nil",
+            NativeImageLayerArguments.renderLayerCreate("base", ArtifactSelection.empty()));
+
+        ArtifactSelection selection = new ArtifactSelection(false,
+            List.of("java.base", "java.logging"),
+            List.of("com.example"),
+            List.of(Path.of("libs", "one.jar"), Path.of("libs", "two.jar")));
+
+        assertEquals("-H:LayerCreate=base.nil,module=java.base,module=java.logging,"
+                + "package=com.example,path=libs/one.jar,path=libs/two.jar",
+            NativeImageLayerArguments.renderLayerCreate("base", selection).replace('\\', '/'));
+    }
+
+    @Test
+    void rendersAllAsAnUnqualifiedCreateAndPlatformPaths() {
+        assertEquals("-H:LayerCreate=dependencies.nil",
+            NativeImageLayerArguments.renderLayerCreate("dependencies",
+                new ArtifactSelection(true, List.of(), List.of(), List.of())));
+        assertTrue(NativeImageLayerArguments.renderLayerUse(Path.of("build", "base.nil"))
+            .endsWith(Path.of("build", "base.nil").toString()));
+    }
+
+    @Test
+    void validatesNamesSelectorsAndCombinations() {
+        assertThrows(IllegalArgumentException.class,
+            () -> NativeImageLayerArguments.renderLayerCreate(" ", ArtifactSelection.empty()));
+        assertThrows(IllegalArgumentException.class,
+            () -> new ArtifactSelection(false, List.of(""), List.of(), List.of()));
+        assertThrows(IllegalArgumentException.class,
+            () -> new ArtifactSelection(true, List.of("java.base"), List.of(), List.of()));
+    }
+
+    @Test
+    void copiesInputCollections() {
+        List<String> modules = new ArrayList<>(List.of("java.base"));
+        ArtifactSelection selection = new ArtifactSelection(false, modules, List.of(), List.of());
+        modules.add("java.logging");
+        assertEquals(List.of("java.base"), selection.getModules());
+        assertThrows(UnsupportedOperationException.class, () -> selection.getModules().add("java.sql"));
+    }
+}

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageLayerArgumentsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageLayerArgumentsTest.java
@@ -105,20 +105,4 @@ class NativeImageLayerArgumentsTest {
         assertThrows(UnsupportedOperationException.class, () -> selection.getModules().add("java.sql"));
     }
 
-    @Test
-    void identifiesUnsupportedLayerConsumptionReleases() {
-        assertTrue(NativeImageLayerArguments.isLayerConsumptionUnsupported(
-            "native-image 25.0.3 2026-04-21\nGraalVM Runtime Environment Oracle GraalVM 25.0.3+9.1"));
-        assertTrue(NativeImageLayerArguments.isLayerConsumptionUnsupported(
-            "native-image 25.0.4 2026-07-21"));
-        assertTrue(NativeImageLayerArguments.isLayerConsumptionUnsupported(
-            "native-image 25.0.4.1 Mandrel-25.0.4.1-Final"));
-        assertEquals(false, NativeImageLayerArguments.isLayerConsumptionUnsupported(
-            "native-image 25.0.3 2026-04-21\n"
-                + "GraalVM Runtime Environment GraalVM CE 25.1.3+9.1 (build 25.0.3+9-jvmci-25.1-b19)"));
-        assertEquals(false, NativeImageLayerArguments.isLayerConsumptionUnsupported(
-            "native-image 25.0.2 2026-01-20"));
-        assertEquals(false, NativeImageLayerArguments.isLayerConsumptionUnsupported(
-            "native-image 25.0.5 2026-10-20"));
-    }
 }

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageLayerArgumentsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageLayerArgumentsTest.java
@@ -56,10 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class NativeImageLayerArgumentsTest {
     @Test
-    void rendersEmptyAndMixedSelectionsDeterministically() {
-        assertEquals("-H:LayerCreate=base.nil",
-            NativeImageLayerArguments.renderLayerCreate("base", ArtifactSelection.empty()));
-
+    void rendersMixedSelectionsDeterministically() {
         ArtifactSelection selection = new ArtifactSelection(false,
             List.of("java.base", "java.logging"),
             List.of("com.example"),
@@ -83,6 +80,9 @@ class NativeImageLayerArgumentsTest {
     void validatesNamesSelectorsAndCombinations() {
         assertThrows(IllegalArgumentException.class,
             () -> NativeImageLayerArguments.renderLayerCreate(" ", ArtifactSelection.empty()));
+        IllegalArgumentException empty = assertThrows(IllegalArgumentException.class,
+            () -> NativeImageLayerArguments.renderLayerCreate("base", ArtifactSelection.empty()));
+        assertTrue(empty.getMessage().contains("Layer 'base' has no contents"));
         assertThrows(IllegalArgumentException.class,
             () -> new ArtifactSelection(false, List.of(""), List.of(), List.of()));
         assertThrows(IllegalArgumentException.class,
@@ -96,5 +96,13 @@ class NativeImageLayerArgumentsTest {
         modules.add("java.logging");
         assertEquals(List.of("java.base"), selection.getModules());
         assertThrows(UnsupportedOperationException.class, () -> selection.getModules().add("java.sql"));
+    }
+
+    @Test
+    void identifiesTheUnsupportedLayerConsumptionRelease() {
+        assertTrue(NativeImageLayerArguments.isLayerConsumptionUnsupported(
+            "native-image 25.0.3 2026-04-21\nGraalVM Runtime Environment Oracle GraalVM 25.0.3+9.1"));
+        assertEquals(false, NativeImageLayerArguments.isLayerConsumptionUnsupported(
+            "native-image 25.0.4 2026-07-21"));
     }
 }

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageLayerRuntimeTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageLayerRuntimeTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.ZipFile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NativeImageLayerRuntimeTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void classifierIncludesOsArchitectureAndNonDefaultLibc() {
+        String classifier = NativeImageLayerRuntime.classifier(List.of());
+        assertTrue(classifier.startsWith("layer-runtime-"));
+        assertFalse(classifier.endsWith("-glibc"));
+        assertEquals(classifier + "-musl", NativeImageLayerRuntime.classifier(List.of("--libc=musl")));
+    }
+
+    @Test
+    void discoversOnlyRuntimeLibrariesAndArchivesThemDeterministically() throws Exception {
+        Path output = temporaryDirectory.resolve("output");
+        Files.createDirectories(output.resolve("nested"));
+        Files.writeString(output.resolve("libbase.so"), "base");
+        Files.writeString(output.resolve("nested/libjava.so.1"), "java");
+        Files.writeString(output.resolve("base.nil"), "nil");
+        Files.writeString(output.resolve("graal_isolate.h"), "header");
+
+        List<Path> runtimeFiles = NativeImageLayerRuntime.discoverRuntimeFiles(output);
+        assertEquals(List.of(output.resolve("libbase.so"), output.resolve("nested/libjava.so.1")), runtimeFiles);
+        assertTrue(NativeImageLayerRuntime.containsPrimaryRuntimeLibrary(runtimeFiles, "libbase"));
+
+        Path first = temporaryDirectory.resolve("first.zip");
+        Path second = temporaryDirectory.resolve("second.zip");
+        NativeImageLayerRuntime.createArchive(output, runtimeFiles, first);
+        NativeImageLayerRuntime.createArchive(output, runtimeFiles, second);
+        assertArrayEquals(Files.readAllBytes(first), Files.readAllBytes(second));
+        try (ZipFile zip = new ZipFile(first.toFile())) {
+            assertEquals(List.of("libbase.so", "nested/libjava.so.1"),
+                zip.stream().map(entry -> entry.getName()).toList());
+        }
+
+        Path extracted = temporaryDirectory.resolve("extracted");
+        NativeImageLayerRuntime.extractArchive(first, extracted, message -> { });
+        assertEquals("base", Files.readString(extracted.resolve("libbase.so")));
+        assertEquals("java", Files.readString(extracted.resolve("nested/libjava.so.1")));
+    }
+}

--- a/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageUtilsTest.java
+++ b/common/utils/src/test/java/org/graalvm/buildtools/utils/NativeImageUtilsTest.java
@@ -178,10 +178,17 @@ class NativeImageUtilsTest {
                 "GraalVM Runtime Environment Oracle GraalVM 25.1.3+9.1 (build 25.0.3+9-LTS-jvmci-25.1-b19)";
         String graalVMCE251 = "native-image 25.0.3 2026-04-21\n" +
                 "GraalVM Runtime Environment GraalVM CE 25.1.3+9.1 (build 25.0.3+9-jvmci-25.1-b19)";
+        String suppliedOracleGraalVMDev = "native-image 25.0.4 2026-07-21\n" +
+                "Java(TM) SE Runtime Environment Oracle GraalVM 25.3.4.1-dev+7.1 " +
+                "(build 25.0.4+7-LTS-jvmci-25.2-b20)";
 
         Assertions.assertFalse(NativeImageUtils.isGraalVMVersionAtLeast(graalVM250, 25, 1));
+        Assertions.assertTrue(NativeImageUtils.isGraalVMVersion(graalVM250, 25, 0));
         Assertions.assertTrue(NativeImageUtils.isGraalVMVersionAtLeast(graalVM251, 25, 1));
+        Assertions.assertFalse(NativeImageUtils.isGraalVMVersion(graalVM251, 25, 0));
         Assertions.assertTrue(NativeImageUtils.isGraalVMVersionAtLeast(graalVMCE251, 25, 1));
+        Assertions.assertTrue(NativeImageUtils.isGraalVMVersionAtLeast(suppliedOracleGraalVMDev, 25, 1));
+        Assertions.assertFalse(NativeImageUtils.isGraalVMVersion(suppliedOracleGraalVMDev, 25, 0));
     }
 
     @Test
@@ -211,6 +218,19 @@ class NativeImageUtilsTest {
     void treatsUnknownGraalVMReleaseAsOlder() {
         Assertions.assertFalse(NativeImageUtils.isGraalVMVersionAtLeast("native-image 25.0.3", 25, 1));
         Assertions.assertFalse(NativeImageUtils.isGraalVMVersionAtLeast("invalid", 25, 1));
+    }
+
+    @Test
+    void warnsOnlyForGraalVM250LayerConsumption() {
+        String graalVM250 = "native-image 25.0.4\n" +
+                "GraalVM Runtime Environment Oracle GraalVM 25.0.4+7.1";
+        String graalVM251 = graalVM250.replace("GraalVM 25.0.4", "GraalVM 25.1.0");
+        String laterDev = graalVM250.replace("GraalVM 25.0.4", "GraalVM 26.0.0-dev");
+
+        Assertions.assertTrue(NativeImageUtils.shouldWarnAboutUnsupportedLayerConsumption(graalVM250, true));
+        Assertions.assertFalse(NativeImageUtils.shouldWarnAboutUnsupportedLayerConsumption(graalVM250, false));
+        Assertions.assertFalse(NativeImageUtils.shouldWarnAboutUnsupportedLayerConsumption(graalVM251, true));
+        Assertions.assertFalse(NativeImageUtils.shouldWarnAboutUnsupportedLayerConsumption(laterDev, true));
     }
 
     @Test

--- a/docs/spec/decisions/layer-model.md
+++ b/docs/spec/decisions/layer-model.md
@@ -26,3 +26,16 @@ The shared model does not contain Gradle, Maven, Aether, task, project, configur
 types. The plugins do not duplicate dependency resolution: they use Gradle artifact views and
 Maven's project/repository model respectively.
 [§NGOAL-no-buildtool-duplicates](../non-goals.md#ngoal-no-buildtool-duplicates-the-plugins-do-not-reimplement-capabilities-that-gradle-or-maven-already-provide).
+
+## 4. GraalVM release support
+
+Native Build Tools supports and tests Native Image layer consumption on GraalVM 25.1 and later.
+Layer consumption on GraalVM 25.0.x remains permitted for backwards compatibility, but it is
+unsupported and proceeds at the user's own risk because Native Image may fail internally while
+loading an otherwise valid layer. Consumers on 25.0.x receive a warning rather than a build-tool
+failure. Layer creation alone is not subject to this consumption warning. Native Image layers
+remain an experimental upstream feature. This policy specializes
+[§FS-native-builds.6](../functional/native-image-builds.md#6-layered-images),
+[§REQ-support-matrix.1](../requirements.md#1-declared-support), and
+[§REQ-backwards-compatibility.1](../requirements.md#1-deprecation-over-removal) without claiming
+that the upstream feature is generally stable.

--- a/docs/spec/decisions/layer-model.md
+++ b/docs/spec/decisions/layer-model.md
@@ -1,0 +1,28 @@
+# DEC-layer-model: Native Image layers use shared selection and build-tool-native wiring
+
+Native Image layer selection is represented once in `common`, while Gradle and Maven own their
+native task and artifact graphs. This implements [§FS-native-builds.6](../functional/native-image-builds.md#6-layered-images),
+[§common/FS-common-libraries.1](../../../common/docs/functional-spec.md#1-shared-native-image-utilities),
+[§gradle/FS-plugin-model.2](../../../native-gradle-plugin/docs/functional/plugin-model.md#2-extension-surface), and
+[§maven/FS-goal-surface.6](../../../native-maven-plugin/docs/functional/goal-surface.md#6-layer-creation).
+
+## 1. Decision
+
+Gradle exposes named layers outside the binary container and binaries consume typed layer objects.
+Maven exposes a `layer-create` goal that attaches a `nil` artifact and compile goals resolve
+declared `nil` dependencies. Both adapters resolve dependency models to paths before using the
+shared immutable artifact selection and renderer.
+
+## 2. Compatibility
+
+The experimental Gradle `createLayer` and `useLayer(String)` calls remain as deprecated adapters.
+The legacy `lib` naming rule applies only to those declarations. Maven layer configuration is
+opt-in and does not alter existing builds.
+[§REQ-backwards-compatibility](../requirements.md#req-backwards-compatibility-plugin-upgrades-keep-existing-gradle-and-maven-builds-working).
+
+## 3. Boundary
+
+The shared model does not contain Gradle, Maven, Aether, task, project, configuration, or artifact
+types. The plugins do not duplicate dependency resolution: they use Gradle artifact views and
+Maven's project/repository model respectively.
+[§NGOAL-no-buildtool-duplicates](../non-goals.md#ngoal-no-buildtool-duplicates-the-plugins-do-not-reimplement-capabilities-that-gradle-or-maven-already-provide).

--- a/docs/spec/functional/native-image-builds.md
+++ b/docs/spec/functional/native-image-builds.md
@@ -71,6 +71,6 @@ common utilities; Gradle owns provider/task wiring and Maven owns goal/artifact/
 The two surfaces may use build-tool-native syntax but must preserve equivalent selector and
 multi-layer behavior. The `all` selector includes the complete runtime dependency graph, including
 artifacts produced by other projects in the same multi-project or reactor build. Empty layer
-selections fail before Native Image is invoked. Both plugins reject Native Image 25.0.3 before
-layer consumption because that release cannot consume layers reliably.
+selections fail before Native Image is invoked. Both plugins reject Native Image 25.0.3 and 25.0.4
+before layer consumption because those releases cannot consume layers reliably.
 [§GOAL-plugin-parity](../goals.md#goal-plugin-parity-shared-native-image-behavior-remains-consistent-across-gradle-and-maven).

--- a/docs/spec/functional/native-image-builds.md
+++ b/docs/spec/functional/native-image-builds.md
@@ -71,7 +71,9 @@ common utilities; Gradle owns provider/task wiring and Maven owns goal/artifact/
 The two surfaces may use build-tool-native syntax but must preserve equivalent selector and
 multi-layer behavior. The `all` selector includes the complete runtime dependency graph, including
 artifacts produced by other projects in the same multi-project or reactor build. Empty layer
-selections fail before Native Image is invoked. Layered executable deployment must make each
+selections fail before Native Image is invoked. Layer consumers retain the classpath or modulepath
+inputs used to create their producer layers; Gradle propagates those build-local inputs through
+its task graph, while Maven consumers declare equivalent dependencies. Layered executable deployment must make each
 layer's shared-library directory discoverable by the platform loader: `LD_LIBRARY_PATH` on Linux,
 `DYLD_LIBRARY_PATH` on macOS, or `PATH` on Windows. Building or attaching a layer does not embed
 or relocate those shared libraries automatically.

--- a/docs/spec/functional/native-image-builds.md
+++ b/docs/spec/functional/native-image-builds.md
@@ -62,3 +62,11 @@ Both plugins must support shared-library output where the build tool's packaging
 Shared-library mode disables entry-point requirements and may change the output file extension.
 The plugin-specific configuration surface and defaults are specified by
 [§gradle/FS-plugin-model](../../../native-gradle-plugin/docs/functional/plugin-model.md#fs-plugin-model-gradle-plugin-activation-and-dsl-model) and [§maven/FS-config-model](../../../native-maven-plugin/docs/functional/configuration-model.md#fs-config-model-maven-xml-and-command-line-properties-configure-native-image-builds).
+
+## 6. Layered images
+
+Both plugins must support named layer creation from resolved build-tool dependencies and layer
+consumption through declared task or artifact relationships. Selection rendering belongs to
+common utilities; Gradle owns provider/task wiring and Maven owns goal/artifact/repository wiring.
+The two surfaces may use build-tool-native syntax but must preserve equivalent selector and
+multi-layer behavior. [§GOAL-plugin-parity](../goals.md#goal-plugin-parity-shared-native-image-behavior-remains-consistent-across-gradle-and-maven).

--- a/docs/spec/functional/native-image-builds.md
+++ b/docs/spec/functional/native-image-builds.md
@@ -73,8 +73,19 @@ multi-layer behavior. The `all` selector includes the complete runtime dependenc
 artifacts produced by other projects in the same multi-project or reactor build. Empty layer
 selections fail before Native Image is invoked. Layer consumers retain the classpath or modulepath
 inputs used to create their producer layers; Gradle propagates those build-local inputs through
-its task graph, while Maven consumers declare equivalent dependencies. Layered executable deployment must make each
-layer's shared-library directory discoverable by the platform loader: `LD_LIBRARY_PATH` on Linux,
-`DYLD_LIBRARY_PATH` on macOS, or `PATH` on Windows. Building or attaching a layer does not embed
-or relocate those shared libraries automatically.
+its task graph, while Maven consumers declare equivalent dependencies. Layered executable
+deployment must make each layer's runtime native files discoverable by the platform loader:
+`LD_LIBRARY_PATH` on Linux, `DYLD_LIBRARY_PATH` on macOS, or `PATH` on Windows.
+
+The `.nil` file is a build-time input consumed through `-H:LayerUse`; it is not the layer's runtime
+payload. Native Image also produces platform-specific runtime libraries beside the `.nil`, and the
+final image loads those files when it runs. Build-tool run and native-test tasks must configure the
+loader for execution from the build tree. Repository and distribution flows must carry or stage
+the runtime files in a consumer-owned location and must not depend on a producer build directory.
+Publishing or attaching only a `.nil` is therefore not a complete deployable repository flow.
+
+Layer consumption is supported on GraalVM 25.1 and later. GraalVM 25.0.x consumption remains
+permitted but unsupported and must warn that it proceeds at the user's own risk; layer creation
+alone does not warn. Native Image layers remain experimental upstream
+([§DEC-layer-model.4](../decisions/layer-model.md#4-graalvm-release-support)).
 [§GOAL-plugin-parity](../goals.md#goal-plugin-parity-shared-native-image-behavior-remains-consistent-across-gradle-and-maven).

--- a/docs/spec/functional/native-image-builds.md
+++ b/docs/spec/functional/native-image-builds.md
@@ -69,4 +69,8 @@ Both plugins must support named layer creation from resolved build-tool dependen
 consumption through declared task or artifact relationships. Selection rendering belongs to
 common utilities; Gradle owns provider/task wiring and Maven owns goal/artifact/repository wiring.
 The two surfaces may use build-tool-native syntax but must preserve equivalent selector and
-multi-layer behavior. [§GOAL-plugin-parity](../goals.md#goal-plugin-parity-shared-native-image-behavior-remains-consistent-across-gradle-and-maven).
+multi-layer behavior. The `all` selector includes the complete runtime dependency graph, including
+artifacts produced by other projects in the same multi-project or reactor build. Empty layer
+selections fail before Native Image is invoked. Both plugins reject Native Image 25.0.3 before
+layer consumption because that release cannot consume layers reliably.
+[§GOAL-plugin-parity](../goals.md#goal-plugin-parity-shared-native-image-behavior-remains-consistent-across-gradle-and-maven).

--- a/docs/spec/functional/native-image-builds.md
+++ b/docs/spec/functional/native-image-builds.md
@@ -71,5 +71,8 @@ common utilities; Gradle owns provider/task wiring and Maven owns goal/artifact/
 The two surfaces may use build-tool-native syntax but must preserve equivalent selector and
 multi-layer behavior. The `all` selector includes the complete runtime dependency graph, including
 artifacts produced by other projects in the same multi-project or reactor build. Empty layer
-selections fail before Native Image is invoked.
+selections fail before Native Image is invoked. Layered executable deployment must make each
+layer's shared-library directory discoverable by the platform loader: `LD_LIBRARY_PATH` on Linux,
+`DYLD_LIBRARY_PATH` on macOS, or `PATH` on Windows. Building or attaching a layer does not embed
+or relocate those shared libraries automatically.
 [§GOAL-plugin-parity](../goals.md#goal-plugin-parity-shared-native-image-behavior-remains-consistent-across-gradle-and-maven).

--- a/docs/spec/functional/native-image-builds.md
+++ b/docs/spec/functional/native-image-builds.md
@@ -71,6 +71,5 @@ common utilities; Gradle owns provider/task wiring and Maven owns goal/artifact/
 The two surfaces may use build-tool-native syntax but must preserve equivalent selector and
 multi-layer behavior. The `all` selector includes the complete runtime dependency graph, including
 artifacts produced by other projects in the same multi-project or reactor build. Empty layer
-selections fail before Native Image is invoked. Both plugins reject Native Image 25.0.3 and 25.0.4
-before layer consumption because those releases cannot consume layers reliably.
+selections fail before Native Image is invoked.
 [§GOAL-plugin-parity](../goals.md#goal-plugin-parity-shared-native-image-behavior-remains-consistent-across-gradle-and-maven).

--- a/docs/spec/functional/plugin-common.md
+++ b/docs/spec/functional/plugin-common.md
@@ -20,6 +20,7 @@ and actionable under [§GOAL-concise-actionable-output](../goals.md#goal-concise
 | Use reachability metadata | [§gradle/FS-resources-and-metadata](../../../native-gradle-plugin/docs/functional/resources-and-metadata.md#fs-resources-and-metadata-gradle-tasks-generate-resources-and-consume-reachability-metadata) | [§maven/FS-resources-and-metadata](../../../native-maven-plugin/docs/functional/resources-and-metadata.md#fs-resources-and-metadata-maven-goals-generate-resources-and-consume-reachability-metadata) | [§FS-resources-and-metadata.2](resources-and-metadata.md#2-reachability-metadata-repository) |
 | Inspect missing metadata | [§gradle/FS-resources-and-metadata](../../../native-gradle-plugin/docs/functional/resources-and-metadata.md#fs-resources-and-metadata-gradle-tasks-generate-resources-and-consume-reachability-metadata) | [§maven/FS-resources-and-metadata](../../../native-maven-plugin/docs/functional/resources-and-metadata.md#fs-resources-and-metadata-maven-goals-generate-resources-and-consume-reachability-metadata) | [§FS-resources-and-metadata.3](resources-and-metadata.md#3-missing-metadata-reports) |
 | Collect agent output | [§gradle/FS-tracing-agent](../../../native-gradle-plugin/docs/functional/tracing-agent.md#fs-tracing-agent-gradle-tasks-attach-and-post-process-native-image-tracing-agent-metadata) | [§maven/FS-tracing-agent](../../../native-maven-plugin/docs/functional/tracing-agent.md#fs-tracing-agent-maven-goals-attach-and-post-process-native-image-tracing-agent-metadata) | [§FS-tracing-agent](tracing-agent.md#fs-tracing-agent-both-plugins-attach-the-native-image-tracing-agent-and-post-process-its-output) |
+| Create and consume layers | [§gradle/FS-plugin-model.2](../../../native-gradle-plugin/docs/functional/plugin-model.md#2-extension-surface) | [§maven/FS-goal-surface.6](../../../native-maven-plugin/docs/functional/goal-surface.md#6-layer-creation) | [§FS-native-builds.6](native-image-builds.md#6-layered-images) |
 
 ```mermaid
 sequenceDiagram
@@ -56,6 +57,7 @@ capability impossible or intentionally different:
 - schema validation ([§FS-resources-and-metadata.5](resources-and-metadata.md#5-schema-validation))
 - Native Image version-dependent behavior ([§FS-native-builds.4](native-image-builds.md#4-version-and-schema-gates))
 - predictable option precedence ([§FS-option-precedence](option-precedence.md#fs-option-precedence-command-line-input-and-durable-configuration-produce-one-option-state))
+- named layer creation and consumption through build-tool-native dependency wiring ([§FS-native-builds.6](native-image-builds.md#6-layered-images))
 
 When a capability is intentionally different between Gradle and Maven, the product-specific specs
 must explain the difference at the point where each plugin adapts this common contract.

--- a/docs/src/docs/asciidoc/changelog.adoc
+++ b/docs/src/docs/asciidoc/changelog.adoc
@@ -6,7 +6,7 @@
 - Added first-class named Native Image layers to the Gradle plugin and Maven `layer-create` /
   `useLayers` support with resolvable `nil` artifacts.
 - Added early validation for empty, duplicate, missing, malformed, and unsupported layer
-  configurations. Native Image 25.0.3 is rejected for layer consumption.
+  configurations. Native Image 25.0.3 and 25.0.4 are rejected for layer consumption.
 
 == Release 1.1.6
 

--- a/docs/src/docs/asciidoc/changelog.adoc
+++ b/docs/src/docs/asciidoc/changelog.adoc
@@ -5,8 +5,7 @@
 
 - Added first-class named Native Image layers to the Gradle plugin and Maven `layer-create` /
   `useLayers` support with resolvable `nil` artifacts.
-- Added early validation for empty, duplicate, missing, malformed, and unsupported layer
-  configurations. Native Image 25.0.3 and 25.0.4 are rejected for layer consumption.
+- Added early validation for empty, duplicate, missing, and malformed layer configurations.
 
 == Release 1.1.6
 

--- a/docs/src/docs/asciidoc/changelog.adoc
+++ b/docs/src/docs/asciidoc/changelog.adoc
@@ -4,7 +4,11 @@
 == Next release
 
 - Added first-class named Native Image layers to the Gradle plugin and Maven `layer-create` /
-  `useLayers` support with resolvable `nil` artifacts.
+  `useLayers` support with resolvable `nil` artifacts and platform runtime bundles. Layer
+  consumption is supported on GraalVM 25.1+; 25.0.x consumption warns and remains unsupported.
+- Added loader-aware Gradle application distributions for layered main binaries. Gradle
+  cross-project layer publication and Maven local-file layer consumption remain manual or
+  unsupported rather than first-class flows.
 - Added early validation for empty, duplicate, missing, and malformed layer configurations.
 
 == Release 1.1.6

--- a/docs/src/docs/asciidoc/changelog.adoc
+++ b/docs/src/docs/asciidoc/changelog.adoc
@@ -1,6 +1,13 @@
 [[changelog]]
 == Changelog
 
+== Next release
+
+- Added first-class named Native Image layers to the Gradle plugin and Maven `layer-create` /
+  `useLayers` support with resolvable `nil` artifacts.
+- Added early validation for empty, duplicate, missing, malformed, and unsupported layer
+  configurations. Native Image 25.0.3 is rejected for layer consumption.
+
 == Release 1.1.6
 
 - Maven native test goals now read the matching Surefire or Failsafe execution, including its configured `testClassesDirectory`, and keep their test-ID output separate.

--- a/docs/src/docs/asciidoc/end-to-end-gradle-guide.adoc
+++ b/docs/src/docs/asciidoc/end-to-end-gradle-guide.adoc
@@ -164,6 +164,33 @@ This works similarly to `JAVA_TOOL_OPTIONS`, where the value of the environment 
 
 Learn more about Native Image build configuration https://www.graalvm.org/reference-manual/native-image/overview/BuildConfiguration/[on the website].
 
+[[build-layered-image]]
+=== Build a Layered Native Image
+
+Define a named layer and assign it to the application binary:
+
+[source,groovy]
+----
+graalvmNative {
+    layers {
+        dependencies {
+            contents {
+                modules('java.base')
+                fromConfiguration(configurations.runtimeClasspath)
+            }
+        }
+    }
+    binaries.main {
+        layer = graalvmNative.layers.dependencies
+    }
+}
+----
+
+Run `./gradlew nativeRun`. Gradle first executes `nativeDependenciesLayer`, then consumes the
+generated _build/native/layers/dependencies/dependencies.nil_ while building the application.
+See <<gradle-plugin.adoc#layered-images,Layered Native Images>> for selector and compatibility
+details.
+
 [[gather-execution-profiles]]
 === Gather Execution Profiles and Build Optimized Images
 

--- a/docs/src/docs/asciidoc/end-to-end-gradle-guide.adoc
+++ b/docs/src/docs/asciidoc/end-to-end-gradle-guide.adoc
@@ -181,13 +181,16 @@ graalvmNative {
         }
     }
     binaries.main {
-        layer = graalvmNative.layers.dependencies
+        usesLayer('dependencies')
     }
 }
 ----
 
 Run `./gradlew nativeRun`. Gradle first executes `nativeDependenciesLayer`, then consumes the
 generated _build/native/layers/dependencies/dependencies.nil_ while building the application.
+Repeat layer-sensitive binary build arguments on the layer itself; layers do not inherit
+`binaries.all { buildArgs(...) }` because one layer can be consumed by differently configured
+binaries.
 See <<gradle-plugin.adoc#layered-images,Layered Native Images>> for selector and compatibility
 details.
 

--- a/docs/src/docs/asciidoc/end-to-end-gradle-guide.adoc
+++ b/docs/src/docs/asciidoc/end-to-end-gradle-guide.adoc
@@ -191,8 +191,9 @@ generated _build/native/layers/dependencies/dependencies.nil_ while building the
 Repeat layer-sensitive binary build arguments on the layer itself; layers do not inherit
 `binaries.all { buildArgs(...) }` because one layer can be consumed by differently configured
 binaries.
-See <<gradle-plugin.adoc#layered-images,Layered Native Images>> for selector and compatibility
-details.
+See <<layered-images.adoc#,Layered Native Images: Reuse, Testing, and Deployment>> for examples
+that share layers with native tests and package the resulting application. The complete DSL
+reference remains in <<gradle-plugin.adoc#layered-images,the Gradle plugin documentation>>.
 
 [[gather-execution-profiles]]
 === Gather Execution Profiles and Build Optimized Images

--- a/docs/src/docs/asciidoc/end-to-end-maven-guide.adoc
+++ b/docs/src/docs/asciidoc/end-to-end-maven-guide.adoc
@@ -244,8 +244,9 @@ reactor project, resolves it outside the Java classpath, and passes it to the co
 When deploying or running the executable directly, ship the layer's shared libraries and add their
 directory to the platform library search path (`LD_LIBRARY_PATH` on Linux, `DYLD_LIBRARY_PATH` on
 macOS, or `PATH` on Windows).
-See <<maven-plugin.adoc#layered-images,Layered Native Images>> for complete producer and consumer
-configuration.
+See <<layered-images.adoc#,Layered Native Images: Reuse, Testing, and Deployment>> for examples
+that share layers across Maven executions and package the resulting application. The complete XML
+reference remains in <<maven-plugin.adoc#layered-images,the Maven plugin documentation>>.
 
 [TIP]
 ====

--- a/docs/src/docs/asciidoc/end-to-end-maven-guide.adoc
+++ b/docs/src/docs/asciidoc/end-to-end-maven-guide.adoc
@@ -229,8 +229,8 @@ Here is an example of additional options usage:
 
 Use a multi-module build with one producer module bound to `native:layer-create` and one consumer
 module. The consumer declares the producer with `<type>nil</type>` and selects it in
-`<useLayers>`. Keep `<extensions>true</extensions>` on the Native Build Tools plugin so Maven can
-resolve the `nil` artifact type.
+`<useLayers>`. Keep `<extensions>true</extensions>` on the Native Build Tools plugin so Maven
+registers the `nil` artifact type consistently.
 
 Run the full reactor:
 
@@ -241,6 +241,9 @@ Run the full reactor:
 
 Maven creates the layer in the producer's _target/native/layers/_ directory, attaches it to the
 reactor project, resolves it outside the Java classpath, and passes it to the consumer image.
+When deploying or running the executable directly, ship the layer's shared libraries and add their
+directory to the platform library search path (`LD_LIBRARY_PATH` on Linux, `DYLD_LIBRARY_PATH` on
+macOS, or `PATH` on Windows).
 See <<maven-plugin.adoc#layered-images,Layered Native Images>> for complete producer and consumer
 configuration.
 

--- a/docs/src/docs/asciidoc/end-to-end-maven-guide.adoc
+++ b/docs/src/docs/asciidoc/end-to-end-maven-guide.adoc
@@ -224,6 +224,26 @@ Here is an example of additional options usage:
 </configuration>
 ----
 
+[[build-layered-image]]
+=== Build a Layered Native Image
+
+Use a multi-module build with one producer module bound to `native:layer-create` and one consumer
+module. The consumer declares the producer with `<type>nil</type>` and selects it in
+`<useLayers>`. Keep `<extensions>true</extensions>` on the Native Build Tools plugin so Maven can
+resolve the `nil` artifact type.
+
+Run the full reactor:
+
+[source,bash]
+----
+./mvnw -Pnative -DskipTests package
+----
+
+Maven creates the layer in the producer's _target/native/layers/_ directory, attaches it to the
+reactor project, resolves it outside the Java classpath, and passes it to the consumer image.
+See <<maven-plugin.adoc#layered-images,Layered Native Images>> for complete producer and consumer
+configuration.
+
 [TIP]
 ====
 As an alternative, you can pass additional build options via the `NATIVE_IMAGE_OPTIONS` environment variable, on the command line.

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -208,26 +208,56 @@ graalvmNative {
     }
     binaries {
         main {
-            layer = graalvmNative.layers.dependencies
+            usesLayer('dependencies')
         }
     }
 }
 ----
 
 `fromConfiguration(...)` and `all = true` include both external modules and artifacts produced by
-other projects in a multi-project build. Use repeated `useLayer(...)` calls to consume multiple
-layers. Assigning the singular `layer` property replaces its previous value.
+other projects in a multi-project build. `all = true` may be combined with module or package
+selectors. Use repeated `usesLayer('<name>')` or typed `useLayer(...)` calls to consume multiple
+layers. Name-based selection is lazy and works even when `binaries` appears before `layers`.
+Assigning the singular `layer` property replaces its previous value.
+Named layers also support `usesLayer('<name>')`, so a layer task can consume another layer and
+produce the next level of a multi-layer stack. The consumed layer is resolved lazily and its task
+is added as a producer dependency automatically.
 
 [IMPORTANT]
 ====
 Inside a Groovy binary closure, the deprecated binary-level `layers` property shadows the
-extension's named-layer container. Use the qualified form
-`graalvmNative.layers.<layerName>`, as shown above.
+extension's named-layer container. Prefer `usesLayer('<layerName>')`; when passing the typed object,
+use the qualified form `graalvmNative.layers.<layerName>`.
 ====
 
-Empty layers and duplicate layer selections fail before Native Image is invoked. Native Image
+Layer names may contain letters, digits, dots, underscores, and hyphens. Empty layers, invalid
+names, and duplicate layer selections fail before Native Image is invoked. Layer tasks use the
+same reachability-metadata repository wiring and schema validation as binary tasks. Native Image
 25.0.3 and 25.0.4 cannot consume layers reliably, so the plugin asks you to upgrade to 25.0.5 or
-later, or remove the layer configuration.
+later, or remove the layer configuration. To deliberately test an affected release, pass
+`-Dorg.graalvm.buildtools.layers.allowUnsupportedConsumption=true` at your own risk.
+
+Layer producers do not inherit binary `buildArgs`: a layer may be shared by binaries with different
+settings. Repeat layer-sensitive options such as optimization, GC, and initialization flags in the
+layer's `buildArgs`. Gradle currently produces and consumes named layers within one project; publish
+or copy `.nil` outputs explicitly when coordinating layers across projects.
+
+[source,kotlin]
+----
+graalvmNative {
+    layers {
+        create("dependencies") {
+            contents {
+                modules("java.base")
+                fromConfiguration(configurations.runtimeClasspath)
+            }
+        }
+    }
+    binaries.named("main") {
+        usesLayer("dependencies")
+    }
+}
+----
 
 ==== Command Line Options
 

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -185,6 +185,50 @@ buildArgs.addAll(
 )
 ----
 
+[[layered-images]]
+=== Layered Native Images
+
+Named layers live in the `graalvmNative.layers` container. A layer can select modules, packages,
+files, a resolved Gradle configuration, dependency coordinates, or the complete runtime dependency
+graph. The plugin registers a task named `native<LayerName>Layer`, writes the layer under
+_build/native/layers/<layerName>/_, and wires consuming binaries to that task automatically.
+
+[source,groovy,role="multi-language-sample"]
+----
+graalvmNative {
+    layers {
+        dependencies {
+            contents {
+                modules('java.base')
+                fromConfiguration(configurations.runtimeClasspath)
+                // Version catalog accessors are also accepted:
+                // dependencies(libs.slf4j.api)
+            }
+        }
+    }
+    binaries {
+        main {
+            layer = graalvmNative.layers.dependencies
+        }
+    }
+}
+----
+
+`fromConfiguration(...)` and `all = true` include both external modules and artifacts produced by
+other projects in a multi-project build. Use repeated `useLayer(...)` calls to consume multiple
+layers. Assigning the singular `layer` property replaces its previous value.
+
+[IMPORTANT]
+====
+Inside a Groovy binary closure, the deprecated binary-level `layers` property shadows the
+extension's named-layer container. Use the qualified form
+`graalvmNative.layers.<layerName>`, as shown above.
+====
+
+Empty layers and duplicate layer selections fail before Native Image is invoked. Native Image
+25.0.3 cannot consume layers reliably, so the plugin asks you to upgrade or remove the layer
+configuration.
+
 ==== Command Line Options
 
 The preferred way to configure native binaries is through the DSL, so that you can provide reproducible builds which do not depend on obscure CLI invocations.

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -226,8 +226,8 @@ extension's named-layer container. Use the qualified form
 ====
 
 Empty layers and duplicate layer selections fail before Native Image is invoked. Native Image
-25.0.3 cannot consume layers reliably, so the plugin asks you to upgrade or remove the layer
-configuration.
+25.0.3 and 25.0.4 cannot consume layers reliably, so the plugin asks you to upgrade to 25.0.5 or
+later, or remove the layer configuration.
 
 ==== Command Line Options
 

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -188,6 +188,9 @@ buildArgs.addAll(
 [[layered-images]]
 === Layered Native Images
 
+For scenario-based examples covering native tests, additional test suites, reuse across binaries,
+and deployment, see <<layered-images.adoc#,Layered Native Images: Reuse, Testing, and Deployment>>.
+
 Named layers live in the `graalvmNative.layers` container. A layer can select modules, packages,
 files, a resolved Gradle configuration, dependency coordinates, or the complete runtime dependency
 graph. The plugin registers a task named `native<LayerName>Layer`, writes the layer under

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -232,10 +232,7 @@ use the qualified form `graalvmNative.layers.<layerName>`.
 
 Layer names may contain letters, digits, dots, underscores, and hyphens. Empty layers, invalid
 names, and duplicate layer selections fail before Native Image is invoked. Layer tasks use the
-same reachability-metadata repository wiring and schema validation as binary tasks. Native Image
-25.0.3 and 25.0.4 cannot consume layers reliably, so the plugin asks you to upgrade to 25.0.5 or
-later, or remove the layer configuration. To deliberately test an affected release, pass
-`-Dorg.graalvm.buildtools.layers.allowUnsupportedConsumption=true` at your own risk.
+same reachability-metadata repository wiring and schema validation as binary tasks.
 
 Layer producers do not inherit binary `buildArgs`: a layer may be shared by binaries with different
 settings. Repeat layer-sensitive options such as optimization, GC, and initialization flags in the

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -222,9 +222,6 @@ other projects in a multi-project build. `all = true` may be combined with modul
 selectors. Use repeated `usesLayer('<name>')` or typed `useLayer(...)` calls to consume multiple
 layers. Name-based selection is lazy and works even when `binaries` appears before `layers`.
 Assigning the singular `layer` property replaces its previous value.
-Named layers also support `usesLayer('<name>')`, so a layer task can consume another layer and
-produce the next level of a multi-layer stack. The consumed layer is resolved lazily and its task
-is added as a producer dependency automatically.
 
 [IMPORTANT]
 ====

--- a/docs/src/docs/asciidoc/gradle-plugin.adoc
+++ b/docs/src/docs/asciidoc/gradle-plugin.adoc
@@ -239,8 +239,16 @@ same reachability-metadata repository wiring and schema validation as binary tas
 
 Layer producers do not inherit binary `buildArgs`: a layer may be shared by binaries with different
 settings. Repeat layer-sensitive options such as optimization, GC, and initialization flags in the
-layer's `buildArgs`. Gradle currently produces and consumes named layers within one project; publish
-or copy `.nil` outputs explicitly when coordinating layers across projects.
+layer's `buildArgs`. Gradle currently produces and consumes named layers within one project.
+Cross-project reuse is not a first-class publication flow; manual file wiring must carry both the
+`.nil` and runtime files.
+
+`nativeRun` configures the platform loader for build-tree execution. For a layered main binary in
+an `application` project, `installDist`, `distZip`, and `distTar` include the native executable,
+runtime files under `lib/native-layers/<layer>`, and a `<imageName>-native` launcher. Other
+packaging plugins can consume the cacheable `nativeLayerRuntimeFiles` task output. Configure
+distinct `imageName` values for multiple custom binaries. Layer consumption is supported on
+GraalVM 25.1+; see the linked guide for the 25.0.x warning policy and native-test module guidance.
 
 [source,kotlin]
 ----

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -24,6 +24,7 @@ If you're new to the Native Build Tools, whether as an end user or a library aut
 
 - <<end-to-end-gradle-guide.adoc#,Building Native Images with Gradle: An End-to-End Guide>>
 - <<end-to-end-maven-guide.adoc#,Building Native Images with Maven: An End-to-End Guide>>
+- <<layered-images.adoc#,Layered Native Images: Reuse, Testing, and Deployment>>
 
 For detailed documentation, see the corresponding page for each build tool:
 

--- a/docs/src/docs/asciidoc/layered-images.adoc
+++ b/docs/src/docs/asciidoc/layered-images.adoc
@@ -13,10 +13,7 @@ application. For the complete configuration reference, see
 
 [IMPORTANT]
 ====
-Layered images are an experimental Native Image feature. Native Build Tools can express
-multi-level layer stacks, but current Native Image releases support one shared base layer and a
-final application image. Keep layer chaining disabled until the Native Image version used by the
-build supports it.
+Layered images are an experimental Native Image feature.
 
 Native Build Tools supports layer consumption on GraalVM 25.1 and later. Consumption on GraalVM
 25.0.x is permitted for compatibility, but is unsupported and proceeds at your own risk because
@@ -53,7 +50,7 @@ Both plugins support module, package, path, dependency, and complete-classpath s
 and packages may be combined in the same layer. Keep frequently changing application classes out
 of a broadly reused layer so that application changes do not force the layer to be rebuilt.
 
-For example, a Gradle layer can select JDK modules and packages from resolved dependencies:
+For example, a Gradle layer can select JDK modules and packages:
 
 [source,groovy]
 ----
@@ -63,7 +60,6 @@ graalvmNative {
             contents {
                 modules('java.base', 'java.logging')
                 packages('org.slf4j')
-                fromConfiguration(configurations.runtimeClasspath)
             }
         }
     }
@@ -83,13 +79,12 @@ The equivalent Maven layer definition is:
   <packages>
     <package>org.slf4j</package>
   </packages>
-  <dependencies>
-    <dependency>
-      <artifact>org.slf4j:slf4j-api</artifact>
-    </dependency>
-  </dependencies>
 </layer>
 ----
+
+Package selectors add packages to the layer; they do not filter files selected through
+`fromConfiguration(...)` (Gradle) or `<dependencies>` (Maven). Use a separate configuration or
+dependency selector when the intent is to include the resolved artifact files themselves.
 
 [[gradle-layer-reuse]]
 == Reuse a Layer with Gradle
@@ -140,35 +135,6 @@ When the `application` plugin is present, `installDist`, `distZip`, and `distTar
 main native executable, selected runtime files under `lib/native-layers/<layer>`, and a
 `bin/<imageName>-native` launcher that configures the platform loader. Projects using another
 packaging model can consume the cacheable `nativeLayerRuntimeFiles` task output.
-
-[[gradle-additional-tests]]
-=== Share a Layer with Additional Test Suites
-
-Register an additional native test binary and configure it like any other layer consumer. The
-following fragment assumes an `integTest` source set and `Test` task already exist:
-
-[source,groovy]
-----
-graalvmNative {
-    registerTestBinary('integTest') {
-        usingSourceSet(sourceSets.integTest)
-        forTestTask(tasks.named('integTest'))
-    }
-
-    binaries {
-        test {
-            usesLayer('sharedRuntime')
-        }
-        integTest {
-            usesLayer('sharedRuntime')
-        }
-    }
-}
-----
-
-`nativeTest` and `nativeIntegTest` now build separate native test images while sharing the same
-layer producer. Different suites can instead select different layers when their runtime
-requirements differ.
 
 [[gradle-multiple-binaries]]
 === Share a Layer Between Executables and Libraries
@@ -314,38 +280,6 @@ The equivalent Maven `<modules>` list uses one `<module>` element for each entry
 omits a module, adding it only to the final consumer is too late: Native Image can report a newly
 seen boot package or another layer-compatibility failure. Add the missing module to the producer
 layer and rebuild it.
-
-[[layer-chaining]]
-== Prepare Multi-Level Layer Stacks
-
-Native Build Tools can describe a layer that consumes another layer. In Gradle, call
-`usesLayer` from the consuming layer:
-
-[source,groovy]
-----
-graalvmNative {
-    layers {
-        base {
-            contents.modules('java.base')
-        }
-        framework {
-            usesLayer('base')
-            contents.packages('org.example.framework')
-        }
-    }
-    binaries.main {
-        usesLayer('framework')
-    }
-}
-----
-
-In Maven, declare the base layer as a `nil` dependency of the next producer module and add
-`<useLayers>` to that module's `layer-create` execution. Each produced layer remains an
-independently ordered build artifact.
-
-Do not enable this topology until the Native Image version used by the build supports chained
-shared layers. When deploying a multi-level stack, every layer's runtime shared library must be
-included in the library search path.
 
 [[shipping-layered-images]]
 == Ship a Layered Application

--- a/docs/src/docs/asciidoc/layered-images.adoc
+++ b/docs/src/docs/asciidoc/layered-images.adoc
@@ -17,6 +17,13 @@ Layered images are an experimental Native Image feature. Native Build Tools can 
 multi-level layer stacks, but current Native Image releases support one shared base layer and a
 final application image. Keep layer chaining disabled until the Native Image version used by the
 build supports it.
+
+Native Build Tools supports layer consumption on GraalVM 25.1 and later. Consumption on GraalVM
+25.0.x is permitted for compatibility, but is unsupported and proceeds at your own risk because
+Native Image may fail internally while loading a valid layer. The plugins warn for 25.0.x
+consumption; creating a layer without consuming another layer does not warn. The runtime release
+reported by `native-image --version`, rather than its first component-version line, determines
+this policy.
 ====
 
 [[layered-image-artifacts]]
@@ -26,12 +33,18 @@ Creating a layer produces two kinds of output:
 
 * A `.nil` file that another Native Image build consumes through `-H:LayerUse`. This is a
   build-time artifact.
-* A platform shared library that the final executable loads at runtime, such as `libbase.so` on
-  Linux. This is a deployment artifact.
+* Platform runtime libraries that the final executable loads, such as `libbase.so` and supporting
+  native libraries on Linux. These are deployment artifacts.
 
-The final executable does not contain the layer's shared library. A deployment must therefore
-include the executable and the shared library from every layer it uses. Publishing or attaching
-the `.nil` file does not automatically publish, copy, or embed the runtime libraries.
+The final executable does not contain the layer's runtime libraries. A deployment must therefore
+include the executable and every discovered runtime library from each layer it uses. Headers and
+diagnostic files emitted beside a layer are not runtime inputs.
+
+Maven attaches a deterministic ZIP containing the runtime files alongside the `.nil`. Its
+classifier identifies the target operating system and architecture, for example
+`layer-runtime-linux-amd64`; non-default Linux C libraries such as musl add that compatibility
+dimension. Gradle models the producer directories as task inputs and stages runtime files without
+flattening different layers into one directory.
 
 [[layer-content-selection]]
 == Select Layer Contents
@@ -123,6 +136,11 @@ Run the application and native tests normally:
 Both task graphs reuse `nativeSharedRuntimeLayer`. The Gradle run tasks add the directories of
 their selected layers to the runtime library search path.
 
+When the `application` plugin is present, `installDist`, `distZip`, and `distTar` also include the
+main native executable, selected runtime files under `lib/native-layers/<layer>`, and a
+`bin/<imageName>-native` launcher that configures the platform loader. Projects using another
+packaging model can consume the cacheable `nativeLayerRuntimeFiles` task output.
+
 [[gradle-additional-tests]]
 === Share a Layer with Additional Test Suites
 
@@ -159,6 +177,14 @@ Repeated `usesLayer` calls can select multiple layers, and the same layer can be
 multiple binaries. For example, an executable and a shared-library binary can both select
 `sharedRuntime`. Each consumer keeps its own Native Image options; layer-sensitive options must
 remain compatible between the producer and every consumer.
+
+Shared-library binaries do not generally require a `mainClass`. For multiple custom binaries,
+configure a distinct `imageName` for each one so packaging and human-facing artifact names remain
+unambiguous.
+
+Same-project named-layer reuse is Gradle's first-class sharing model. Cross-project reuse does not
+currently publish a consumable layer variant; it requires manual `getLayerFiles()` or equivalent
+file wiring, including the runtime files needed for deployment.
 
 [[maven-layer-reuse]]
 == Reuse a Layer with Maven
@@ -199,9 +225,10 @@ Bind `layer-create` in the producer module:
 </plugin>
 ----
 
-The goal creates
-_target/native/layers/shared-runtime/shared-runtime.nil_ and attaches it to the project as a
-`nil` artifact.
+The goal creates _target/native/layers/shared-runtime/shared-runtime.nil_ and attaches it to the
+project as a `nil` artifact. It also attaches the platform-classified runtime ZIP. A layer producer
+may use `<packaging>pom</packaging>`: `layer-create` still runs when bound to the lifecycle.
+`skipNativeBuildForPom` applies to `compile-no-fork`, not to `layer-create`.
 
 [[maven-main-and-tests]]
 === Share One Layer Between Build Executions
@@ -260,10 +287,33 @@ different layers. Multiple consumer modules can declare and select the same `nil
 [NOTE]
 ====
 When a native test is executed, the plugin adds the directories containing its selected layer
-artifacts to the platform library search path. For a layer resolved from a repository, the
-runtime shared library must also be staged next to the `.nil` file or added to the search path
-separately.
+runtime files to the platform library search path. For repository dependencies, the plugin
+automatically resolves the matching runtime ZIP and extracts it into a consumer-owned directory
+under `target/native/layer-runtime`. It never relies on a producer `target` directory or extracts
+into the local Maven repository. If an older publication contains only a `.nil`, the build fails
+before Native Image runs and reports the missing companion coordinate.
 ====
+
+Maven `useLayers` is coordinate-based: declare a dependency with `<type>nil</type>` and select it
+by `groupId:artifactId[:version]`. Local layer-file paths are not a supported Maven consumption
+form. Reactor and external-repository consumers use the same declaration.
+
+[[native-test-layer-modules]]
+== Include Modules Required by Every Consumer
+
+A layer shared by applications and native tests must contain every JDK module required by every
+consumer. Native JUnit fixtures commonly need at least `java.management`, and tests using JDBC
+need `java.sql`; add `java.xml` when XML APIs are used. For example:
+
+[source,groovy]
+----
+contents.modules('java.base', 'java.management', 'java.sql')
+----
+
+The equivalent Maven `<modules>` list uses one `<module>` element for each entry. If the producer
+omits a module, adding it only to the final consumer is too late: Native Image can report a newly
+seen boot package or another layer-compatibility failure. Add the missing module to the producer
+layer and rebuild it.
 
 [[layer-chaining]]
 == Prepare Multi-Level Layer Stacks
@@ -307,10 +357,15 @@ example, a Linux distribution can use this layout:
 ----
 application/
 |-- bin/
-|   `-- application
+|   `-- application-native
 `-- lib/
-    |-- libbase.so
-    `-- libframework.so
+    |-- native/
+    |   `-- application
+    `-- native-layers/
+        |-- base/
+        |   `-- libbase.so
+        `-- framework/
+            `-- libframework.so
 ----
 
 The `.nil` files are needed to build downstream images, but they are not required merely to run
@@ -323,8 +378,8 @@ need to consume the layers.
 [source,bash]
 ----
 APP_HOME=/opt/application
-LD_LIBRARY_PATH="$APP_HOME/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-    "$APP_HOME/bin/application"
+LD_LIBRARY_PATH="$APP_HOME/lib/native-layers/base${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+    "$APP_HOME/lib/native/application"
 ----
 
 For a container image, copy both directories and set `LD_LIBRARY_PATH` in the runtime image:
@@ -332,8 +387,8 @@ For a container image, copy both directories and set `LD_LIBRARY_PATH` in the ru
 [source,dockerfile]
 ----
 COPY application/ /opt/application/
-ENV LD_LIBRARY_PATH=/opt/application/lib
-ENTRYPOINT ["/opt/application/bin/application"]
+ENV LD_LIBRARY_PATH=/opt/application/lib/native-layers/base
+ENTRYPOINT ["/opt/application/lib/native/application"]
 ----
 
 [[shipping-macos]]
@@ -342,8 +397,8 @@ ENTRYPOINT ["/opt/application/bin/application"]
 [source,bash]
 ----
 APP_HOME=/opt/application
-DYLD_LIBRARY_PATH="$APP_HOME/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" \
-    "$APP_HOME/bin/application"
+DYLD_LIBRARY_PATH="$APP_HOME/lib/native-layers/base${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" \
+    "$APP_HOME/lib/native/application"
 ----
 
 [[shipping-windows]]
@@ -351,11 +406,19 @@ DYLD_LIBRARY_PATH="$APP_HOME/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" \
 
 [source,powershell]
 ----
-$env:PATH = "$PWD\lib;$env:PATH"
-& "$PWD\bin\application.exe"
+$env:PATH = "$PWD\lib\native-layers\base;$env:PATH"
+& "$PWD\lib\native\application.exe"
 ----
 
-Native Build Tools builds the final executable and each layer's shared library, but does not
-package them together for deployment. The project's packaging process must include the executable
-and all layer shared libraries, and configure the platform loader to find those libraries at
-runtime.
+Gradle application distributions generate this packaging and a loader-aware launcher. Maven stages
+repository runtime bundles for build and native-test execution, but a Maven deployment plugin must
+still copy the executable and staged runtime directories into the final application or container.
+
+[[layer-storage]]
+== Plan Repository Storage
+
+`.nil` files can be hundreds of megabytes even for representative JDK-module or dependency layers.
+Normal Maven transport compression may reduce transfer size, but Native Image must ultimately
+receive the original `.nil`. Plan repository retention, quotas, and remote-cache capacity, and
+publish broadly shared layers deliberately. Content-addressing or cross-artifact deduplication is
+outside the current layer contract.

--- a/docs/src/docs/asciidoc/layered-images.adoc
+++ b/docs/src/docs/asciidoc/layered-images.adoc
@@ -1,0 +1,361 @@
+= Layered Native Images: Reuse, Testing, and Deployment
+The GraalVM team
+
+Native Image layers let several native binaries reuse a separately built part of an image. A
+typical project puts stable modules and dependencies in a base layer, then consumes that layer
+from the application image, native tests, or other native binaries.
+
+This guide focuses on how layers fit into a real build: selecting layer contents, sharing one
+layer between build targets, using layers from native tests, and shipping the resulting
+application. For the complete configuration reference, see
+<<gradle-plugin.adoc#layered-images,the Gradle plugin documentation>> and
+<<maven-plugin.adoc#layered-images,the Maven plugin documentation>>.
+
+[IMPORTANT]
+====
+Layered images are an experimental Native Image feature. Native Build Tools can express
+multi-level layer stacks, but current Native Image releases support one shared base layer and a
+final application image. Keep layer chaining disabled until the Native Image version used by the
+build supports it.
+====
+
+[[layered-image-artifacts]]
+== Understand the Generated Artifacts
+
+Creating a layer produces two kinds of output:
+
+* A `.nil` file that another Native Image build consumes through `-H:LayerUse`. This is a
+  build-time artifact.
+* A platform shared library that the final executable loads at runtime, such as `libbase.so` on
+  Linux. This is a deployment artifact.
+
+The final executable does not contain the layer's shared library. A deployment must therefore
+include the executable and the shared library from every layer it uses. Publishing or attaching
+the `.nil` file does not automatically publish, copy, or embed the runtime libraries.
+
+[[layer-content-selection]]
+== Select Layer Contents
+
+Both plugins support module, package, path, dependency, and complete-classpath selection. Modules
+and packages may be combined in the same layer. Keep frequently changing application classes out
+of a broadly reused layer so that application changes do not force the layer to be rebuilt.
+
+For example, a Gradle layer can select JDK modules and packages from resolved dependencies:
+
+[source,groovy]
+----
+graalvmNative {
+    layers {
+        sharedRuntime {
+            contents {
+                modules('java.base', 'java.logging')
+                packages('org.slf4j')
+                fromConfiguration(configurations.runtimeClasspath)
+            }
+        }
+    }
+}
+----
+
+The equivalent Maven layer definition is:
+
+[source,xml]
+----
+<layer>
+  <name>shared-runtime</name>
+  <modules>
+    <module>java.base</module>
+    <module>java.logging</module>
+  </modules>
+  <packages>
+    <package>org.slf4j</package>
+  </packages>
+  <dependencies>
+    <dependency>
+      <artifact>org.slf4j:slf4j-api</artifact>
+    </dependency>
+  </dependencies>
+</layer>
+----
+
+[[gradle-layer-reuse]]
+== Reuse a Layer with Gradle
+
+Gradle layers are named objects outside the binary container. Calling `usesLayer` adds the
+producer task as a dependency of the consuming binary, so requesting `nativeCompile` or
+`nativeTest` also builds the layer when necessary.
+
+[[gradle-main-and-tests]]
+=== Share One Layer Between the Application and Native Tests
+
+The `main` and `test` binaries can consume the same named layer:
+
+[source,groovy]
+----
+graalvmNative {
+    layers {
+        sharedRuntime {
+            contents {
+                modules('java.base', 'java.logging')
+                fromConfiguration(configurations.runtimeClasspath)
+            }
+        }
+    }
+    binaries {
+        main {
+            usesLayer('sharedRuntime')
+        }
+        test {
+            usesLayer('sharedRuntime')
+        }
+    }
+}
+----
+
+Run the application and native tests normally:
+
+[source,bash]
+----
+./gradlew nativeRun
+./gradlew nativeTest
+----
+
+Both task graphs reuse `nativeSharedRuntimeLayer`. The Gradle run tasks add the directories of
+their selected layers to the runtime library search path.
+
+[[gradle-additional-tests]]
+=== Share a Layer with Additional Test Suites
+
+Register an additional native test binary and configure it like any other layer consumer. The
+following fragment assumes an `integTest` source set and `Test` task already exist:
+
+[source,groovy]
+----
+graalvmNative {
+    registerTestBinary('integTest') {
+        usingSourceSet(sourceSets.integTest)
+        forTestTask(tasks.named('integTest'))
+    }
+
+    binaries {
+        test {
+            usesLayer('sharedRuntime')
+        }
+        integTest {
+            usesLayer('sharedRuntime')
+        }
+    }
+}
+----
+
+`nativeTest` and `nativeIntegTest` now build separate native test images while sharing the same
+layer producer. Different suites can instead select different layers when their runtime
+requirements differ.
+
+[[gradle-multiple-binaries]]
+=== Share a Layer Between Executables and Libraries
+
+Repeated `usesLayer` calls can select multiple layers, and the same layer can be selected by
+multiple binaries. For example, an executable and a shared-library binary can both select
+`sharedRuntime`. Each consumer keeps its own Native Image options; layer-sensitive options must
+remain compatible between the producer and every consumer.
+
+[[maven-layer-reuse]]
+== Reuse a Layer with Maven
+
+Maven represents a layer as an attached artifact of type `nil`. A consumer declares the producer
+as a normal dependency with `<type>nil</type>`, which gives Maven enough information to order
+reactor modules and resolve layers from a repository without adding them to the Java classpath.
+
+[[maven-producer-module]]
+=== Create a Layer in a Producer Module
+
+Bind `layer-create` in the producer module:
+
+[source,xml]
+----
+<plugin>
+  <groupId>org.graalvm.buildtools</groupId>
+  <artifactId>native-maven-plugin</artifactId>
+  <extensions>true</extensions>
+  <executions>
+    <execution>
+      <id>create-shared-runtime</id>
+      <phase>package</phase>
+      <goals>
+        <goal>layer-create</goal>
+      </goals>
+      <configuration>
+        <layer>
+          <name>shared-runtime</name>
+          <modules>
+            <module>java.base</module>
+            <module>java.logging</module>
+          </modules>
+        </layer>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
+----
+
+The goal creates
+_target/native/layers/shared-runtime/shared-runtime.nil_ and attaches it to the project as a
+`nil` artifact.
+
+[[maven-main-and-tests]]
+=== Share One Layer Between Build Executions
+
+Declare the producer in the consumer module:
+
+[source,xml]
+----
+<dependency>
+  <groupId>org.example</groupId>
+  <artifactId>shared-runtime-layer</artifactId>
+  <version>${project.version}</version>
+  <type>nil</type>
+  <scope>runtime</scope>
+</dependency>
+----
+
+Put `<useLayers>` in the plugin-level configuration when every configured goal should use the
+same layer. In this example the application image and native tests share it:
+
+[source,xml]
+----
+<plugin>
+  <groupId>org.graalvm.buildtools</groupId>
+  <artifactId>native-maven-plugin</artifactId>
+  <extensions>true</extensions>
+  <configuration>
+    <useLayers>
+      <useLayer>
+        <artifact>org.example:shared-runtime-layer</artifact>
+      </useLayer>
+    </useLayers>
+  </configuration>
+  <executions>
+    <execution>
+      <id>build-application</id>
+      <phase>package</phase>
+      <goals>
+        <goal>compile-no-fork</goal>
+      </goals>
+    </execution>
+    <execution>
+      <id>run-native-tests</id>
+      <phase>test</phase>
+      <goals>
+        <goal>test</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+----
+
+Use execution-specific `<configuration>` blocks instead when application and test images need
+different layers. Multiple consumer modules can declare and select the same `nil` dependency.
+
+[NOTE]
+====
+When a native test is executed, the plugin adds the directories containing its selected layer
+artifacts to the platform library search path. For a layer resolved from a repository, the
+runtime shared library must also be staged next to the `.nil` file or added to the search path
+separately.
+====
+
+[[layer-chaining]]
+== Prepare Multi-Level Layer Stacks
+
+Native Build Tools can describe a layer that consumes another layer. In Gradle, call
+`usesLayer` from the consuming layer:
+
+[source,groovy]
+----
+graalvmNative {
+    layers {
+        base {
+            contents.modules('java.base')
+        }
+        framework {
+            usesLayer('base')
+            contents.packages('org.example.framework')
+        }
+    }
+    binaries.main {
+        usesLayer('framework')
+    }
+}
+----
+
+In Maven, declare the base layer as a `nil` dependency of the next producer module and add
+`<useLayers>` to that module's `layer-create` execution. Each produced layer remains an
+independently ordered build artifact.
+
+Do not enable this topology until the Native Image version used by the build supports chained
+shared layers. When deploying a multi-level stack, every layer's runtime shared library must be
+included in the library search path.
+
+[[shipping-layered-images]]
+== Ship a Layered Application
+
+A portable application bundle should keep the executable and its layer libraries together. For
+example, a Linux distribution can use this layout:
+
+[source,text]
+----
+application/
+|-- bin/
+|   `-- application
+`-- lib/
+    |-- libbase.so
+    `-- libframework.so
+----
+
+The `.nil` files are needed to build downstream images, but they are not required merely to run
+an already-built final executable. Keep them in a build artifact repository when other builds
+need to consume the layers.
+
+[[shipping-linux]]
+=== Linux
+
+[source,bash]
+----
+APP_HOME=/opt/application
+LD_LIBRARY_PATH="$APP_HOME/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+    "$APP_HOME/bin/application"
+----
+
+For a container image, copy both directories and set `LD_LIBRARY_PATH` in the runtime image:
+
+[source,dockerfile]
+----
+COPY application/ /opt/application/
+ENV LD_LIBRARY_PATH=/opt/application/lib
+ENTRYPOINT ["/opt/application/bin/application"]
+----
+
+[[shipping-macos]]
+=== macOS
+
+[source,bash]
+----
+APP_HOME=/opt/application
+DYLD_LIBRARY_PATH="$APP_HOME/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" \
+    "$APP_HOME/bin/application"
+----
+
+[[shipping-windows]]
+=== Windows
+
+[source,powershell]
+----
+$env:PATH = "$PWD\lib;$env:PATH"
+& "$PWD\bin\application.exe"
+----
+
+Native Build Tools builds the final executable and each layer's shared library, but does not
+package them together for deployment. The project's packaging process must include the executable
+and all layer shared libraries, and configure the platform loader to find those libraries at
+runtime.

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -219,6 +219,9 @@ For example, to build a native image named `myapp` that uses `org.example.ClassN
 [[layered-images]]
 === Layered Native Images
 
+For scenario-based examples covering native tests, reuse across executions and modules, and
+deployment, see <<layered-images.adoc#,Layered Native Images: Reuse, Testing, and Deployment>>.
+
 The `layer-create` goal produces a `.nil` Native Image layer and attaches it to the Maven project.
 A consuming module declares that artifact with `<type>nil</type>` and selects it through
 `<useLayers>`. The `nil` dependency is resolved separately and never enters the Java classpath.

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -296,8 +296,7 @@ explicit layer-producing execution.
 
 `<useLayers>` applies to every goal that receives that configuration, including `native:test` and
 shared-library builds. Put it in an execution-specific `<configuration>` when tests should use a
-different layer stack from the main image. A `layer-create` execution may also configure
-`<useLayers>` to build one named layer on top of another.
+different layer selection from the main image.
 
 The application executable dynamically loads the runtime libraries contained in its producer
 layers. Repository consumers extract those libraries under `target/native/layer-runtime`; package

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -223,12 +223,12 @@ The `layer-create` goal produces a `.nil` Native Image layer and attaches it to 
 A consuming module declares that artifact with `<type>nil</type>` and selects it through
 `<useLayers>`. The `nil` dependency is resolved separately and never enters the Java classpath.
 
-[IMPORTANT]
+[TIP]
 ====
-Configure the Native Build Tools plugin with `<extensions>true</extensions>` in the parent or every
-module that resolves `nil` dependencies. Without it, Maven does not load the `nil` artifact handler;
-the dependency may be treated like a normal Java artifact or fail to resolve with an unexpected
-extension.
+Configure the Native Build Tools plugin with `<extensions>true</extensions>` in the parent so Maven
+registers the `nil` artifact handler early and consistently across reactor and repository builds.
+Some Maven versions can preserve an explicitly declared `<type>nil</type>` without extension loading,
+but the extension remains the supported, predictable setup.
 ====
 
 A producer execution can select modules, packages, explicit paths, dependency coordinates, or all
@@ -282,7 +282,19 @@ The consumer declares and selects the attached artifact:
 Coordinates use `groupId:artifactId` or `groupId:artifactId:version`. The plugin reports malformed,
 missing, ambiguous, and duplicate selections before invoking Native Image, and warns when a
 declared `nil` dependency is not selected. Native Image 25.0.3 and 25.0.4 cannot consume layers
-reliably, so upgrade to 25.0.5 or later before using `<useLayers>`.
+reliably, so upgrade to 25.0.5 or later before using `<useLayers>`. To deliberately test an affected
+release, pass `-Dorg.graalvm.buildtools.layers.allowUnsupportedConsumption=true` at your own risk.
+Layer names may contain letters, digits, dots, underscores, and hyphens. The legacy
+`<includeDependencies>` option accepts only `all`; other values fail fast.
+
+`<useLayers>` applies to every goal that receives that configuration, including `native:test` and
+shared-library builds. Put it in an execution-specific `<configuration>` when tests should use a
+different layer stack from the main image. A `layer-create` execution may also configure
+`<useLayers>` to build one named layer on top of another.
+
+The application executable dynamically loads the shared libraries contained in its producer
+layers. Ship those libraries with the application and add their directories to `LD_LIBRARY_PATH`
+on Linux, `DYLD_LIBRARY_PATH` on macOS, or `PATH` on Windows before launching the executable.
 
 [NOTE]
 ====

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -222,9 +222,10 @@ For example, to build a native image named `myapp` that uses `org.example.ClassN
 For scenario-based examples covering native tests, reuse across executions and modules, and
 deployment, see <<layered-images.adoc#,Layered Native Images: Reuse, Testing, and Deployment>>.
 
-The `layer-create` goal produces a `.nil` Native Image layer and attaches it to the Maven project.
-A consuming module declares that artifact with `<type>nil</type>` and selects it through
-`<useLayers>`. The `nil` dependency is resolved separately and never enters the Java classpath.
+The `layer-create` goal produces a `.nil` Native Image layer plus a platform-classified runtime
+ZIP and attaches both to the Maven project. A consuming module declares the `.nil` artifact with
+`<type>nil</type>` and selects it through `<useLayers>`. The `nil` dependency is resolved separately
+and never enters the Java classpath; the matching runtime ZIP is resolved and staged automatically.
 
 [TIP]
 ====
@@ -288,14 +289,21 @@ declared `nil` dependency is not selected. Layer names may contain letters, digi
 underscores, and hyphens. The legacy
 `<includeDependencies>` option accepts only `all`; other values fail fast.
 
+Consumption is coordinate-only; local `.nil` paths are not a supported `<useLayers>` form. A
+producer may use `<packaging>pom</packaging>` and still bind `layer-create`. The
+`skipNativeBuildForPom` option skips `compile-no-fork` for POM projects but does not skip an
+explicit layer-producing execution.
+
 `<useLayers>` applies to every goal that receives that configuration, including `native:test` and
 shared-library builds. Put it in an execution-specific `<configuration>` when tests should use a
 different layer stack from the main image. A `layer-create` execution may also configure
 `<useLayers>` to build one named layer on top of another.
 
-The application executable dynamically loads the shared libraries contained in its producer
-layers. Ship those libraries with the application and add their directories to `LD_LIBRARY_PATH`
-on Linux, `DYLD_LIBRARY_PATH` on macOS, or `PATH` on Windows before launching the executable.
+The application executable dynamically loads the runtime libraries contained in its producer
+layers. Repository consumers extract those libraries under `target/native/layer-runtime`; package
+those directories with the application and add them to `LD_LIBRARY_PATH` on Linux,
+`DYLD_LIBRARY_PATH` on macOS, or `PATH` on Windows before launching the executable. See the linked
+guide for the GraalVM 25.1+ support policy, native-test module requirements, and storage guidance.
 
 [NOTE]
 ====

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -281,10 +281,8 @@ The consumer declares and selects the attached artifact:
 
 Coordinates use `groupId:artifactId` or `groupId:artifactId:version`. The plugin reports malformed,
 missing, ambiguous, and duplicate selections before invoking Native Image, and warns when a
-declared `nil` dependency is not selected. Native Image 25.0.3 and 25.0.4 cannot consume layers
-reliably, so upgrade to 25.0.5 or later before using `<useLayers>`. To deliberately test an affected
-release, pass `-Dorg.graalvm.buildtools.layers.allowUnsupportedConsumption=true` at your own risk.
-Layer names may contain letters, digits, dots, underscores, and hyphens. The legacy
+declared `nil` dependency is not selected. Layer names may contain letters, digits, dots,
+underscores, and hyphens. The legacy
 `<includeDependencies>` option accepts only `all`; other values fail fast.
 
 `<useLayers>` applies to every goal that receives that configuration, including `native:test` and

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -216,6 +216,74 @@ For example, to build a native image named `myapp` that uses `org.example.ClassN
 </configuration>
 ----
 
+[[layered-images]]
+=== Layered Native Images
+
+The `layer-create` goal produces a `.nil` Native Image layer and attaches it to the Maven project.
+A consuming module declares that artifact with `<type>nil</type>` and selects it through
+`<useLayers>`. The `nil` dependency is resolved separately and never enters the Java classpath.
+
+[IMPORTANT]
+====
+Configure the Native Build Tools plugin with `<extensions>true</extensions>` in the parent or every
+module that resolves `nil` dependencies. Without it, Maven does not load the `nil` artifact handler;
+the dependency may be treated like a normal Java artifact or fail to resolve with an unexpected
+extension.
+====
+
+A producer execution can select modules, packages, explicit paths, dependency coordinates, or all
+runtime dependencies:
+
+[source,xml]
+----
+<execution>
+  <id>create-base-layer</id>
+  <phase>package</phase>
+  <goals>
+    <goal>layer-create</goal>
+  </goals>
+  <configuration>
+    <layer>
+      <name>base</name>
+      <modules>
+        <module>java.base</module>
+      </modules>
+      <dependencies>
+        <dependency>
+          <artifact>org.slf4j:slf4j-api</artifact>
+        </dependency>
+      </dependencies>
+    </layer>
+  </configuration>
+</execution>
+----
+
+The consumer declares and selects the attached artifact:
+
+[source,xml]
+----
+<dependency>
+  <groupId>org.example</groupId>
+  <artifactId>base-layer</artifactId>
+  <version>${project.version}</version>
+  <type>nil</type>
+  <scope>runtime</scope>
+</dependency>
+
+<configuration>
+  <useLayers>
+    <useLayer>
+      <artifact>org.example:base-layer</artifact>
+    </useLayer>
+  </useLayers>
+</configuration>
+----
+
+Coordinates use `groupId:artifactId` or `groupId:artifactId:version`. The plugin reports malformed,
+missing, ambiguous, and duplicate selections before invoking Native Image, and warns when a
+declared `nil` dependency is not selected. Native Image 25.0.3 cannot consume layers reliably, so
+upgrade to a newer release before using `<useLayers>`.
+
 [NOTE]
 ====
 Most of the aforementioned properties can also be set on the command line as a part of Maven invocation. For example, if you want to temporarily enable verbose mode, you can append `-Dverbose` to your Maven command.

--- a/docs/src/docs/asciidoc/maven-plugin.adoc
+++ b/docs/src/docs/asciidoc/maven-plugin.adoc
@@ -281,8 +281,8 @@ The consumer declares and selects the attached artifact:
 
 Coordinates use `groupId:artifactId` or `groupId:artifactId:version`. The plugin reports malformed,
 missing, ambiguous, and duplicate selections before invoking Native Image, and warns when a
-declared `nil` dependency is not selected. Native Image 25.0.3 cannot consume layers reliably, so
-upgrade to a newer release before using `<useLayers>`.
+declared `nil` dependency is not selected. Native Image 25.0.3 and 25.0.4 cannot consume layers
+reliably, so upgrade to 25.0.5 or later before using `<useLayers>`.
 
 [NOTE]
 ====

--- a/native-gradle-plugin/docs/architecture.md
+++ b/native-gradle-plugin/docs/architecture.md
@@ -32,6 +32,10 @@ tasks so one binary has one authoritative configuration model. Delegating option
 used when a task needs a compile-only or runtime-only view of a binary, but the wrapper must not
 fork behavior from the underlying `NativeImageOptions` object.
 
+Named layers are separate domain objects with dedicated producer tasks; binaries consume their
+provider-backed outputs. The compatibility boundary and cross-tool artifact model follow
+[§root/DEC-layer-model](../../docs/spec/decisions/layer-model.md#dec-layer-model-native-image-layers-use-shared-selection-and-build-tool-native-wiring).
+
 ## 3. Task graph architecture
 
 For each binary, the plugin registers a compile task, run task, resource config task, and dynamic

--- a/native-gradle-plugin/docs/e2e.md
+++ b/native-gradle-plugin/docs/e2e.md
@@ -74,6 +74,9 @@ image names, PGO/layer-related options, fat JAR behavior, runtime arguments, com
 construction, and named-layer consumption by executable, native-test, and shared-library binaries. This
 protects [§FS-native-tasks.4](functional/native-image-tasks.md#4-command-line-overrides), [§FS-native-invocation.3](functional/native-image-invocation.md#3-command-line-construction), and
 [§FS-native-invocation.5](functional/native-image-invocation.md#5-classpath-jar-and-artifact-analysis).
+Its layer scenarios cover module, package, explicit-path, and `all` selectors; executable,
+native-test, shared-library, and chained consumers; and provider duplicate validation before a
+producer task starts.
 
 ### 3.7 Gradle integration
 

--- a/native-gradle-plugin/docs/e2e.md
+++ b/native-gradle-plugin/docs/e2e.md
@@ -75,11 +75,11 @@ construction, and named-layer consumption by executable, native-test, and shared
 protects [§FS-native-tasks.4](functional/native-image-tasks.md#4-command-line-overrides), [§FS-native-invocation.3](functional/native-image-invocation.md#3-command-line-construction), and
 [§FS-native-invocation.5](functional/native-image-invocation.md#5-classpath-jar-and-artifact-analysis).
 Its layer scenarios cover module, package, explicit-path, and `all` selectors; executable,
-native-test, shared-library, and chained consumers; and provider duplicate validation before a
-producer task starts.
+native-test (including additional test suites), and shared-library consumers; and provider duplicate
+validation before a producer task starts.
 Layer-consumption scenarios that exercise the `all` selector, custom shared-library consumers,
-application distributions, or chained layers are skipped on GraalVM 25.0.x because Native Image
-can fail after `-H:LayerUse` loads a valid layer.
+application distributions, or native tests are skipped on GraalVM 25.0.x because Native Image can
+fail after `-H:LayerUse` loads a valid layer.
 
 ### 3.7 Gradle integration
 

--- a/native-gradle-plugin/docs/e2e.md
+++ b/native-gradle-plugin/docs/e2e.md
@@ -70,8 +70,9 @@ standard and conditional mode behavior, agent output, configuration-cache compat
 ### 3.6 Native Image options
 
 `NativeImageOptionsTest` and `LayeredApplicationFunctionalTest` verify build arguments, quick build,
-image names, PGO/layer-related options, fat JAR behavior, runtime arguments, and command-line
-construction. This protects [§FS-native-tasks.4](functional/native-image-tasks.md#4-command-line-overrides), [§FS-native-invocation.3](functional/native-image-invocation.md#3-command-line-construction), and
+image names, PGO/layer-related options, fat JAR behavior, runtime arguments, command-line
+construction, and named-layer consumption by executable, native-test, and shared-library binaries. This
+protects [§FS-native-tasks.4](functional/native-image-tasks.md#4-command-line-overrides), [§FS-native-invocation.3](functional/native-image-invocation.md#3-command-line-construction), and
 [§FS-native-invocation.5](functional/native-image-invocation.md#5-classpath-jar-and-artifact-analysis).
 
 ### 3.7 Gradle integration

--- a/native-gradle-plugin/docs/e2e.md
+++ b/native-gradle-plugin/docs/e2e.md
@@ -77,8 +77,9 @@ protects [§FS-native-tasks.4](functional/native-image-tasks.md#4-command-line-o
 Its layer scenarios cover module, package, explicit-path, and `all` selectors; executable,
 native-test, shared-library, and chained consumers; and provider duplicate validation before a
 producer task starts.
-Layer-consumption scenarios that exercise the `all` selector or chained layers are skipped on
-GraalVM 25.0.x because Native Image can fail after `-H:LayerUse` loads a valid layer.
+Layer-consumption scenarios that exercise the `all` selector, custom shared-library consumers,
+application distributions, or chained layers are skipped on GraalVM 25.0.x because Native Image
+can fail after `-H:LayerUse` loads a valid layer.
 
 ### 3.7 Gradle integration
 

--- a/native-gradle-plugin/docs/e2e.md
+++ b/native-gradle-plugin/docs/e2e.md
@@ -77,8 +77,8 @@ protects [§FS-native-tasks.4](functional/native-image-tasks.md#4-command-line-o
 Its layer scenarios cover module, package, explicit-path, and `all` selectors; executable,
 native-test, shared-library, and chained consumers; and provider duplicate validation before a
 producer task starts.
-Layer-consumption scenarios that exercise the `all` selector or chained layers are skipped on
-GraalVM 25.0.x because Native Image can fail after `-H:LayerUse` loads a valid layer.
+Layer-consumption scenarios are skipped on GraalVM 25.0.x because Native Image can fail after
+`-H:LayerUse` loads a valid layer. Producer-only selector coverage continues on GraalVM 25.0.x.
 
 ### 3.7 Gradle integration
 

--- a/native-gradle-plugin/docs/e2e.md
+++ b/native-gradle-plugin/docs/e2e.md
@@ -77,8 +77,8 @@ protects [§FS-native-tasks.4](functional/native-image-tasks.md#4-command-line-o
 Its layer scenarios cover module, package, explicit-path, and `all` selectors; executable,
 native-test, shared-library, and chained consumers; and provider duplicate validation before a
 producer task starts.
-Layer-consumption scenarios are skipped on GraalVM 25.0.x because Native Image can fail after
-`-H:LayerUse` loads a valid layer. Producer-only selector coverage continues on GraalVM 25.0.x.
+Layer-consumption scenarios that exercise the `all` selector or chained layers are skipped on
+GraalVM 25.0.x because Native Image can fail after `-H:LayerUse` loads a valid layer.
 
 ### 3.7 Gradle integration
 

--- a/native-gradle-plugin/docs/e2e.md
+++ b/native-gradle-plugin/docs/e2e.md
@@ -77,8 +77,8 @@ protects [§FS-native-tasks.4](functional/native-image-tasks.md#4-command-line-o
 Its layer scenarios cover module, package, explicit-path, and `all` selectors; executable,
 native-test, shared-library, and chained consumers; and provider duplicate validation before a
 producer task starts.
-The `all`-selector layer-consumption scenario is skipped on GraalVM 25.0.x because its image-heap
-scanner can fail after `-H:LayerUse` loads a valid layer.
+Layer-consumption scenarios that exercise the `all` selector or chained layers are skipped on
+GraalVM 25.0.x because Native Image can fail after `-H:LayerUse` loads a valid layer.
 
 ### 3.7 Gradle integration
 

--- a/native-gradle-plugin/docs/e2e.md
+++ b/native-gradle-plugin/docs/e2e.md
@@ -77,6 +77,8 @@ protects [§FS-native-tasks.4](functional/native-image-tasks.md#4-command-line-o
 Its layer scenarios cover module, package, explicit-path, and `all` selectors; executable,
 native-test, shared-library, and chained consumers; and provider duplicate validation before a
 producer task starts.
+The `all`-selector layer-consumption scenario is skipped on GraalVM 25.0.x because its image-heap
+scanner can fail after `-H:LayerUse` loads a valid layer.
 
 ### 3.7 Gradle integration
 

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -49,8 +49,7 @@ project artifacts as well as external modules. Empty layer selections, duplicate
 invalid layer names fail with actionable errors before Native Image is invoked. A named layer may
 consume named layers; its task passes their `.nil` files with `-H:LayerUse`, declares them as task
 inputs, and depends on their producer tasks. Layer tasks use the same reachability-metadata
-repository and schema preflight as binary tasks. Native Image 25.0.3 or 25.0.4 consumption fails
-before invocation unless the user explicitly enables the documented unsupported-version override.
+repository and schema preflight as binary tasks.
 [§REQ-gradle-model](../requirements.md#req-gradle-model-the-gradle-plugin-preserves-gradle-model-compatibility).
 
 ## 4. Argument files

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -46,7 +46,7 @@ Consuming binaries pass each produced `.nil` file with `-H:LayerUse`, depend on 
 and declare the file as an input. Complete configurations and selected dependency coordinates are
 resolved lazily through Gradle artifact APIs before translation. Resolved configurations include
 project artifacts as well as external modules. Empty layer selections, duplicate consumption, and
-Native Image 25.0.3 consumption fail with actionable errors before Native Image is invoked.
+Native Image 25.0.3 or 25.0.4 consumption fail with actionable errors before Native Image is invoked.
 [§REQ-gradle-model](../requirements.md#req-gradle-model-the-gradle-plugin-preserves-gradle-model-compatibility).
 
 ## 4. Argument files

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -44,8 +44,8 @@ model and use the common renderer from
 [§common/FS-common-libraries.1](../../../common/docs/functional-spec.md#1-shared-native-image-utilities).
 Consuming binaries pass each produced `.nil` file with `-H:LayerUse`, depend on its producer task,
 and declare the file as an input. They also inherit the producer layer's declared classpath inputs,
-including inputs inherited through a layer stack, so Native Image sees the same entries in every
-dependent build. Complete configurations and selected dependency coordinates are
+so Native Image sees the same entries in every dependent build. Complete configurations and selected
+dependency coordinates are
 resolved lazily through Gradle artifact APIs before translation. Resolved configurations include
 project artifacts as well as external modules. Empty layer selections, duplicate consumption, and
 invalid layer names fail with actionable errors before Native Image is invoked. A named layer may

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -43,7 +43,9 @@ Named layer tasks translate their Gradle-native contents into the shared artifac
 model and use the common renderer from
 [§common/FS-common-libraries.1](../../../common/docs/functional-spec.md#1-shared-native-image-utilities).
 Consuming binaries pass each produced `.nil` file with `-H:LayerUse`, depend on its producer task,
-and declare the file as an input. Complete configurations and selected dependency coordinates are
+and declare the file as an input. They also inherit the producer layer's declared classpath inputs,
+including inputs inherited through a layer stack, so Native Image sees the same entries in every
+dependent build. Complete configurations and selected dependency coordinates are
 resolved lazily through Gradle artifact APIs before translation. Resolved configurations include
 project artifacts as well as external modules. Empty layer selections, duplicate consumption, and
 invalid layer names fail with actionable errors before Native Image is invoked. A named layer may

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -46,7 +46,11 @@ Consuming binaries pass each produced `.nil` file with `-H:LayerUse`, depend on 
 and declare the file as an input. Complete configurations and selected dependency coordinates are
 resolved lazily through Gradle artifact APIs before translation. Resolved configurations include
 project artifacts as well as external modules. Empty layer selections, duplicate consumption, and
-Native Image 25.0.3 or 25.0.4 consumption fail with actionable errors before Native Image is invoked.
+invalid layer names fail with actionable errors before Native Image is invoked. A named layer may
+consume named layers; its task passes their `.nil` files with `-H:LayerUse`, declares them as task
+inputs, and depends on their producer tasks. Layer tasks use the same reachability-metadata
+repository and schema preflight as binary tasks. Native Image 25.0.3 or 25.0.4 consumption fails
+before invocation unless the user explicitly enables the documented unsupported-version override.
 [§REQ-gradle-model](../requirements.md#req-gradle-model-the-gradle-plugin-preserves-gradle-model-compatibility).
 
 ## 4. Argument files

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -39,6 +39,14 @@ For a layer created from declared JARs, the command line must use those JARs as 
 the layer input remains limited to the declaration. A layer created from packages must instead
 retain the binary classpath, which supplies the classes selected by those package names.
 
+Named layer tasks translate their Gradle-native contents into the shared artifact-selection
+model and use the common renderer from
+[§common/FS-common-libraries.1](../../../common/docs/functional-spec.md#1-shared-native-image-utilities).
+Consuming binaries pass each produced `.nil` file with `-H:LayerUse`, depend on its producer task,
+and declare the file as an input. Complete configurations and selected dependency coordinates are
+resolved lazily through Gradle artifact APIs before translation.
+[§REQ-gradle-model](../requirements.md#req-gradle-model-the-gradle-plugin-preserves-gradle-model-compatibility).
+
 ## 4. Argument files
 
 The plugin must support Native Image argument files for command lines that should not be passed as

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -44,7 +44,9 @@ model and use the common renderer from
 [§common/FS-common-libraries.1](../../../common/docs/functional-spec.md#1-shared-native-image-utilities).
 Consuming binaries pass each produced `.nil` file with `-H:LayerUse`, depend on its producer task,
 and declare the file as an input. Complete configurations and selected dependency coordinates are
-resolved lazily through Gradle artifact APIs before translation.
+resolved lazily through Gradle artifact APIs before translation. Resolved configurations include
+project artifacts as well as external modules. Empty layer selections, duplicate consumption, and
+Native Image 25.0.3 consumption fail with actionable errors before Native Image is invoked.
 [§REQ-gradle-model](../requirements.md#req-gradle-model-the-gradle-plugin-preserves-gradle-model-compatibility).
 
 ## 4. Argument files

--- a/native-gradle-plugin/docs/functional/native-image-tasks.md
+++ b/native-gradle-plugin/docs/functional/native-image-tasks.md
@@ -23,13 +23,17 @@ consistently.
 Every named layer receives a derived `native<Layer>Layer` task with an output under
 `build/native/layers/<layer>/<layer>.nil`. Its inputs are the explicit selection and, only when
 packages require it, the configured application classpath. Consuming compile and run tasks are
-wired to that output through providers.
+wired to that output through providers. The layer task creates and executes from its declared
+output directory before invoking Native Image. It uses the logical layer name for the `.nil`
+bundle and the platform's native shared-library naming derived from `lib<layer>` for the companion
+library consumed by later image builds.
 
 ## 2. Run tasks
 
 `nativeRun` executes the output of `nativeCompile` for the `main` binary and passes runtime
 arguments from the binary configuration. When layered Native Image output is used, it sets up layer
-library paths. Custom runnable binaries receive derived run tasks that execute their own
+library paths lazily from the produced layer files while remaining compatible with Gradle's
+configuration cache. Custom runnable binaries receive derived run tasks that execute their own
 compile-task output.
 
 `nativeTest` executes the output of `nativeTestCompile` unless native test execution is skipped.

--- a/native-gradle-plugin/docs/functional/native-image-tasks.md
+++ b/native-gradle-plugin/docs/functional/native-image-tasks.md
@@ -20,6 +20,11 @@ declare Gradle inputs and outputs for the selected options and generated files, 
 binary's classpath and reachability-metadata exclusions, so Gradle can skip, cache, or rerun them
 consistently.
 
+Every named layer receives a derived `native<Layer>Layer` task with an output under
+`build/native/layers/<layer>/<layer>.nil`. Its inputs are the explicit selection and, only when
+packages require it, the configured application classpath. Consuming compile and run tasks are
+wired to that output through providers.
+
 ## 2. Run tasks
 
 `nativeRun` executes the output of `nativeCompile` for the `main` binary and passes runtime

--- a/native-gradle-plugin/docs/functional/plugin-model.md
+++ b/native-gradle-plugin/docs/functional/plugin-model.md
@@ -75,9 +75,10 @@ The same duplicate and name validation applies when a named layer consumes anoth
 Every selection form (`layer =`, `useLayer(NativeImageLayer)`,
 `useLayer(Provider<NativeImageLayer>)`, and `usesLayer(String)`) contributes its logical layer
 name to the same selection set. A consuming binary may select each logical name only once. The
-plugin resolves provider-backed names at a cache-safe validation boundary after configuration and
-fails that validation before any selected producer task executes; it retains lazy name resolution
-and configuration-cache compatibility.
+plugin resolves provider-backed names lazily and fails duplicate-name validation before any
+selected producer task executes. This layer model must not introduce avoidable project or task
+container serialization; general configuration-cache compatibility remains governed by the
+plugin's existing configuration-cache baseline.
 
 `fromConfiguration(...)` and `all` include resolved external and project dependencies. Dependency
 selectors also accept Gradle providers, including version-catalog accessors.
@@ -96,12 +97,17 @@ original naming and external-module-only semantics. Only legacy layer declaratio
 | Native test | `binaries.test.usesLayer` | `LayeredApplicationFunctionalTest` |
 | Shared library | `binaries.main.sharedLibrary` with `usesLayer` | `LayeredApplicationFunctionalTest` |
 | Chained layers | `NativeImageLayer.usesLayer` | `LayeredApplicationFunctionalTest` |
-| Cross-project publication | Gradle task output and file dependency wiring | Gradle-specific; Maven uses reactor/repository `nil` artifacts instead |
+| Application distribution | Main layered binary is added to `installDist`, `distZip`, and `distTar` with staged runtime files and a native launcher | Installed and archived distributions run without producer build directories |
+| Cross-project publication | Not first-class; manual `getLayerFiles()` or file wiring only | No consumable publication variant is promised |
 
 Layer shared libraries remain external runtime dependencies. On Linux set `LD_LIBRARY_PATH`; on
 macOS set `DYLD_LIBRARY_PATH`; and on Windows add the layer directory to `PATH` before running a
-layered executable. `nativeRun` supplies this for its selected layers, but deployed executables
-need the same platform loader configuration. [§root/FS-native-builds.6](../../../docs/spec/functional/native-image-builds.md#6-layered-images).
+layered executable. `nativeRun` supplies this for its selected layers. When the `application`
+plugin is present, the main distribution includes the native executable under `lib/native`, each
+selected layer's runtime files under `lib/native-layers/<layer>`, and a `<imageName>-native`
+launcher under `bin` that configures the loader before execution. Other packaging plugins can
+consume the cacheable `nativeLayerRuntimeFiles` task output.
+[§root/FS-native-builds.6](../../../docs/spec/functional/native-image-builds.md#6-layered-images).
 
 ## 3. Default binaries
 

--- a/native-gradle-plugin/docs/functional/plugin-model.md
+++ b/native-gradle-plugin/docs/functional/plugin-model.md
@@ -34,6 +34,32 @@ The extension feeds the option objects consumed by compile, run, resource-genera
 and native-test tasks. Users should not repeat `imageName`, `mainClass`, `buildArgs`, metadata
 directories, or resource settings separately on each task.
 
+Named Native Image layers are first-class entries in a `layers` container beside `binaries`.
+Each layer owns its contents and deterministic `.nil` output. Binaries consume one or more layer
+objects through typed, lazy references:
+
+```groovy
+graalvmNative {
+    layers {
+        base {
+            contents {
+                modules.add('java.base')
+                fromConfiguration(configurations.runtimeClasspath)
+            }
+        }
+    }
+    binaries {
+        main {
+            useLayer(layers.base)
+        }
+    }
+}
+```
+
+The previous binary-scoped `createLayer` and string-based `useLayer` surface remains as a
+deprecated compatibility adapter. Only legacy layer declarations retain the `lib` binary-name
+rule. [§root/REQ-backwards-compatibility.1](../../../docs/spec/requirements.md#1-deprecation-over-removal).
+
 ## 3. Default binaries
 
 For Java application projects, the plugin must create a `main` binary whose `mainClass` convention
@@ -61,8 +87,8 @@ Users may add entries to the `binaries` container for extra source sets or entry
 must create matching compile and run tasks with predictable task names derived from the binary
 name. Custom binaries apply [§root/FS-native-builds](../../../docs/spec/functional/native-image-builds.md#fs-native-builds-both-plugins-build-native-images-from-build-tool-project-state) without forcing users outside the
 plugin's option model. Custom application binaries default to the main runtime classpath unless a
-specialized registration or image mode, such as a native test binary or layer-create binary,
-provides a source-set-specific or intentionally empty classpath.
+specialized registration, such as a native test binary, provides a source-set-specific classpath.
+Named layers create dedicated tasks outside the binary container.
 
 ## 5. Activation examples
 

--- a/native-gradle-plugin/docs/functional/plugin-model.md
+++ b/native-gradle-plugin/docs/functional/plugin-model.md
@@ -36,7 +36,10 @@ directories, or resource settings separately on each task.
 
 Named Native Image layers are first-class entries in a `layers` container beside `binaries`.
 Each layer owns its contents and deterministic `.nil` output. Binaries consume one or more layer
-objects through typed, lazy references:
+objects through typed, lazy references. Layers may consume earlier layers through the same API,
+allowing a build to express a multi-level Native Image layer stack. `usesLayer('<name>')` is the
+order-independent Groovy DSL form and resolves the named layer lazily, so consumers may be
+declared before their producers:
 
 ```groovy
 graalvmNative {
@@ -47,26 +50,35 @@ graalvmNative {
                 fromConfiguration(configurations.runtimeClasspath)
             }
         }
+        applicationFramework {
+            usesLayer('base')
+            contents {
+                packages('com.example.framework')
+            }
+        }
     }
     binaries {
         main {
-            useLayer(graalvmNative.layers.base)
+            usesLayer('base')
         }
     }
 }
 ```
 
 Inside a binary closure, the deprecated binary-scoped `layers` property shadows the extension
-container. Groovy builds must therefore use the qualified `graalvmNative.layers.<name>` path.
+container. Groovy builds may use `usesLayer('<name>')` or the qualified
+`graalvmNative.layers.<name>` path.
 The singular `layer` property replaces its previous assignment, while repeated `useLayer(...)`
 calls add distinct layers. Duplicate layer selections fail before Native Image is invoked.
+The same duplicate and name validation applies when a named layer consumes another named layer.
 
 `fromConfiguration(...)` and `all` include resolved external and project dependencies. Dependency
 selectors also accept Gradle providers, including version-catalog accessors.
 
-The previous binary-scoped `createLayer` and string-based `useLayer` surface remains as a
-deprecated compatibility adapter. Only legacy layer declarations retain the `lib` binary-name
-rule. [§root/REQ-backwards-compatibility.1](../../../docs/spec/requirements.md#1-deprecation-over-removal).
+The previous binary-scoped `createLayer`, string-based `useLayer`, and
+`externalDependenciesOf(...)` surfaces remain as deprecated compatibility adapters with their
+original naming and external-module-only semantics. Only legacy layer declarations retain the
+`lib` binary-name rule. [§root/REQ-backwards-compatibility.1](../../../docs/spec/requirements.md#1-deprecation-over-removal).
 
 ## 3. Default binaries
 
@@ -88,6 +100,8 @@ application {
 
 The plugin must also create a `test` binary connected to the default `test` task and `test` source
 set so `nativeTest` can build and run native JUnit tests without a separate binary declaration.
+Test and shared-library binaries use the same layer-consumption model as executable binaries;
+layer selection is explicit on each binary and is not inherited from `binaries.main`.
 
 ## 4. Custom binaries
 

--- a/native-gradle-plugin/docs/functional/plugin-model.md
+++ b/native-gradle-plugin/docs/functional/plugin-model.md
@@ -50,11 +50,19 @@ graalvmNative {
     }
     binaries {
         main {
-            useLayer(layers.base)
+            useLayer(graalvmNative.layers.base)
         }
     }
 }
 ```
+
+Inside a binary closure, the deprecated binary-scoped `layers` property shadows the extension
+container. Groovy builds must therefore use the qualified `graalvmNative.layers.<name>` path.
+The singular `layer` property replaces its previous assignment, while repeated `useLayer(...)`
+calls add distinct layers. Duplicate layer selections fail before Native Image is invoked.
+
+`fromConfiguration(...)` and `all` include resolved external and project dependencies. Dependency
+selectors also accept Gradle providers, including version-catalog accessors.
 
 The previous binary-scoped `createLayer` and string-based `useLayer` surface remains as a
 deprecated compatibility adapter. Only legacy layer declarations retain the `lib` binary-name

--- a/native-gradle-plugin/docs/functional/plugin-model.md
+++ b/native-gradle-plugin/docs/functional/plugin-model.md
@@ -86,6 +86,22 @@ The previous binary-scoped `createLayer`, string-based `useLayer`, and
 original naming and external-module-only semantics. Only legacy layer declarations retain the
 `lib` binary-name rule. [§root/REQ-backwards-compatibility.1](../../../docs/spec/requirements.md#1-deprecation-over-removal).
 
+### Layer support matrix
+
+| Selector or consumer | Gradle DSL support | Executable evidence |
+| --- | --- | --- |
+| Modules, packages, explicit paths, `all` | `contents.modules`, `contents.packages`, `contents.from`, `contents.all` | `LayeredApplicationFunctionalTest` |
+| Main executable | `binaries.main.usesLayer` | `LayeredApplicationFunctionalTest` |
+| Native test | `binaries.test.usesLayer` | `LayeredApplicationFunctionalTest` |
+| Shared library | `binaries.main.sharedLibrary` with `usesLayer` | `LayeredApplicationFunctionalTest` |
+| Chained layers | `NativeImageLayer.usesLayer` | `LayeredApplicationFunctionalTest` |
+| Cross-project publication | Gradle task output and file dependency wiring | Gradle-specific; Maven uses reactor/repository `nil` artifacts instead |
+
+Layer shared libraries remain external runtime dependencies. On Linux set `LD_LIBRARY_PATH`; on
+macOS set `DYLD_LIBRARY_PATH`; and on Windows add the layer directory to `PATH` before running a
+layered executable. `nativeRun` supplies this for its selected layers, but deployed executables
+need the same platform loader configuration. [§root/FS-native-builds.6](../../../docs/spec/functional/native-image-builds.md#6-layered-images).
+
 ## 3. Default binaries
 
 For Java application projects, the plugin must create a `main` binary whose `mainClass` convention

--- a/native-gradle-plugin/docs/functional/plugin-model.md
+++ b/native-gradle-plugin/docs/functional/plugin-model.md
@@ -71,6 +71,12 @@ container. Groovy builds may use `usesLayer('<name>')` or the qualified
 The singular `layer` property replaces its previous assignment, while repeated `useLayer(...)`
 calls add distinct layers. Duplicate layer selections fail before Native Image is invoked.
 The same duplicate and name validation applies when a named layer consumes another named layer.
+Every selection form (`layer =`, `useLayer(NativeImageLayer)`,
+`useLayer(Provider<NativeImageLayer>)`, and `usesLayer(String)`) contributes its logical layer
+name to the same selection set. A consuming binary may select each logical name only once. The
+plugin resolves provider-backed names at a cache-safe validation boundary after configuration and
+fails that validation before any selected producer task executes; it retains lazy name resolution
+and configuration-cache compatibility.
 
 `fromConfiguration(...)` and `all` include resolved external and project dependencies. Dependency
 selectors also accept Gradle providers, including version-catalog accessors.

--- a/native-gradle-plugin/docs/functional/plugin-model.md
+++ b/native-gradle-plugin/docs/functional/plugin-model.md
@@ -68,8 +68,9 @@ graalvmNative {
 Inside a binary closure, the deprecated binary-scoped `layers` property shadows the extension
 container. Groovy builds may use `usesLayer('<name>')` or the qualified
 `graalvmNative.layers.<name>` path.
-The singular `layer` property replaces its previous assignment, while repeated `useLayer(...)`
-calls add distinct layers. Duplicate layer selections fail before Native Image is invoked.
+The singular `layer` property replaces its previous assignment, including that layer's compatibility
+classpath contribution, while repeated `useLayer(...)` calls add distinct layers. Duplicate layer
+selections fail before Native Image is invoked.
 The same duplicate and name validation applies when a named layer consumes another named layer.
 Every selection form (`layer =`, `useLayer(NativeImageLayer)`,
 `useLayer(Provider<NativeImageLayer>)`, and `usesLayer(String)`) contributes its logical layer

--- a/native-gradle-plugin/docs/functional/plugin-model.md
+++ b/native-gradle-plugin/docs/functional/plugin-model.md
@@ -36,10 +36,8 @@ directories, or resource settings separately on each task.
 
 Named Native Image layers are first-class entries in a `layers` container beside `binaries`.
 Each layer owns its contents and deterministic `.nil` output. Binaries consume one or more layer
-objects through typed, lazy references. Layers may consume earlier layers through the same API,
-allowing a build to express a multi-level Native Image layer stack. `usesLayer('<name>')` is the
-order-independent Groovy DSL form and resolves the named layer lazily, so consumers may be
-declared before their producers:
+objects through typed, lazy references. `usesLayer('<name>')` is the order-independent Groovy DSL
+form and resolves the named layer lazily, so consumers may be declared before their producers:
 
 ```groovy
 graalvmNative {
@@ -48,12 +46,6 @@ graalvmNative {
             contents {
                 modules.add('java.base')
                 fromConfiguration(configurations.runtimeClasspath)
-            }
-        }
-        applicationFramework {
-            usesLayer('base')
-            contents {
-                packages('com.example.framework')
             }
         }
     }
@@ -71,7 +63,6 @@ container. Groovy builds may use `usesLayer('<name>')` or the qualified
 The singular `layer` property replaces its previous assignment, including that layer's compatibility
 classpath contribution, while repeated `useLayer(...)` calls add distinct layers. Duplicate layer
 selections fail before Native Image is invoked.
-The same duplicate and name validation applies when a named layer consumes another named layer.
 Every selection form (`layer =`, `useLayer(NativeImageLayer)`,
 `useLayer(Provider<NativeImageLayer>)`, and `usesLayer(String)`) contributes its logical layer
 name to the same selection set. A consuming binary may select each logical name only once. The
@@ -96,7 +87,6 @@ original naming and external-module-only semantics. Only legacy layer declaratio
 | Main executable | `binaries.main.usesLayer` | `LayeredApplicationFunctionalTest` |
 | Native test | `binaries.test.usesLayer` | `LayeredApplicationFunctionalTest` |
 | Shared library | `binaries.main.sharedLibrary` with `usesLayer` | `LayeredApplicationFunctionalTest` |
-| Chained layers | `NativeImageLayer.usesLayer` | `LayeredApplicationFunctionalTest` |
 | Application distribution | Main layered binary is added to `installDist`, `distZip`, and `distTar` with staged runtime files and a native launcher | Installed and archived distributions run without producer build directories |
 | Cross-project publication | Not first-class; manual `getLayerFiles()` or file wiring only | No consumable publication variant is promised |
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -225,6 +225,40 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    def "builds and consumes a layer from an individual dependency selector"() {
+        def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
+
+        given:
+        withSample("layered-java-application")
+        buildFile << '''
+            repositories {
+                mavenCentral()
+            }
+            graalvmNative {
+                metadataRepository.enabled = false
+                layers.dependencies.contents.dependencies("org.apache.commons:commons-lang3:3.17.0")
+                layers.dependencies.verbose = true
+            }
+        '''.stripIndent()
+
+        when:
+        run 'nativeRun', '-Pmessage="individual dependency selector"'
+
+        then:
+        tasks {
+            succeeded ':nativeDependenciesLayer', ':nativeCompile', ':nativeRun'
+        }
+        outputContains "-H:LayerCreate=dependencies.nil,module=java.base,path="
+        outputContains "- '-H:LayerUse' (origin(s): command line)"
+        file("build/native/layers/dependencies/dependencies.nil").isFile()
+        nativeApp.isFile()
+        outputContains "individual dependency selector"
+    }
+
+    @Requires(
+            { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
+    )
     @IgnoreIf({ os.windows || os.macOs })
     def "builds a layer with a package selector"() {
         given:

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -120,7 +120,7 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "can build a native image using layers"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
 
@@ -325,7 +325,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "builds and runs a layer from explicit paths"() {
         given:
         withSample("layered-java-application")
@@ -359,7 +359,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "native test binaries can consume named layers"() {
         given:
         withSample("layered-java-application")
@@ -388,7 +388,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "shared library binaries can consume named layers"() {
         given:
         withSample("layered-java-application")
@@ -413,7 +413,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "custom shared library consumes a layer without a main class"() {
         given:
         withSample("layered-java-application")
@@ -444,7 +444,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "application distributions carry and launch layered native images"() {
         given:
         withSample("layered-java-application")

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -83,6 +83,30 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
         errorOutputContains "Layer 'empty' has no contents"
     }
 
+    def "rejects duplicate provider layer selections before the producer runs"() {
+        given:
+        withSample("layered-java-application")
+        buildFile << '''
+            graalvmNative {
+                binaries.main {
+                    useLayer(graalvmNative.layers.getByName('dependencies'))
+                    useLayer(providers.provider { graalvmNative.layers.getByName('dependencies') })
+                }
+            }
+        '''.stripIndent()
+
+        when:
+        fails 'nativeCompile', '--configuration-cache'
+
+        then:
+        errorOutputContains "Native Image binary 'main' selects a layer more than once"
+        errorOutputContains "dependencies"
+        tasks {
+            failed ':validateNativeCompileLayerSelection'
+            doesNotContain ':nativeDependenciesLayer'
+        }
+    }
+
     // Layers are disabled on JDK 25.0.x Darwin and Windows CI platforms. §E2E-functional-tests.3.6.
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -83,7 +83,7 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
         errorOutputContains "Layer 'empty' has no contents"
     }
 
-    // Layer execution remains unavailable on Windows and macOS CI platforms. §E2E-functional-tests.3.6.
+    // Layers are disabled on JDK 25.0.x Darwin and Windows CI platforms. §E2E-functional-tests.3.6.
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -254,6 +254,66 @@ public class Application {
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
     @IgnoreIf({ os.windows || os.macOs })
+    def "builds and runs an all selector layer"() {
+        def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
+
+        given:
+        withSample("layered-java-application")
+        buildFile.text = buildFile.text.replace('''                modules("java.base")
+                fromConfiguration(configurations.runtimeClasspath)
+''', '''                all = true
+''')
+        buildFile << '''
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.layers.dependencies.verbose = true
+        '''.stripIndent()
+
+        when:
+        run 'nativeRun', '-Pmessage="all selector"'
+
+        then:
+        tasks {
+            succeeded ':nativeDependenciesLayer', ':nativeCompile', ':nativeRun'
+        }
+        outputContains "-H:LayerCreate=dependencies.nil"
+        outputContains "- '-H:LayerUse' (origin(s): command line)"
+        file("build/native/layers/dependencies/dependencies.nil").isFile()
+        nativeApp.isFile()
+        outputContains "all selector"
+    }
+
+    @Requires(
+            { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
+    )
+    @IgnoreIf({ os.windows || os.macOs })
+    def "builds and runs a layer from explicit paths"() {
+        given:
+        withSample("layered-java-application")
+        buildFile.text = buildFile.text.replace('''                fromConfiguration(configurations.runtimeClasspath)
+''', '''                from(configurations.runtimeClasspath)
+''')
+        buildFile << '''
+            graalvmNative.metadataRepository.enabled = false
+            graalvmNative.layers.dependencies.verbose = true
+        '''.stripIndent()
+
+        when:
+        run 'nativeRun', '-Pmessage="path selector"'
+
+        then:
+        tasks {
+            succeeded ':nativeDependenciesLayer', ':nativeCompile', ':nativeRun'
+        }
+        outputContains "-H:LayerCreate=dependencies.nil,module=java.base,path="
+        outputContains "- '-H:LayerUse' (origin(s): command line)"
+        file("build/native/layers/dependencies/dependencies.nil").isFile()
+        outputContains "path selector"
+    }
+
+    @Requires(
+            { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
+    )
+    @IgnoreIf({ os.windows || os.macOs })
     def "native test binaries can consume named layers"() {
         given:
         withSample("layered-java-application")
@@ -268,14 +328,15 @@ public class Application {
         '''.stripIndent()
 
         when:
-        run 'nativeTestCompile'
+        run 'nativeTest'
 
         then:
         tasks {
-            succeeded ':nativeDependenciesLayer', ':nativeTestCompile'
+            succeeded ':nativeDependenciesLayer', ':nativeTestCompile', ':nativeTest'
         }
         outputContains "- '-H:LayerUse' (origin(s): command line)"
         getExecutableFile("build/native/nativeTestCompile/layered-java-application-tests").exists()
+        outputContains "[         1 tests successful      ]"
     }
 
     @Requires(
@@ -301,6 +362,44 @@ public class Application {
         }
         outputContains "- '-H:LayerUse' (origin(s): command line)"
         file("build/native/nativeCompile/layered-java-application${IS_WINDOWS ? '.dll' : IS_MAC ? '.dylib' : '.so'}").exists()
+    }
+
+    @Requires(
+            { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
+    )
+    @IgnoreIf({ os.windows || os.macOs })
+    def "builds and runs a three-level layer stack"() {
+        given:
+        withSample("layered-java-application")
+        buildFile << '''
+            graalvmNative {
+                metadataRepository.enabled = false
+                layers {
+                    framework {
+                        usesLayer('dependencies')
+                        contents.modules('java.sql')
+                        verbose = true
+                    }
+                }
+                binaries.main {
+                    usesLayer('dependencies')
+                    usesLayer('framework')
+                }
+                layers.dependencies.verbose = true
+            }
+        '''.stripIndent()
+
+        when:
+        run 'nativeRun', '-Pmessage="three levels"'
+
+        then:
+        tasks {
+            succeeded ':nativeDependenciesLayer', ':nativeFrameworkLayer', ':nativeCompile', ':nativeRun'
+        }
+        outputContains "-H:LayerCreate=framework.nil,module=java.sql"
+        output.count("- '-H:LayerUse' (origin(s): command line)") >= 2
+        file("build/native/layers/framework/framework.nil").isFile()
+        outputContains "three levels"
     }
 
     @Ignore("Disable test temporarily because of a problem on GraalVM side")

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -489,6 +489,7 @@ public class Application {
         execution.in.text.contains('relocated distribution')
     }
 
+    // Retain this probe for a future Native Image release that supports chained shared layers.
     @Ignore("GraalVM Native Image currently supports one shared base layer and a final application executable, not chained shared layers.")
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -54,11 +54,25 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.nio.charset.StandardCharsets
 
-@Requires(
-        { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
-)
+// Exercises the top-level layer model, named task wiring, and configuration-cache isolation.
+// §FS-plugin-model.2 §FS-native-tasks.1 §FS-native-invocation.3.
 class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
+    def "configures a named layer outside the binary container"() {
+        given:
+        withSample("layered-java-application")
+
+        when:
+        run 'tasks', '--all'
+
+        then:
+        outputContains "nativeDependenciesLayer"
+        outputContains "Builds the dependencies Native Image layer."
+    }
+
     // Layers are disabled on JDK 25.0.x Darwin and Windows CI platforms. §E2E-functional-tests.3.6.
+    @Requires(
+            { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
+    )
     @IgnoreIf({ os.windows || os.macOs })
     def "can build a native image using layers"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
@@ -72,19 +86,19 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
         """.stripIndent()
 
         when:
-        runAndReloadConfigurationCache 'nativeLibdependenciesCompile'
+        runAndReloadConfigurationCache 'nativeDependenciesLayer'
 
         then:
         if (hasConfigurationCache) {
             configurationCacheStoreTasks {
-                succeeded ':nativeLibdependenciesCompile'
+                succeeded ':nativeDependenciesLayer'
             }
             tasks {
-                upToDate ':nativeLibdependenciesCompile'
+                upToDate ':nativeDependenciesLayer'
             }
         } else {
             tasks {
-                succeeded ':nativeLibdependenciesCompile'
+                succeeded ':nativeDependenciesLayer'
             }
         }
         if (hasConfigurationCache) {
@@ -99,15 +113,15 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
         then:
         if (hasConfigurationCache) {
             configurationCacheStoreTasks {
-                upToDate ':nativeLibdependenciesCompile'
+                upToDate ':nativeDependenciesLayer'
                 succeeded ':nativeCompile'
             }
             tasks {
-                upToDate ':nativeLibdependenciesCompile', ':nativeCompile'
+                upToDate ':nativeDependenciesLayer', ':nativeCompile'
             }
         } else {
             tasks {
-                upToDate ':nativeLibdependenciesCompile'
+                upToDate ':nativeDependenciesLayer'
                 succeeded ':nativeCompile'
             }
         }
@@ -143,17 +157,17 @@ public class Application {
         if (hasConfigurationCache) {
             configurationCacheStoreTasks {
                 // Base layer is not rebuilt
-                upToDate ':nativeLibdependenciesCompile'
+                upToDate ':nativeDependenciesLayer'
                 // Application layer is recompiled
                 succeeded ':nativeCompile'
             }
             tasks {
-                upToDate ':nativeLibdependenciesCompile', ':nativeCompile'
+                upToDate ':nativeDependenciesLayer', ':nativeCompile'
             }
         } else {
             tasks {
                 // Base layer is not rebuilt
-                upToDate ':nativeLibdependenciesCompile'
+                upToDate ':nativeDependenciesLayer'
                 // Application layer is recompiled
                 succeeded ':nativeCompile'
             }
@@ -167,6 +181,9 @@ public class Application {
     }
 
     @Ignore("Disable test temporarily because of a problem on GraalVM side")
+    @Requires(
+            { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
+    )
     def "can build a layered Micronaut application"() {
         given:
         withSample("layered-mn-application")
@@ -176,7 +193,7 @@ public class Application {
 
         then:
         tasks {
-            succeeded ':nativeLibdependenciesCompile', ':nativeCompile'
+            succeeded ':nativeDependenciesLayer', ':nativeCompile'
         }
 
         when:
@@ -185,7 +202,7 @@ public class Application {
             .inheritIO()
             .command("build/native/nativeCompile/layered-mn-app${IS_WINDOWS?".exe":""}")
         def env = builder.environment()
-        env["LD_LIBRARY_PATH"] = testDirectory.resolve("build/native/nativeLibdependenciesCompile").toString()
+        env["LD_LIBRARY_PATH"] = testDirectory.resolve("build/native/layers/dependencies").toString()
         def process = builder.start()
         def client = HttpClient.newHttpClient()
         def request = HttpRequest.newBuilder()

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -374,6 +374,7 @@ public class Application {
         file("build/native/nativeCompile/layered-java-application${IS_WINDOWS ? '.dll' : IS_MAC ? '.dylib' : '.so'}").exists()
     }
 
+    @Ignore("GraalVM Native Image currently supports one shared base layer and a final application executable, not chained shared layers.")
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -53,16 +53,13 @@ import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.zip.ZipFile
 
 // Exercises the top-level layer model, named task wiring, and configuration-cache isolation.
 // §FS-plugin-model.2 §FS-native-tasks.1 §FS-native-invocation.3.
 class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
-    // GraalVM 25.0.x can fail during LayerUse processing.
-    // §E2E-functional-tests.3.6.
-    private static boolean hasLayerConsumptionBug() {
-        !NativeImageUtils.isGraalVMVersionAtLeast(GraalVMSupport.getGraalVMHomeVersionString(), 25, 1)
-    }
-
     def "configures a named layer outside the binary container"() {
         given:
         withSample("layered-java-application")
@@ -225,7 +222,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "builds and consumes a layer from an individual dependency selector"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
 
@@ -292,7 +289,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "builds and runs an all selector layer"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
 
@@ -408,11 +405,90 @@ public class Application {
         file("build/native/nativeCompile/layered-java-application${IS_WINDOWS ? '.dll' : IS_MAC ? '.dylib' : '.so'}").exists()
     }
 
+    @Requires(
+            { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
+    )
+    @IgnoreIf({ os.windows || os.macOs })
+    def "custom shared library consumes a layer without a main class"() {
+        given:
+        withSample("layered-java-application")
+        buildFile << '''
+            graalvmNative {
+                metadataRepository.enabled = false
+                binaries {
+                    customLibrary {
+                        imageName = 'custom-layered-library'
+                        sharedLibrary = true
+                        usesLayer('dependencies')
+                    }
+                }
+            }
+        '''.stripIndent()
+
+        when:
+        run 'nativeCustomLibraryCompile'
+
+        then:
+        tasks {
+            succeeded ':nativeDependenciesLayer', ':nativeCustomLibraryCompile'
+        }
+        outputContains "- '-H:LayerUse' (origin(s): command line)"
+        file("build/native/nativeCustomLibraryCompile/custom-layered-library.so").isFile()
+    }
+
+    @Requires(
+            { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
+    )
+    @IgnoreIf({ os.windows || os.macOs })
+    def "application distributions carry and launch layered native images"() {
+        given:
+        withSample("layered-java-application")
+        buildFile << '''
+            graalvmNative.metadataRepository.enabled = false
+        '''.stripIndent()
+
+        when:
+        run 'installDist', 'distZip', 'distTar'
+
+        then:
+        tasks {
+            succeeded ':nativeDependenciesLayer', ':nativeCompile', ':nativeLayerRuntimeFiles',
+                ':nativeDistributionLauncher', ':installDist', ':distZip', ':distTar'
+        }
+        def installDirectory = file("build/install/layered-java-application")
+        def runtimeDirectory = new File(installDirectory, "lib/native-layers/dependencies")
+        runtimeDirectory.listFiles().any { it.name.endsWith('.so') }
+        new File(installDirectory, "lib/native/layered-java-application").isFile()
+        new File(installDirectory, "bin/layered-java-application-native").isFile()
+
+        def zipFile = file("build/distributions/layered-java-application.zip")
+        def zipEntries
+        new ZipFile(zipFile).withCloseable { zip ->
+            zipEntries = zip.entries().collect { it.name }
+        }
+        zipEntries.any { it.contains('/lib/native-layers/dependencies/') && it.endsWith('.so') }
+        zipEntries.contains('layered-java-application/bin/layered-java-application-native')
+        def tarListing = ['tar', '-tf', file("build/distributions/layered-java-application.tar").absolutePath].execute()
+        assert tarListing.waitFor() == 0
+        assert tarListing.in.text.contains('layered-java-application/lib/native-layers/dependencies/')
+
+        when: "the installed distribution is relocated and producer outputs are unavailable"
+        def relocated = file("relocated-distribution")
+        copyDirectory(installDirectory.toPath(), relocated.toPath())
+        assert file("build/native/layers").deleteDir()
+        def execution = [new File(relocated, "bin/layered-java-application-native").absolutePath,
+                         'relocated distribution'].execute(null, relocated)
+
+        then:
+        execution.waitFor() == 0
+        execution.in.text.contains('relocated distribution')
+    }
+
     @Ignore("GraalVM Native Image currently supports one shared base layer and a final application executable, not chained shared layers.")
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "builds and runs a three-level layer stack"() {
         given:
         withSample("layered-java-application")
@@ -488,5 +564,19 @@ public class Application {
 
         cleanup:
         process.destroy()
+    }
+
+    private static void copyDirectory(java.nio.file.Path source, java.nio.file.Path destination) {
+        Files.walk(source).withCloseable { paths ->
+            paths.forEach { path ->
+                def target = destination.resolve(source.relativize(path))
+                if (Files.isDirectory(path)) {
+                    Files.createDirectories(target)
+                } else {
+                    Files.copy(path, target, StandardCopyOption.REPLACE_EXISTING,
+                        StandardCopyOption.COPY_ATTRIBUTES)
+                }
+            }
+        }
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -186,16 +186,10 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
         file("src/main/java/org/graalvm/demo/Application.java").text = """
 package org.graalvm.demo;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class Application {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);
-
     public static void main(String[] args) {
-        LOGGER.info("App started with args {}", String.join(", ", args));
+        System.out.println("Updated application: " + String.join(", ", args));
     }
-
 }
 
 """
@@ -235,8 +229,12 @@ public class Application {
     def "builds a layer with a package selector"() {
         given:
         withSample("layered-java-application")
+        buildFile << '''
+            dependencies {
+                implementation("org.slf4j:slf4j-api:2.0.17")
+            }
+        '''.stripIndent()
         buildFile.text = buildFile.text.replace('''                modules("java.base")
-                fromConfiguration(configurations.runtimeClasspath)
 ''', '''                packages("org.slf4j")
 ''')
         buildFile << '''
@@ -267,7 +265,6 @@ public class Application {
         given:
         withSample("layered-java-application")
         buildFile.text = buildFile.text.replace('''                modules("java.base")
-                fromConfiguration(configurations.runtimeClasspath)
 ''', '''                all = true
 ''')
         buildFile << '''
@@ -296,8 +293,14 @@ public class Application {
     def "builds and runs a layer from explicit paths"() {
         given:
         withSample("layered-java-application")
-        buildFile.text = buildFile.text.replace('''                fromConfiguration(configurations.runtimeClasspath)
-''', '''                from(configurations.runtimeClasspath)
+        buildFile << '''
+            dependencies {
+                implementation("org.apache.commons:commons-lang3:3.17.0")
+            }
+        '''.stripIndent()
+        buildFile.text = buildFile.text.replace('''                modules("java.base")
+''', '''                modules("java.base")
+                from(configurations.runtimeClasspath)
 ''')
         buildFile << '''
             graalvmNative.metadataRepository.enabled = false
@@ -327,7 +330,7 @@ public class Application {
         buildFile << '''
             graalvmNative {
                 metadataRepository.enabled = false
-                layers.dependencies.contents.modules('java.sql')
+                layers.dependencies.contents.modules('java.sql', 'java.management')
                 binaries.test {
                     usesLayer('dependencies')
                 }
@@ -379,12 +382,15 @@ public class Application {
         given:
         withSample("layered-java-application")
         buildFile << '''
+            dependencies {
+                implementation("org.apache.commons:commons-lang3:3.17.0")
+            }
             graalvmNative {
                 metadataRepository.enabled = false
                 layers {
                     framework {
                         usesLayer('dependencies')
-                        contents.modules('java.sql')
+                        contents.fromConfiguration(configurations.runtimeClasspath)
                         verbose = true
                     }
                 }
@@ -402,7 +408,7 @@ public class Application {
         tasks {
             succeeded ':nativeDependenciesLayer', ':nativeFrameworkLayer', ':nativeCompile', ':nativeRun'
         }
-        outputContains "-H:LayerCreate=framework.nil,module=java.sql"
+        outputContains "-H:LayerCreate=framework.nil,path="
         output.count("- '-H:LayerUse' (origin(s): command line)") >= 2
         file("build/native/layers/framework/framework.nil").isFile()
         outputContains "three levels"

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -92,14 +92,15 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
     def "rejects duplicate provider layer selections before the producer runs"() {
         given:
         withSample("layered-java-application")
-        buildFile << '''
-            graalvmNative {
-                binaries.main {
-                    useLayer(graalvmNative.layers.getByName('dependencies'))
-                    useLayer(providers.provider { graalvmNative.layers.getByName('dependencies') })
-                }
-            }
-        '''.stripIndent()
+        // Replace the sample's happy-path consumer so this test isolates direct/provider duplicates. §FS-plugin-model.2.
+        buildFile.text = buildFile.text.replace('''        main {
+            usesLayer('dependencies')
+        }
+''', '''        main {
+            useLayer(graalvmNative.layers.getByName('dependencies'))
+            useLayer(providers.provider { graalvmNative.layers.getByName('dependencies') })
+        }
+''')
 
         when:
         fails 'nativeCompile', '--configuration-cache'
@@ -388,7 +389,6 @@ public class Application {
                     }
                 }
                 binaries.main {
-                    usesLayer('dependencies')
                     usesLayer('framework')
                 }
                 layers.dependencies.verbose = true

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -43,6 +43,7 @@ package org.graalvm.buildtools.gradle
 
 import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 import org.graalvm.buildtools.gradle.fixtures.GraalVMSupport
+import org.graalvm.buildtools.utils.NativeImageLayerArguments
 import org.graalvm.buildtools.utils.NativeImageUtils
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
@@ -88,7 +89,8 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
     @IgnoreIf({
-        os.windows || os.macOs || GraalVMSupport.getGraalVMHomeVersionString().contains("native-image 25.0.3")
+        os.windows || os.macOs || NativeImageLayerArguments.isLayerConsumptionUnsupported(
+                GraalVMSupport.getGraalVMHomeVersionString())
     })
     def "can build a native image using layers"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -198,6 +198,94 @@ public class Application {
         }
     }
 
+    @Requires(
+            { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
+    )
+    @IgnoreIf({ os.windows || os.macOs })
+    def "builds a layer with a package selector"() {
+        given:
+        withSample("layered-java-application")
+        buildFile.text = buildFile.text.replace('''                modules("java.base")
+                fromConfiguration(configurations.runtimeClasspath)
+''', '''                packages("org.slf4j")
+''')
+        buildFile << '''
+            graalvmNative {
+                metadataRepository.enabled = false
+                layers.dependencies.verbose = true
+            }
+        '''.stripIndent()
+
+        when:
+        run 'nativeDependenciesLayer'
+
+        then:
+        tasks {
+            succeeded ':nativeDependenciesLayer'
+        }
+        outputContains "-H:LayerCreate=dependencies.nil,package=org.slf4j"
+        file("build/native/layers/dependencies/dependencies.nil").isFile()
+    }
+
+    @Requires(
+            { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
+    )
+    @IgnoreIf({
+        os.windows || os.macOs || NativeImageLayerArguments.isLayerConsumptionUnsupported(
+                GraalVMSupport.getGraalVMHomeVersionString())
+    })
+    def "native test binaries can consume named layers"() {
+        given:
+        withSample("layered-java-application")
+        buildFile << '''
+            graalvmNative {
+                metadataRepository.enabled = false
+                layers.dependencies.contents.modules('java.sql')
+                binaries.test {
+                    usesLayer('dependencies')
+                }
+            }
+        '''.stripIndent()
+
+        when:
+        run 'nativeTestCompile'
+
+        then:
+        tasks {
+            succeeded ':nativeDependenciesLayer', ':nativeTestCompile'
+        }
+        outputContains "- '-H:LayerUse' (origin(s): command line)"
+        getExecutableFile("build/native/nativeTestCompile/layered-java-application-tests").exists()
+    }
+
+    @Requires(
+            { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
+    )
+    @IgnoreIf({
+        os.windows || os.macOs || NativeImageLayerArguments.isLayerConsumptionUnsupported(
+                GraalVMSupport.getGraalVMHomeVersionString())
+    })
+    def "shared library binaries can consume named layers"() {
+        given:
+        withSample("layered-java-application")
+        buildFile << '''
+            graalvmNative {
+                metadataRepository.enabled = false
+                binaries.main.sharedLibrary = true
+            }
+        '''.stripIndent()
+
+        when:
+        run 'nativeCompile'
+
+        then:
+        tasks {
+            succeeded ':nativeDependenciesLayer', ':nativeCompile'
+        }
+        outputContains "- '-H:LayerUse' (origin(s): command line)"
+        file("build/native/nativeCompile/layered-java-application${IS_WINDOWS ? '.dll' : IS_MAC ? '.dylib' : '.so'}").exists()
+    }
+
     @Ignore("Disable test temporarily because of a problem on GraalVM side")
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -413,7 +413,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "custom shared library consumes a layer without a main class"() {
         given:
         withSample("layered-java-application")
@@ -444,7 +444,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "application distributions carry and launch layered native images"() {
         given:
         withSample("layered-java-application")

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -233,13 +233,10 @@ public class Application {
     def "native test binaries can consume named layers"() {
         given:
         withSample("layered-java-application")
-        buildFile.text = buildFile.text.replace('''                modules("java.base")
-                modules("java.sql")
-                fromConfiguration(configurations.runtimeClasspath)
-''')
         buildFile << '''
             graalvmNative {
                 metadataRepository.enabled = false
+                layers.dependencies.contents.modules('java.sql')
                 binaries.test {
                     usesLayer('dependencies')
                 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -60,6 +60,11 @@ import java.util.zip.ZipFile
 // Exercises the top-level layer model, named task wiring, and configuration-cache isolation.
 // §FS-plugin-model.2 §FS-native-tasks.1 §FS-native-invocation.3.
 class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
+    // GraalVM 25.0.x can fail after LayerUse loads a valid layer. §E2E-functional-tests.3.6.
+    private static boolean hasLayerConsumptionBug() {
+        !NativeImageUtils.isGraalVMVersionAtLeast(GraalVMSupport.getGraalVMHomeVersionString(), 25, 1)
+    }
+
     def "configures a named layer outside the binary container"() {
         given:
         withSample("layered-java-application")
@@ -115,7 +120,7 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "can build a native image using layers"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
 
@@ -222,7 +227,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "builds and consumes a layer from an individual dependency selector"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
 
@@ -289,7 +294,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "builds and runs an all selector layer"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
 
@@ -320,7 +325,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "builds and runs a layer from explicit paths"() {
         given:
         withSample("layered-java-application")
@@ -354,7 +359,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "native test binaries can consume named layers"() {
         given:
         withSample("layered-java-application")
@@ -383,7 +388,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "shared library binaries can consume named layers"() {
         given:
         withSample("layered-java-application")
@@ -408,7 +413,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "custom shared library consumes a layer without a main class"() {
         given:
         withSample("layered-java-application")
@@ -439,7 +444,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "application distributions carry and launch layered native images"() {
         given:
         withSample("layered-java-application")

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -57,9 +57,9 @@ import java.nio.charset.StandardCharsets
 // Exercises the top-level layer model, named task wiring, and configuration-cache isolation.
 // §FS-plugin-model.2 §FS-native-tasks.1 §FS-native-invocation.3.
 class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
-    // GraalVM 25.0.x can seal its image-heap scanner during all-selector LayerUse processing.
+    // GraalVM 25.0.x can fail during LayerUse processing.
     // §E2E-functional-tests.3.6.
-    private static boolean hasAllSelectorLayerConsumptionBug() {
+    private static boolean hasLayerConsumptionBug() {
         !NativeImageUtils.isGraalVMVersionAtLeast(GraalVMSupport.getGraalVMHomeVersionString(), 25, 1)
     }
 
@@ -260,7 +260,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs || hasAllSelectorLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "builds and runs an all selector layer"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
 
@@ -374,7 +374,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "builds and runs a three-level layer stack"() {
         given:
         withSample("layered-java-application")

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -57,6 +57,12 @@ import java.nio.charset.StandardCharsets
 // Exercises the top-level layer model, named task wiring, and configuration-cache isolation.
 // §FS-plugin-model.2 §FS-native-tasks.1 §FS-native-invocation.3.
 class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
+    // GraalVM 25.0.x can seal its image-heap scanner during all-selector LayerUse processing.
+    // §E2E-functional-tests.3.6.
+    private static boolean hasAllSelectorLayerConsumptionBug() {
+        !NativeImageUtils.isGraalVMVersionAtLeast(GraalVMSupport.getGraalVMHomeVersionString(), 25, 1)
+    }
+
     def "configures a named layer outside the binary container"() {
         given:
         withSample("layered-java-application")
@@ -107,7 +113,7 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
         }
     }
 
-    // Layers are disabled on JDK 25.0.x Darwin and Windows CI platforms. §E2E-functional-tests.3.6.
+    // Layers are disabled on Darwin and Windows CI platforms. §E2E-functional-tests.3.6.
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
@@ -253,7 +259,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasAllSelectorLayerConsumptionBug() })
     def "builds and runs an all selector layer"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -69,11 +69,27 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
         outputContains "Builds the dependencies Native Image layer."
     }
 
+    def "rejects an empty named layer before invoking Native Image"() {
+        given:
+        withSample("layered-java-application")
+        buildFile << """
+            graalvmNative.layers.create("empty")
+        """
+
+        when:
+        fails 'nativeEmptyLayer'
+
+        then:
+        errorOutputContains "Layer 'empty' has no contents"
+    }
+
     // Layers are disabled on JDK 25.0.x Darwin and Windows CI platforms. §E2E-functional-tests.3.6.
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({
+        os.windows || os.macOs || GraalVMSupport.getGraalVMHomeVersionString().contains("native-image 25.0.3")
+    })
     def "can build a native image using layers"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -43,7 +43,6 @@ package org.graalvm.buildtools.gradle
 
 import org.graalvm.buildtools.gradle.fixtures.AbstractFunctionalTest
 import org.graalvm.buildtools.gradle.fixtures.GraalVMSupport
-import org.graalvm.buildtools.utils.NativeImageLayerArguments
 import org.graalvm.buildtools.utils.NativeImageUtils
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
@@ -84,14 +83,11 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
         errorOutputContains "Layer 'empty' has no contents"
     }
 
-    // Layers are disabled on JDK 25.0.x Darwin and Windows CI platforms. §E2E-functional-tests.3.6.
+    // Layer execution remains unavailable on Windows and macOS CI platforms. §E2E-functional-tests.3.6.
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({
-        os.windows || os.macOs || NativeImageLayerArguments.isLayerConsumptionUnsupported(
-                GraalVMSupport.getGraalVMHomeVersionString())
-    })
+    @IgnoreIf({ os.windows || os.macOs })
     def "can build a native image using layers"() {
         def nativeApp = getExecutableFile("build/native/nativeCompile/layered-java-application")
 
@@ -126,7 +122,7 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
         }
 
         when:
-        runAndReloadConfigurationCache 'nativeRun', '-Pmessage="Hello, layered images!"'
+        runAndReloadConfigurationCache 'nativeRun', '-Pmessage="Hello, layered application!"'
 
         then:
         if (hasConfigurationCache) {
@@ -144,6 +140,9 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
             }
         }
         nativeApp.exists()
+
+        and:
+        outputContains "Hello, layered application!"
 
         and:
         if (hasConfigurationCache) {
@@ -169,7 +168,7 @@ public class Application {
 }
 
 """
-        runAndReloadConfigurationCache 'nativeRun', '-Pmessage="Hello, layered images!"'
+        runAndReloadConfigurationCache 'nativeRun', '-Pmessage="Hello, layered application!"'
 
         then:
         if (hasConfigurationCache) {
@@ -230,17 +229,17 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({
-        os.windows || os.macOs || NativeImageLayerArguments.isLayerConsumptionUnsupported(
-                GraalVMSupport.getGraalVMHomeVersionString())
-    })
+    @IgnoreIf({ os.windows || os.macOs })
     def "native test binaries can consume named layers"() {
         given:
         withSample("layered-java-application")
+        buildFile.text = buildFile.text.replace('''                modules("java.base")
+                modules("java.sql")
+                fromConfiguration(configurations.runtimeClasspath)
+''')
         buildFile << '''
             graalvmNative {
                 metadataRepository.enabled = false
-                layers.dependencies.contents.modules('java.sql')
                 binaries.test {
                     usesLayer('dependencies')
                 }
@@ -261,10 +260,7 @@ public class Application {
     @Requires(
             { NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 }
     )
-    @IgnoreIf({
-        os.windows || os.macOs || NativeImageLayerArguments.isLayerConsumptionUnsupported(
-                GraalVMSupport.getGraalVMHomeVersionString())
-    })
+    @IgnoreIf({ os.windows || os.macOs })
     def "shared library binaries can consume named layers"() {
         given:
         withSample("layered-java-application")

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -47,6 +47,7 @@ import org.graalvm.buildtools.agent.AgentMode;
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
 import org.graalvm.buildtools.gradle.dsl.GraalVMReachabilityMetadataRepositoryExtension;
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
+import org.graalvm.buildtools.gradle.dsl.NativeImageLayer;
 import org.graalvm.buildtools.gradle.dsl.agent.AgentOptions;
 import org.graalvm.buildtools.gradle.internal.AgentCommandLineProvider;
 import org.graalvm.buildtools.gradle.internal.BaseNativeImageOptions;
@@ -66,7 +67,6 @@ import org.graalvm.buildtools.gradle.tasks.GenerateResourcesConfigFile;
 import org.graalvm.buildtools.gradle.tasks.ListLibrariesMissingMetadata;
 import org.graalvm.buildtools.gradle.tasks.MetadataCopyTask;
 import org.graalvm.buildtools.gradle.tasks.NativeRunTask;
-import org.graalvm.buildtools.gradle.tasks.UseLayerOptions;
 import org.graalvm.buildtools.gradle.tasks.actions.CleanupAgentFilesAction;
 import org.graalvm.buildtools.gradle.tasks.actions.MergeAgentFilesAction;
 import org.graalvm.buildtools.gradle.tasks.scanner.JarAnalyzerTransform;
@@ -399,6 +399,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                                                 GraalVMExtension graalExtension,
                                                 TaskContainer tasks,
                                                 SourceSetContainer sourceSets) {
+        configureLayerTasks(project, graalExtension, tasks, sourceSets);
         graalExtension.getBinaries().configureEach(options -> {
             configureCustomApplicationBinary(project, options);
             String binaryName = options.getName();
@@ -441,18 +442,11 @@ public class NativeImagePlugin implements Plugin<Project> {
                 task.setDescription("Runs the " + options.getName() + " native binary.");
                 task.getImage().convention(imageBuilder.flatMap(BuildNativeImageTask::getOutputFile));
                 task.getRuntimeArgs().convention(options.getRuntimeArgs());
-                var useLayers = options.getLayers()
-                    .stream()
-                    .filter(layer -> layer instanceof UseLayerOptions)
-                    .toList();
-                if (!useLayers.isEmpty()) {
+                if (!options.getLayerFiles().isEmpty()) {
                     var libsDirs = project.getObjects().fileCollection();
-                    libsDirs.from(useLayers
-                        .stream()
-                        .map(l -> l.getLayerName().flatMap(layerName -> tasks.named(compileTaskNameForBinary(layerName), BuildNativeImageTask.class))
-                            .map(t -> t.getOutputDirectory().getAsFile())
-                        )
-                        .toList());
+                    libsDirs.from(options.getLayerFiles().getElements().map(elements -> elements.stream()
+                        .map(location -> location.getAsFile().getParentFile())
+                        .toList()));
                     if (IS_WINDOWS) {
                         var pathVariable = providers.environmentVariable("PATH");
                         task.getEnvironment().put("PATH", pathVariable.map(path -> path + ";" + libsDirs.getAsPath()).orElse(providers.provider(libsDirs::getAsPath)));
@@ -508,6 +502,55 @@ public class NativeImagePlugin implements Plugin<Project> {
         });
     }
 
+    private void configureLayerTasks(Project project,
+                                     GraalVMExtension graalExtension,
+                                     TaskContainer tasks,
+                                     SourceSetContainer sourceSets) {
+        graalExtension.getLayers().configureEach(layer -> {
+            String taskName = deriveTaskName(layer.getName(), "native", "Layer");
+            NativeImageOptions layerOptions = project.getObjects().newInstance(
+                BaseNativeImageOptions.class,
+                "__layer_" + layer.getName(),
+                project.getObjects(),
+                project.getProviders(),
+                project.getExtensions().findByType(JavaToolchainService.class),
+                "lib" + layer.getName()
+            );
+            CreateLayerOptions create = project.getObjects().newInstance(CreateLayerOptions.class);
+            create.getLayerName().set(layer.getName());
+            create.getAll().convention(layer.getContents().getAll());
+            create.getModules().convention(layer.getContents().getModules());
+            create.getPackages().convention(layer.getContents().getPackages());
+            create.getJars().from(layer.getContents().getFiles());
+            layerOptions.getLayerCreate().set(create);
+            layerOptions.getBuildArgs().convention(layer.getBuildArgs());
+            layerOptions.getVerbose().convention(layer.getVerbose());
+            layer.getVerbose().convention(false);
+
+            Configuration runtimeClasspath = project.getConfigurations()
+                .getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            create.getClasspath().from(layer.getContents().getAll()
+                .flatMap(all -> Boolean.TRUE.equals(all)
+                    ? layerOptions.externalDependenciesOf(runtimeClasspath)
+                    : project.getProviders().provider(Collections::emptyList)));
+            create.getClasspath().from(layer.getContents().getPackages()
+                .flatMap(packages -> packages.isEmpty()
+                    ? project.getProviders().provider(Collections::emptyList)
+                    : project.getProviders().provider(() ->
+                        sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath())));
+
+            TaskProvider<BuildNativeImageTask> task = tasks.register(taskName, BuildNativeImageTask.class, builder -> {
+                builder.setDescription("Builds the " + layer.getName() + " Native Image layer.");
+                builder.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+                builder.getOptions().set(layerOptions);
+                builder.getUseArgFile().convention(graalExtension.getUseArgFile());
+                builder.getOutputDirectory().set(project.getLayout().getBuildDirectory()
+                    .dir("native/layers/" + layer.getName()));
+            });
+            layer.getOutputFile().convention(task.flatMap(BuildNativeImageTask::getCreatedLayerFile));
+        });
+    }
+
     private void configureCustomApplicationBinary(Project project, NativeImageOptions options) {
         ConfigurationContainer configurations = project.getConfigurations();
         String binaryName = options.getName();
@@ -522,7 +565,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     }
 
     private static boolean createsLayer(NativeImageOptions options) {
-        return options.getLayers().stream().anyMatch(CreateLayerOptions.class::isInstance);
+        return options.getLayerCreate().isPresent();
     }
 
     private static boolean emitsBuildReport(String buildArg) {
@@ -770,8 +813,12 @@ public class NativeImagePlugin implements Plugin<Project> {
                     project.getExtensions().findByType(JavaToolchainService.class),
                     project.getName())
             );
+        NamedDomainObjectContainer<NativeImageLayer> layers = project.getObjects()
+            .domainObjectContainer(NativeImageLayer.class, name ->
+                project.getObjects().newInstance(NativeImageLayer.class, name, project.getObjects(), project)
+            );
         GraalVMExtension graalvmNative = project.getExtensions().create(GraalVMExtension.class, "graalvmNative",
-            DefaultGraalVmExtension.class, nativeImages, this, project);
+            DefaultGraalVmExtension.class, nativeImages, layers, this, project);
         graalvmNative.getGeneratedResourcesDirectory().set(project.getLayout()
             .getBuildDirectory()
             .dir("native/generated/"));

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -72,6 +72,7 @@ import org.graalvm.buildtools.gradle.tasks.actions.MergeAgentFilesAction;
 import org.graalvm.buildtools.gradle.tasks.scanner.JarAnalyzerTransform;
 import org.graalvm.buildtools.utils.JUnitPlatformNativeDependenciesHelper;
 import org.graalvm.buildtools.utils.JUnitUtils;
+import org.graalvm.buildtools.utils.NativeImageLayerArguments;
 import org.graalvm.buildtools.utils.SharedConstants;
 import org.graalvm.reachability.DirectoryConfiguration;
 import org.graalvm.reachability.MissingMetadataCommandSupport;
@@ -519,6 +520,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                 project.getObjects(),
                 project.getProviders(),
                 project.getExtensions().findByType(JavaToolchainService.class),
+                graalExtension.getLayers(),
                 "lib" + layer.getName()
             );
             CreateLayerOptions create = project.getObjects().newInstance(CreateLayerOptions.class);
@@ -528,6 +530,8 @@ public class NativeImagePlugin implements Plugin<Project> {
             create.getPackages().convention(layer.getContents().getPackages());
             create.getJars().from(layer.getContents().getFiles());
             layerOptions.getLayerCreate().set(create);
+            layerOptions.getLayerNames().addAll(layer.getUseLayerNames());
+            layerOptions.getLayerFiles().from(layer.getUseLayerFiles());
             layerOptions.getBuildArgs().convention(layer.getBuildArgs());
             layerOptions.getVerbose().convention(layer.getVerbose());
             layer.getVerbose().convention(false);
@@ -551,7 +555,20 @@ public class NativeImagePlugin implements Plugin<Project> {
                 builder.getUseArgFile().convention(graalExtension.getUseArgFile());
                 builder.getOutputDirectory().set(project.getLayout().getBuildDirectory()
                     .dir("native/layers/" + layer.getName()));
+                GraalVMReachabilityMetadataRepositoryExtension repoExt = reachabilityExtensionOn(graalExtension);
+                Provider<Boolean> repoEnabled = repoExt.getEnabled().flatMap(serializableTransformerOf(enabled ->
+                    enabled
+                        ? repoExt.getUri().map(serializableTransformerOf(obj -> true))
+                            .orElse(project.getProviders().provider(() -> false))
+                        : project.getProviders().provider(() -> false)));
+                Provider<GraalVMReachabilityMetadataService> svc = graalVMReachabilityMetadataService(project, repoExt);
+                builder.getMetadataRepositoryEnabled().set(repoEnabled);
+                builder.getMetadataRepositoryRootPath().set(svc.map(serializableTransformerOf(service ->
+                    service.getRepositoryDirectory().map(path -> path.toAbsolutePath().toString()).orElse(null))));
             });
+            SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+            configureJvmReachabilityConfigurationDirectories(project, graalExtension, layerOptions, mainSourceSet);
+            configureJvmReachabilityExcludeConfigArgs(project, graalExtension, layerOptions, mainSourceSet);
             layer.getOutputFile().convention(task.flatMap(BuildNativeImageTask::getCreatedLayerFile));
         });
     }
@@ -809,6 +826,11 @@ public class NativeImagePlugin implements Plugin<Project> {
     }
 
     private GraalVMExtension registerGraalVMExtension(Project project) {
+        NamedDomainObjectContainer<NativeImageLayer> layers = project.getObjects()
+            .domainObjectContainer(NativeImageLayer.class, name -> {
+                NativeImageLayerArguments.validateLayerName(name);
+                return project.getObjects().newInstance(NativeImageLayer.class, name, project.getObjects(), project);
+            });
         NamedDomainObjectContainer<NativeImageOptions> nativeImages = project.getObjects()
             .domainObjectContainer(NativeImageOptions.class, name ->
                 project.getObjects().newInstance(BaseNativeImageOptions.class,
@@ -816,11 +838,8 @@ public class NativeImagePlugin implements Plugin<Project> {
                     project.getObjects(),
                     project.getProviders(),
                     project.getExtensions().findByType(JavaToolchainService.class),
+                    layers,
                     project.getName())
-            );
-        NamedDomainObjectContainer<NativeImageLayer> layers = project.getObjects()
-            .domainObjectContainer(NativeImageLayer.class, name ->
-                project.getObjects().newInstance(NativeImageLayer.class, name, project.getObjects(), project)
             );
         GraalVMExtension graalvmNative = project.getExtensions().create(GraalVMExtension.class, "graalvmNative",
             DefaultGraalVmExtension.class, nativeImages, layers, this, project);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -549,6 +549,8 @@ public class NativeImagePlugin implements Plugin<Project> {
                     ? project.getProviders().provider(Collections::emptyList)
                     : project.getProviders().provider(() ->
                         sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath())));
+            create.getClasspath().from(layer.getInheritedCompatibilityClasspath());
+            layer.getCompatibilityClasspath().from(create.getJars(), create.getClasspath());
 
             TaskProvider<BuildNativeImageTask> task = tasks.register(taskName, BuildNativeImageTask.class, builder -> {
                 builder.setDescription("Builds the " + layer.getName() + " Native Image layer.");

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -64,10 +64,12 @@ import org.graalvm.buildtools.gradle.tasks.CreateLayerOptions;
 import org.graalvm.buildtools.gradle.tasks.ValidateNativeImageLayerSelectionTask;
 import org.graalvm.buildtools.gradle.tasks.GenerateAgentAccessFilter;
 import org.graalvm.buildtools.gradle.tasks.GenerateDynamicAccessMetadata;
+import org.graalvm.buildtools.gradle.tasks.GenerateNativeImageLauncherTask;
 import org.graalvm.buildtools.gradle.tasks.GenerateResourcesConfigFile;
 import org.graalvm.buildtools.gradle.tasks.ListLibrariesMissingMetadata;
 import org.graalvm.buildtools.gradle.tasks.MetadataCopyTask;
 import org.graalvm.buildtools.gradle.tasks.NativeRunTask;
+import org.graalvm.buildtools.gradle.tasks.StageNativeImageLayerRuntimeFilesTask;
 import org.graalvm.buildtools.gradle.tasks.actions.CleanupAgentFilesAction;
 import org.graalvm.buildtools.gradle.tasks.actions.MergeAgentFilesAction;
 import org.graalvm.buildtools.gradle.tasks.scanner.JarAnalyzerTransform;
@@ -102,6 +104,7 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.JavaApplication;
@@ -316,6 +319,8 @@ public class NativeImagePlugin implements Plugin<Project> {
         configureAutomaticTaskCreation(project, graalExtension, tasks, javaConvention.getSourceSets());
 
         TaskProvider<BuildNativeImageTask> imageBuilder = tasks.named(NATIVE_COMPILE_TASK_NAME, BuildNativeImageTask.class);
+        configureApplicationDistribution(project, mainOptions, imageBuilder,
+            tasks.named("nativeLayerRuntimeFiles", StageNativeImageLayerRuntimeFilesTask.class), tasks);
         tasks.register(DEPRECATED_NATIVE_BUILD_TASK, t -> {
             t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
             t.setDescription("Deprecated alias for nativeCompile.");
@@ -433,6 +438,21 @@ public class NativeImagePlugin implements Plugin<Project> {
                     builder.getMetadataRepositoryRootPath().set(repoRootPath);
                 });
             configureLayerSelectionValidation(project, tasks, compileTaskName, options, imageBuilder);
+            String stageTaskName = NATIVE_MAIN_EXTENSION.equals(binaryName)
+                ? "nativeLayerRuntimeFiles"
+                : deriveTaskName(binaryName, "native", "LayerRuntimeFiles");
+            TaskProvider<StageNativeImageLayerRuntimeFilesTask> stagedRuntimeFiles = tasks.register(
+                stageTaskName, StageNativeImageLayerRuntimeFilesTask.class, task -> {
+                    task.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+                    task.setDescription("Stages runtime libraries for the " + options.getName() + " native binary.");
+                    task.getLayerFiles().from(options.getLayerFiles());
+                    task.getLayerDirectories().from(options.getLayerFiles().getElements()
+                        .map(serializableTransformerOf(elements -> elements.stream()
+                            .map(location -> location.getAsFile().getParentFile())
+                            .toList())));
+                    task.getDestinationDirectory().set(project.getLayout().getBuildDirectory()
+                        .dir("native/layer-runtime-files/" + binaryName));
+                });
             String runTaskName = deriveTaskName(binaryName, "native", "Run");
             var providers = project.getProviders();
             if (NATIVE_MAIN_EXTENSION.equals(binaryName)) {
@@ -457,8 +477,10 @@ public class NativeImagePlugin implements Plugin<Project> {
                             .zip(libsPath, serializableBiFunctionOf((path, libs) -> path + File.pathSeparator + libs))
                             .orElse(libsPath));
                     } else {
-                        var ldLibraryPath = providers.environmentVariable("LD_LIBRARY_PATH");
-                        task.getEnvironment().put("LD_LIBRARY_PATH", ldLibraryPath
+                        String variable = System.getProperty("os.name", "").startsWith("Mac")
+                            ? "DYLD_LIBRARY_PATH" : "LD_LIBRARY_PATH";
+                        var ldLibraryPath = providers.environmentVariable(variable);
+                        task.getEnvironment().put(variable, ldLibraryPath
                             .zip(libsPath, serializableBiFunctionOf((path, libs) -> path + File.pathSeparator + libs))
                             .orElse(libsPath));
                     }
@@ -507,6 +529,42 @@ public class NativeImagePlugin implements Plugin<Project> {
 
             configureJvmReachabilityConfigurationDirectories(project, graalExtension, options, sourceSet);
             configureJvmReachabilityExcludeConfigArgs(project, graalExtension, options, sourceSet);
+        });
+    }
+
+    private static void configureApplicationDistribution(Project project,
+                                                         NativeImageOptions options,
+                                                         TaskProvider<BuildNativeImageTask> imageBuilder,
+                                                         TaskProvider<StageNativeImageLayerRuntimeFilesTask> stagedRuntimeFiles,
+                                                         TaskContainer tasks) {
+        project.afterEvaluate(ignored -> {
+            if (options.getLayerFiles().isEmpty()) {
+                return;
+            }
+            project.getPlugins().withId("application", applicationPlugin -> {
+                TaskProvider<GenerateNativeImageLauncherTask> launcher = tasks.register(
+                    "nativeDistributionLauncher", GenerateNativeImageLauncherTask.class, task -> {
+                        task.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+                        task.setDescription("Generates the launcher for the layered native application distribution.");
+                        task.getExecutableName().set(imageBuilder.flatMap(BuildNativeImageTask::getExecutableName));
+                        task.getLauncherName().set(options.getImageName().map(name -> name + "-native"));
+                        task.getOutputDirectory().set(project.getLayout().getBuildDirectory()
+                            .dir("native/distribution-launcher"));
+                    });
+                DistributionContainer distributions = project.getExtensions().getByType(DistributionContainer.class);
+                distributions.named("main", distribution -> {
+                    distribution.getContents().from(imageBuilder.flatMap(BuildNativeImageTask::getOutputFile), spec -> {
+                        spec.into("lib/native");
+                    });
+                    distribution.getContents().from(stagedRuntimeFiles.flatMap(
+                        StageNativeImageLayerRuntimeFilesTask::getDestinationDirectory),
+                        spec -> spec.into("lib/native-layers"));
+                    distribution.getContents().from(launcher.flatMap(GenerateNativeImageLauncherTask::getOutputDirectory),
+                        spec -> {
+                            spec.into("bin");
+                        });
+                });
+            });
         });
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -443,16 +443,21 @@ public class NativeImagePlugin implements Plugin<Project> {
                 task.getImage().convention(imageBuilder.flatMap(BuildNativeImageTask::getOutputFile));
                 task.getRuntimeArgs().convention(options.getRuntimeArgs());
                 if (!options.getLayerFiles().isEmpty()) {
-                    var libsDirs = project.getObjects().fileCollection();
-                    libsDirs.from(options.getLayerFiles().getElements().map(elements -> elements.stream()
-                        .map(location -> location.getAsFile().getParentFile())
-                        .toList()));
+                    Provider<String> libsPath = options.getLayerFiles().getElements()
+                        .map(serializableTransformerOf(elements -> elements.stream()
+                            .map(location -> location.getAsFile().getParent())
+                            .distinct()
+                            .collect(Collectors.joining(File.pathSeparator))));
                     if (IS_WINDOWS) {
                         var pathVariable = providers.environmentVariable("PATH");
-                        task.getEnvironment().put("PATH", pathVariable.map(path -> path + ";" + libsDirs.getAsPath()).orElse(providers.provider(libsDirs::getAsPath)));
+                        task.getEnvironment().put("PATH", pathVariable
+                            .zip(libsPath, serializableBiFunctionOf((path, libs) -> path + File.pathSeparator + libs))
+                            .orElse(libsPath));
                     } else {
                         var ldLibraryPath = providers.environmentVariable("LD_LIBRARY_PATH");
-                        task.getEnvironment().put("LD_LIBRARY_PATH", ldLibraryPath.map(path -> path + ":" + libsDirs.getAsPath()).orElse(providers.provider(libsDirs::getAsPath)));
+                        task.getEnvironment().put("LD_LIBRARY_PATH", ldLibraryPath
+                            .zip(libsPath, serializableBiFunctionOf((path, libs) -> path + File.pathSeparator + libs))
+                            .orElse(libsPath));
                     }
                 }
                 task.getInternalRuntimeArgs().convention(

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -536,7 +536,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                 .getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
             create.getClasspath().from(layer.getContents().getAll()
                 .flatMap(all -> Boolean.TRUE.equals(all)
-                    ? layerOptions.externalDependenciesOf(runtimeClasspath)
+                    ? layerOptions.resolvedArtifactsOf(runtimeClasspath)
                     : project.getProviders().provider(Collections::emptyList)));
             create.getClasspath().from(layer.getContents().getPackages()
                 .flatMap(packages -> packages.isEmpty()

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -61,6 +61,7 @@ import org.graalvm.buildtools.gradle.internal.agent.AgentConfigurationFactory;
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask;
 import org.graalvm.buildtools.gradle.tasks.CollectReachabilityMetadata;
 import org.graalvm.buildtools.gradle.tasks.CreateLayerOptions;
+import org.graalvm.buildtools.gradle.tasks.ValidateNativeImageLayerSelectionTask;
 import org.graalvm.buildtools.gradle.tasks.GenerateAgentAccessFilter;
 import org.graalvm.buildtools.gradle.tasks.GenerateDynamicAccessMetadata;
 import org.graalvm.buildtools.gradle.tasks.GenerateResourcesConfigFile;
@@ -431,6 +432,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                     builder.getMetadataRepositoryEnabled().set(repoEnabled);
                     builder.getMetadataRepositoryRootPath().set(repoRootPath);
                 });
+            configureLayerSelectionValidation(project, tasks, compileTaskName, options, imageBuilder);
             String runTaskName = deriveTaskName(binaryName, "native", "Run");
             var providers = project.getProviders();
             if (NATIVE_MAIN_EXTENSION.equals(binaryName)) {
@@ -566,11 +568,33 @@ public class NativeImagePlugin implements Plugin<Project> {
                 builder.getMetadataRepositoryRootPath().set(svc.map(serializableTransformerOf(service ->
                     service.getRepositoryDirectory().map(path -> path.toAbsolutePath().toString()).orElse(null))));
             });
+            configureLayerSelectionValidation(project, tasks, taskName, layerOptions, task);
             SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
             configureJvmReachabilityConfigurationDirectories(project, graalExtension, layerOptions, mainSourceSet);
             configureJvmReachabilityExcludeConfigArgs(project, graalExtension, layerOptions, mainSourceSet);
             layer.getOutputFile().convention(task.flatMap(BuildNativeImageTask::getCreatedLayerFile));
         });
+    }
+
+    /**
+     * Orders duplicate validation before all Native Image producers in a requested task graph.
+     * §FS-plugin-model.2.
+     */
+    private static void configureLayerSelectionValidation(Project project,
+                                                          TaskContainer tasks,
+                                                          String consumerTaskName,
+                                                          NativeImageOptions options,
+                                                          TaskProvider<BuildNativeImageTask> consumer) {
+        String validationTaskName = "validate" + capitalize(consumerTaskName) + "LayerSelection";
+        TaskProvider<ValidateNativeImageLayerSelectionTask> validation = tasks.register(
+            validationTaskName, ValidateNativeImageLayerSelectionTask.class, task -> {
+                task.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+                task.setDescription("Validates Native Image layer selection for " + options.getName() + ".");
+                task.getBinaryName().set(options.getName());
+                task.getLayerNames().set(options.getLayerNames());
+            });
+        consumer.configure(task -> task.dependsOn(validation));
+        tasks.withType(BuildNativeImageTask.class).configureEach(producer -> producer.mustRunAfter(validation));
     }
 
     private void configureCustomApplicationBinary(Project project, NativeImageOptions options) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
@@ -99,6 +99,20 @@ public interface GraalVMExtension {
     void binaries(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec);
 
     /**
+     * Returns first-class named Native Image layers. §FS-plugin-model.2.
+     *
+     * @return configured layers
+     */
+    NamedDomainObjectContainer<NativeImageLayer> getLayers();
+
+    /**
+     * Configures named Native Image layers. §FS-plugin-model.2.
+     *
+     * @param spec layer configuration
+     */
+    void layers(Action<? super NamedDomainObjectContainer<NativeImageLayer>> spec);
+
+    /**
      * Registers a new native image binary with testing support.
      *
      * @param name the name of the binary

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/LayerContents.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/LayerContents.java
@@ -43,8 +43,8 @@ package org.graalvm.buildtools.gradle.dsl;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.MinimalExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
@@ -103,11 +103,11 @@ public abstract class LayerContents {
     }
 
     public void fromConfiguration(Configuration configuration) {
-        getFiles().from(externalDependenciesOf(configuration));
+        getFiles().from(resolvedArtifactsOf(configuration));
     }
 
     public void fromConfiguration(Provider<Configuration> configuration) {
-        getFiles().from(configuration.flatMap(this::externalDependenciesOf));
+        getFiles().from(configuration.flatMap(this::resolvedArtifactsOf));
     }
 
     public void dependencies(String notation) {
@@ -120,6 +120,21 @@ public abstract class LayerContents {
         addDependency(notation, spec.isTransitive());
     }
 
+    public void dependencies(Provider<? extends MinimalExternalModuleDependency> dependency) {
+        dependencies(dependency, spec -> {
+        });
+    }
+
+    public void dependencies(Provider<? extends MinimalExternalModuleDependency> dependency,
+                             Action<? super LayerDependencySpec> action) {
+        LayerDependencySpec spec = new LayerDependencySpec();
+        action.execute(spec);
+        Provider<String> notation = dependency.map(value ->
+            value.getModule().toString() + ":" + value.getVersionConstraint().getRequiredVersion());
+        getDependencies().add(notation.map(value -> new LayerDependency(value, spec.isTransitive())));
+        getFiles().from(notation.flatMap(value -> resolvedArtifactsOf(detachedConfiguration(value, spec.isTransitive()))));
+    }
+
     private void addDependency(String notation, boolean transitive) {
         LayerDependency selection = new LayerDependency(notation, transitive);
         getDependencies().add(selection);
@@ -127,14 +142,21 @@ public abstract class LayerContents {
         if (dependency instanceof ModuleDependency) {
             ((ModuleDependency) dependency).setTransitive(transitive);
         }
-        getFiles().from(externalDependenciesOf(project.getConfigurations().detachedConfiguration(dependency)));
+        getFiles().from(resolvedArtifactsOf(project.getConfigurations().detachedConfiguration(dependency)));
     }
 
-    private Provider<List<File>> externalDependenciesOf(Configuration configuration) {
+    private Configuration detachedConfiguration(String notation, boolean transitive) {
+        Dependency dependency = project.getDependencies().create(notation);
+        if (dependency instanceof ModuleDependency) {
+            ((ModuleDependency) dependency).setTransitive(transitive);
+        }
+        return project.getConfigurations().detachedConfiguration(dependency);
+    }
+
+    private Provider<List<File>> resolvedArtifactsOf(Configuration configuration) {
         return configuration.getIncoming()
             .artifactView(view -> {
                 view.setLenient(false);
-                view.componentFilter(id -> id instanceof ModuleComponentIdentifier);
             })
             .getArtifacts()
             .getResolvedArtifacts()

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/LayerContents.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/LayerContents.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.dsl;
+
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.Project;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Lazy contents of a named Native Image layer. §FS-plugin-model.2.
+ */
+public abstract class LayerContents {
+    private final transient Project project;
+
+    @Input
+    public abstract Property<Boolean> getAll();
+
+    @Input
+    public abstract ListProperty<String> getModules();
+
+    @Input
+    public abstract ListProperty<String> getPackages();
+
+    @Classpath
+    public abstract ConfigurableFileCollection getFiles();
+
+    @Nested
+    public abstract ListProperty<LayerDependency> getDependencies();
+
+    @Inject
+    public LayerContents(Project project) {
+        this.project = project;
+        getAll().convention(false);
+        getModules().convention(List.of());
+        getPackages().convention(List.of());
+        getDependencies().convention(List.of());
+    }
+
+    public void modules(String... modules) {
+        getModules().addAll(Arrays.asList(modules));
+    }
+
+    public void packages(String... packages) {
+        getPackages().addAll(Arrays.asList(packages));
+    }
+
+    public void from(Object... paths) {
+        getFiles().from(paths);
+    }
+
+    public void fromConfiguration(Configuration configuration) {
+        getFiles().from(externalDependenciesOf(configuration));
+    }
+
+    public void fromConfiguration(Provider<Configuration> configuration) {
+        getFiles().from(configuration.flatMap(this::externalDependenciesOf));
+    }
+
+    public void dependencies(String notation) {
+        addDependency(notation, true);
+    }
+
+    public void dependencies(String notation, Action<? super LayerDependencySpec> action) {
+        LayerDependencySpec spec = new LayerDependencySpec();
+        action.execute(spec);
+        addDependency(notation, spec.isTransitive());
+    }
+
+    private void addDependency(String notation, boolean transitive) {
+        LayerDependency selection = new LayerDependency(notation, transitive);
+        getDependencies().add(selection);
+        Dependency dependency = project.getDependencies().create(notation);
+        if (dependency instanceof ModuleDependency) {
+            ((ModuleDependency) dependency).setTransitive(transitive);
+        }
+        getFiles().from(externalDependenciesOf(project.getConfigurations().detachedConfiguration(dependency)));
+    }
+
+    private Provider<List<File>> externalDependenciesOf(Configuration configuration) {
+        return configuration.getIncoming()
+            .artifactView(view -> {
+                view.setLenient(false);
+                view.componentFilter(id -> id instanceof ModuleComponentIdentifier);
+            })
+            .getArtifacts()
+            .getResolvedArtifacts()
+            .map(artifacts -> {
+                List<File> files = new ArrayList<>();
+                for (var artifact : artifacts) {
+                    files.add(artifact.getFile());
+                }
+                return files;
+            });
+    }
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/LayerDependency.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/LayerDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,52 +38,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.graalvm.buildtools.gradle.dsl;
 
-plugins {
-    id 'application'
-    id 'org.graalvm.buildtools.native'
-}
+import java.io.Serializable;
 
-repositories {
-    mavenCentral()
-}
+/**
+ * Gradle dependency selector used by named layer contents. §FS-plugin-model.2.
+ */
+public final class LayerDependency implements Serializable {
+    private final String notation;
+    private final boolean transitive;
 
-application {
-    mainClass.set('org.graalvm.demo.Application')
-}
-
-def junitVersion = providers.gradleProperty('junit.jupiter.version')
-        .get()
-
-dependencies {
-    implementation("org.slf4j:slf4j-api:2.0.17")
-    runtimeOnly("ch.qos.logback:logback-classic:1.5.6")
-    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
-}
-
-test {
-    useJUnitPlatform()
-}
-
-tasks.named("nativeRun") {
-    runtimeArgs.add(providers.gradleProperty("message").orElse("default message"))
-}
-
-graalvmNative {
-    // Named layers are built independently from application binaries. §gradle/FS-plugin-model.2.
-    layers {
-        dependencies {
-            contents {
-                modules("java.base")
-                fromConfiguration(configurations.runtimeClasspath)
-            }
+    public LayerDependency(String notation, boolean transitive) {
+        if (notation == null || notation.isBlank()) {
+            throw new IllegalArgumentException("Layer dependency notation must not be blank");
         }
+        this.notation = notation;
+        this.transitive = transitive;
     }
-    binaries {
-        main {
-            layer = graalvmNative.layers.dependencies
-        }
+
+    public String getNotation() {
+        return notation;
+    }
+
+    public boolean isTransitive() {
+        return transitive;
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/LayerDependencySpec.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/LayerDependencySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,52 +38,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.graalvm.buildtools.gradle.dsl;
 
-plugins {
-    id 'application'
-    id 'org.graalvm.buildtools.native'
-}
+/**
+ * Mutable DSL adapter for one dependency selector. §FS-plugin-model.2.
+ */
+public final class LayerDependencySpec {
+    private boolean transitive = true;
 
-repositories {
-    mavenCentral()
-}
-
-application {
-    mainClass.set('org.graalvm.demo.Application')
-}
-
-def junitVersion = providers.gradleProperty('junit.jupiter.version')
-        .get()
-
-dependencies {
-    implementation("org.slf4j:slf4j-api:2.0.17")
-    runtimeOnly("ch.qos.logback:logback-classic:1.5.6")
-    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
-}
-
-test {
-    useJUnitPlatform()
-}
-
-tasks.named("nativeRun") {
-    runtimeArgs.add(providers.gradleProperty("message").orElse("default message"))
-}
-
-graalvmNative {
-    // Named layers are built independently from application binaries. §gradle/FS-plugin-model.2.
-    layers {
-        dependencies {
-            contents {
-                modules("java.base")
-                fromConfiguration(configurations.runtimeClasspath)
-            }
-        }
+    public boolean isTransitive() {
+        return transitive;
     }
-    binaries {
-        main {
-            layer = graalvmNative.layers.dependencies
-        }
+
+    public void setTransitive(boolean transitive) {
+        this.transitive = transitive;
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageCompileOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageCompileOptions.java
@@ -46,7 +46,6 @@ import org.graalvm.buildtools.gradle.tasks.LayerOptions;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.ListProperty;
@@ -57,6 +56,7 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
@@ -269,6 +269,15 @@ public interface NativeImageCompileOptions {
     @PathSensitive(PathSensitivity.NAME_ONLY)
     ConfigurableFileCollection getLayerFiles();
 
+    /**
+     * Logical names of layers consumed by this binary, used for duplicate validation.
+     * §FS-native-invocation.3.
+     *
+     * @return the selected layer names
+     */
+    @Input
+    ListProperty<String> getLayerNames();
+
     void layers(Action<? super DomainObjectSet<LayerOptions>> spec);
 
     /**
@@ -285,6 +294,9 @@ public interface NativeImageCompileOptions {
 
     void useLayer(Provider<? extends NativeImageLayer> layer);
 
+    @Internal
+    NativeImageLayer getLayer();
+
     void setLayer(NativeImageLayer layer);
 
     /**
@@ -297,15 +309,14 @@ public interface NativeImageCompileOptions {
     @Deprecated
     void createLayer(Action<? super CreateLayerOptions> spec);
 
-    default Provider<List<File>> externalDependenciesOf(Provider<Configuration> configurationProvider) {
-        return configurationProvider.flatMap(this::externalDependenciesOf);
+    default Provider<List<File>> resolvedArtifactsOf(Provider<Configuration> configurationProvider) {
+        return configurationProvider.flatMap(this::resolvedArtifactsOf);
     }
 
-    default Provider<List<File>> externalDependenciesOf(Configuration configuration) {
+    default Provider<List<File>> resolvedArtifactsOf(Configuration configuration) {
         return configuration.getIncoming()
             .artifactView(view -> {
                 view.setLenient(false);
-                view.componentFilter(id -> id instanceof ModuleComponentIdentifier);
             })
             .getArtifacts()
             .getResolvedArtifacts()

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageCompileOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageCompileOptions.java
@@ -250,10 +250,51 @@ public interface NativeImageCompileOptions {
     @Nested
     DomainObjectSet<LayerOptions> getLayers();
 
+    /**
+     * Internal normalized layer-create model used by dedicated layer tasks and the legacy adapter.
+     * §FS-plugin-model.2.
+     *
+     * @return the optional layer-create selection
+     */
+    @Nested
+    @Optional
+    Property<CreateLayerOptions> getLayerCreate();
+
+    /**
+     * Produced layer files consumed by this binary. §FS-native-invocation.3.
+     *
+     * @return the layer files
+     */
+    @InputFiles
+    @PathSensitive(PathSensitivity.NAME_ONLY)
+    ConfigurableFileCollection getLayerFiles();
+
     void layers(Action<? super DomainObjectSet<LayerOptions>> spec);
 
+    /**
+     * Consumes a layer produced by a legacy binary-scoped layer declaration. §FS-plugin-model.2.
+     *
+     * @param name the legacy layer-producing binary name
+     * @deprecated define a named layer in {@code graalvmNative.layers} and pass its typed
+     *             {@link NativeImageLayer} object to {@link #useLayer(NativeImageLayer)}
+     */
+    @Deprecated
     void useLayer(String name);
 
+    void useLayer(NativeImageLayer layer);
+
+    void useLayer(Provider<? extends NativeImageLayer> layer);
+
+    void setLayer(NativeImageLayer layer);
+
+    /**
+     * Configures this legacy {@code lib}-prefixed binary as a Native Image layer producer.
+     * §FS-plugin-model.2.
+     *
+     * @param spec the legacy layer contents
+     * @deprecated define a named layer in {@code graalvmNative.layers} instead
+     */
+    @Deprecated
     void createLayer(Action<? super CreateLayerOptions> spec);
 
     default Provider<List<File>> externalDependenciesOf(Provider<Configuration> configurationProvider) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageCompileOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageCompileOptions.java
@@ -46,6 +46,7 @@ import org.graalvm.buildtools.gradle.tasks.LayerOptions;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.ListProperty;
@@ -294,6 +295,13 @@ public interface NativeImageCompileOptions {
 
     void useLayer(Provider<? extends NativeImageLayer> layer);
 
+    /**
+     * Lazily consumes a first-class named layer, independent of declaration order. §FS-plugin-model.2.
+     *
+     * @param name named layer to consume
+     */
+    void usesLayer(String name);
+
     @Internal
     NativeImageLayer getLayer();
 
@@ -323,6 +331,45 @@ public interface NativeImageCompileOptions {
             .map(artifacts -> {
                 var files = new ArrayList<File>();
                 // not using .stream() intentionally because of https://github.com/gradle/gradle/issues/33152
+                for (var artifact : artifacts) {
+                    files.add(artifact.getFile());
+                }
+                return files;
+            });
+    }
+
+    /**
+     * Resolves only external module artifacts, preserving the pre-1.1.8 adapter semantics.
+     * §FS-plugin-model.2.
+     *
+     * @param configurationProvider configuration provider
+     * @return resolved external artifact files
+     * @deprecated use {@link #resolvedArtifactsOf(Provider)} when project artifacts should be included
+     */
+    @Deprecated
+    default Provider<List<File>> externalDependenciesOf(Provider<Configuration> configurationProvider) {
+        return configurationProvider.flatMap(this::externalDependenciesOf);
+    }
+
+    /**
+     * Resolves only external module artifacts, preserving the pre-1.1.8 adapter semantics.
+     * §FS-plugin-model.2.
+     *
+     * @param configuration configuration to resolve
+     * @return resolved external artifact files
+     * @deprecated use {@link #resolvedArtifactsOf(Configuration)} when project artifacts should be included
+     */
+    @Deprecated
+    default Provider<List<File>> externalDependenciesOf(Configuration configuration) {
+        return configuration.getIncoming()
+            .artifactView(view -> {
+                view.setLenient(false);
+                view.componentFilter(id -> id instanceof ModuleComponentIdentifier);
+            })
+            .getArtifacts()
+            .getResolvedArtifacts()
+            .map(artifacts -> {
+                var files = new ArrayList<File>();
                 for (var artifact : artifacts) {
                     files.add(artifact.getFile());
                 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageLayer.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,52 +38,59 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.graalvm.buildtools.gradle.dsl;
 
-plugins {
-    id 'application'
-    id 'org.graalvm.buildtools.native'
-}
+import org.gradle.api.Action;
+import org.gradle.api.Named;
+import org.gradle.api.Project;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
 
-repositories {
-    mavenCentral()
-}
+import javax.inject.Inject;
 
-application {
-    mainClass.set('org.graalvm.demo.Application')
-}
+/**
+ * First-class named Native Image layer. §FS-plugin-model.2.
+ */
+public abstract class NativeImageLayer implements Named {
+    private final String name;
+    private final LayerContents contents;
 
-def junitVersion = providers.gradleProperty('junit.jupiter.version')
-        .get()
-
-dependencies {
-    implementation("org.slf4j:slf4j-api:2.0.17")
-    runtimeOnly("ch.qos.logback:logback-classic:1.5.6")
-    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
-}
-
-test {
-    useJUnitPlatform()
-}
-
-tasks.named("nativeRun") {
-    runtimeArgs.add(providers.gradleProperty("message").orElse("default message"))
-}
-
-graalvmNative {
-    // Named layers are built independently from application binaries. §gradle/FS-plugin-model.2.
-    layers {
-        dependencies {
-            contents {
-                modules("java.base")
-                fromConfiguration(configurations.runtimeClasspath)
-            }
-        }
+    @Inject
+    public NativeImageLayer(String name, ObjectFactory objects, Project project) {
+        this.name = name;
+        this.contents = objects.newInstance(LayerContents.class, project);
     }
-    binaries {
-        main {
-            layer = graalvmNative.layers.dependencies
-        }
+
+    @Override
+    @Internal
+    public String getName() {
+        return name;
     }
+
+    @Nested
+    public LayerContents getContents() {
+        return contents;
+    }
+
+    public void contents(Action<? super LayerContents> action) {
+        action.execute(contents);
+    }
+
+    @Input
+    public abstract ListProperty<String> getBuildArgs();
+
+    @Input
+    public abstract Property<Boolean> getVerbose();
+
+    public void buildArgs(String... arguments) {
+        getBuildArgs().addAll(arguments);
+    }
+
+    @Internal
+    public abstract RegularFileProperty getOutputFile();
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageLayer.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageLayer.java
@@ -66,6 +66,8 @@ public abstract class NativeImageLayer implements Named {
     private final LayerContents contents;
     private final Project project;
     private final ConfigurableFileCollection layerFiles;
+    private final ConfigurableFileCollection inheritedCompatibilityClasspath;
+    private final ConfigurableFileCollection compatibilityClasspath;
     private final Set<String> configuredLayerNames = new HashSet<>();
 
     @Inject
@@ -74,6 +76,8 @@ public abstract class NativeImageLayer implements Named {
         this.contents = objects.newInstance(LayerContents.class, project);
         this.project = project;
         this.layerFiles = project.files();
+        this.inheritedCompatibilityClasspath = project.files();
+        this.compatibilityClasspath = project.files();
     }
 
     @Override
@@ -115,6 +119,7 @@ public abstract class NativeImageLayer implements Named {
             .getLayers()
             .getByName(name));
         layerFiles.from(layer.flatMap(NativeImageLayer::getOutputFile));
+        inheritedCompatibilityClasspath.from(layer.map(NativeImageLayer::getCompatibilityClasspath));
     }
 
     @Internal
@@ -123,6 +128,24 @@ public abstract class NativeImageLayer implements Named {
     @Internal
     public ConfigurableFileCollection getUseLayerFiles() {
         return layerFiles;
+    }
+
+    /**
+     * Classpath entries inherited from layers consumed by this layer.
+     * §FS-native-invocation.3.
+     */
+    @Internal
+    public ConfigurableFileCollection getInheritedCompatibilityClasspath() {
+        return inheritedCompatibilityClasspath;
+    }
+
+    /**
+     * Classpath entries that must accompany this layer in every dependent layer or binary.
+     * §FS-native-invocation.3.
+     */
+    @Internal
+    public ConfigurableFileCollection getCompatibilityClasspath() {
+        return compatibilityClasspath;
     }
 
     @Internal

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageLayer.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageLayer.java
@@ -43,15 +43,20 @@ package org.graalvm.buildtools.gradle.dsl;
 import org.gradle.api.Action;
 import org.gradle.api.Named;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
+import org.graalvm.buildtools.utils.NativeImageLayerArguments;
 
 import javax.inject.Inject;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * First-class named Native Image layer. §FS-plugin-model.2.
@@ -59,11 +64,16 @@ import javax.inject.Inject;
 public abstract class NativeImageLayer implements Named {
     private final String name;
     private final LayerContents contents;
+    private final Project project;
+    private final ConfigurableFileCollection layerFiles;
+    private final Set<String> configuredLayerNames = new HashSet<>();
 
     @Inject
     public NativeImageLayer(String name, ObjectFactory objects, Project project) {
         this.name = name;
         this.contents = objects.newInstance(LayerContents.class, project);
+        this.project = project;
+        this.layerFiles = project.files();
     }
 
     @Override
@@ -89,6 +99,30 @@ public abstract class NativeImageLayer implements Named {
 
     public void buildArgs(String... arguments) {
         getBuildArgs().addAll(arguments);
+    }
+
+    /**
+     * Adds a lazily resolved named producer layer to this layer. §FS-plugin-model.2.
+     */
+    public void usesLayer(String name) {
+        NativeImageLayerArguments.validateLayerName(name);
+        if (!configuredLayerNames.add(name)) {
+            throw new IllegalArgumentException("Layer '" + name + "' is selected more than once");
+        }
+        getUseLayerNames().add(name);
+        Provider<NativeImageLayer> layer = project.provider(() -> project.getExtensions()
+            .getByType(GraalVMExtension.class)
+            .getLayers()
+            .getByName(name));
+        layerFiles.from(layer.flatMap(NativeImageLayer::getOutputFile));
+    }
+
+    @Internal
+    public abstract ListProperty<String> getUseLayerNames();
+
+    @Internal
+    public ConfigurableFileCollection getUseLayerFiles() {
+        return layerFiles;
     }
 
     @Internal

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -42,6 +42,7 @@
 package org.graalvm.buildtools.gradle.internal;
 
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
+import org.graalvm.buildtools.gradle.dsl.NativeImageLayer;
 import org.graalvm.buildtools.gradle.dsl.NativeResourcesOptions;
 import org.graalvm.buildtools.gradle.dsl.agent.DeprecatedAgentOptions;
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask;
@@ -430,22 +431,48 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
 
     @Override
     public void useLayer(String name) {
+        // Keep the deprecated string adapter operational while directing callers to typed layer objects. §FS-plugin-model.2.
+        LOGGER.warn("useLayer(String) is deprecated; configure graalvmNative.layers and pass the typed layer object instead.");
         var taskName = compileTaskNameForBinary(name);
         var layer = objects.newInstance(UseLayerOptions.class);
         layer.getLayerName().convention(name);
         layer.getLayerFile().convention(tasks.named(taskName, BuildNativeImageTask.class).flatMap(BuildNativeImageTask::getCreatedLayerFile));
+        getLayerFiles().from(layer.getLayerFile());
         layers(options -> options.add(layer));
     }
 
     @Override
+    public void useLayer(NativeImageLayer layer) {
+        // Typed layer consumption records the producing layer output on the binary. §FS-plugin-model.2.
+        if (getLayerFiles().getFrom().contains(layer.getOutputFile())) {
+            throw new IllegalArgumentException("Layer '" + layer.getName() + "' is already assigned to binary '" + getName() + "'");
+        }
+        getLayerFiles().from(layer.getOutputFile());
+    }
+
+    @Override
+    public void useLayer(Provider<? extends NativeImageLayer> layer) {
+        // Provider-backed layer consumption preserves the typed, lazy extension surface. §FS-plugin-model.2.
+        getLayerFiles().from(layer.flatMap(NativeImageLayer::getOutputFile));
+    }
+
+    @Override
+    public void setLayer(NativeImageLayer layer) {
+        useLayer(layer);
+    }
+
+    @Override
     public void createLayer(Action<? super CreateLayerOptions> spec) {
+        LOGGER.warn("createLayer is deprecated; configure a named layer in graalvmNative.layers instead.");
         var layer = objects.newInstance(CreateLayerOptions.class);
         var binaryName = getName();
         if (!binaryName.startsWith("lib")) {
             throw new IllegalArgumentException("Binary name for a layer must start with 'lib'");
         }
         layer.getLayerName().convention(binaryName);
+        layer.getAll().convention(false);
         spec.execute(layer);
+        getLayerCreate().set(layer);
         layers(options -> options.add(layer));
     }
 }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -456,6 +456,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         // Typed layer consumption records the producing layer output on the binary. §FS-plugin-model.2.
         addLayerName(layer.getName());
         getLayerFiles().from(layer.getOutputFile());
+        getClasspath().from(layer.getCompatibilityClasspath());
     }
 
     @Override
@@ -463,6 +464,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         // Provider-backed layer consumption preserves the typed, lazy extension surface. §FS-plugin-model.2.
         getLayerNames().add(layer.map(NativeImageLayer::getName));
         getLayerFiles().from(layer.flatMap(NativeImageLayer::getOutputFile));
+        getClasspath().from(layer.map(NativeImageLayer::getCompatibilityClasspath));
     }
 
     @Override
@@ -472,6 +474,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         Provider<NativeImageLayer> layer = providers.provider(() -> namedLayers.getByName(name));
         addLayerName(name);
         getLayerFiles().from(layer.flatMap(NativeImageLayer::getOutputFile));
+        getClasspath().from(layer.map(NativeImageLayer::getCompatibilityClasspath));
     }
 
     @Override
@@ -485,6 +488,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         assignedLayer = layer;
         getLayerNames().set(List.of(layer.getName()));
         getLayerFiles().setFrom(layer.getOutputFile());
+        getClasspath().from(layer.getCompatibilityClasspath());
     }
 
     private void addLayerName(String layerName) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -91,6 +91,7 @@ import static org.graalvm.buildtools.gradle.NativeImagePlugin.compileTaskNameFor
 public abstract class BaseNativeImageOptions implements NativeImageOptions {
     private static final GraalVMLogger LOGGER = GraalVMLogger.of(Logging.getLogger(BaseNativeImageOptions.class));
     private final DomainObjectSet<LayerOptions> layers;
+    private NativeImageLayer assignedLayer;
 
     private final String name;
     private final transient TaskContainer tasks;
@@ -278,6 +279,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         getImageName().convention(defaultImageName);
         getUseFatJar().convention(false);
         getPgoInstrument().convention(false);
+        getLayerNames().convention(List.of());
         DirectoryProperty pgoProfileDir = objectFactory.directoryProperty();
         pgoProfileDir.convention(layout.getProjectDirectory().dir("src/pgo-profiles/" + name));
         getPgoProfilesDirectory().convention(pgoProfileDir.map(d -> d.getAsFile().exists() ? d : null));
@@ -433,6 +435,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
     public void useLayer(String name) {
         // Keep the deprecated string adapter operational while directing callers to typed layer objects. §FS-plugin-model.2.
         LOGGER.warn("useLayer(String) is deprecated; configure graalvmNative.layers and pass the typed layer object instead.");
+        addLayerName(name);
         var taskName = compileTaskNameForBinary(name);
         var layer = objects.newInstance(UseLayerOptions.class);
         layer.getLayerName().convention(name);
@@ -444,21 +447,36 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
     @Override
     public void useLayer(NativeImageLayer layer) {
         // Typed layer consumption records the producing layer output on the binary. §FS-plugin-model.2.
-        if (getLayerFiles().getFrom().contains(layer.getOutputFile())) {
-            throw new IllegalArgumentException("Layer '" + layer.getName() + "' is already assigned to binary '" + getName() + "'");
-        }
+        addLayerName(layer.getName());
         getLayerFiles().from(layer.getOutputFile());
     }
 
     @Override
     public void useLayer(Provider<? extends NativeImageLayer> layer) {
         // Provider-backed layer consumption preserves the typed, lazy extension surface. §FS-plugin-model.2.
+        getLayerNames().add(layer.map(NativeImageLayer::getName));
         getLayerFiles().from(layer.flatMap(NativeImageLayer::getOutputFile));
     }
 
     @Override
+    public NativeImageLayer getLayer() {
+        return assignedLayer;
+    }
+
+    @Override
     public void setLayer(NativeImageLayer layer) {
-        useLayer(layer);
+        // Singular property assignment replaces any prior layer selection. §FS-plugin-model.2.
+        assignedLayer = layer;
+        getLayerNames().set(List.of(layer.getName()));
+        getLayerFiles().setFrom(layer.getOutputFile());
+    }
+
+    private void addLayerName(String layerName) {
+        if (getLayerNames().getOrElse(List.of()).contains(layerName)) {
+            throw new IllegalArgumentException("Layer '" + layerName + "' is already assigned to binary '" + getName() + "'");
+        }
+        assignedLayer = null;
+        getLayerNames().add(layerName);
     }
 
     @Override

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -93,6 +93,7 @@ import static org.graalvm.buildtools.gradle.NativeImagePlugin.compileTaskNameFor
 public abstract class BaseNativeImageOptions implements NativeImageOptions {
     private static final GraalVMLogger LOGGER = GraalVMLogger.of(Logging.getLogger(BaseNativeImageOptions.class));
     private final DomainObjectSet<LayerOptions> layers;
+    private final ConfigurableFileCollection layerCompatibilityClasspath;
     private NativeImageLayer assignedLayer;
 
     private final String name;
@@ -289,6 +290,8 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         pgoProfileDir.convention(layout.getProjectDirectory().dir("src/pgo-profiles/" + name));
         getPgoProfilesDirectory().convention(pgoProfileDir.map(d -> d.getAsFile().exists() ? d : null));
         this.layers = objectFactory.domainObjectSet(LayerOptions.class);
+        this.layerCompatibilityClasspath = objectFactory.fileCollection();
+        getClasspath().from(layerCompatibilityClasspath);
         this.tasks = tasks;
         this.objects = objectFactory;
         this.providers = providers;
@@ -456,7 +459,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         // Typed layer consumption records the producing layer output on the binary. §FS-plugin-model.2.
         addLayerName(layer.getName());
         getLayerFiles().from(layer.getOutputFile());
-        getClasspath().from(layer.getCompatibilityClasspath());
+        layerCompatibilityClasspath.from(layer.getCompatibilityClasspath());
     }
 
     @Override
@@ -464,7 +467,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         // Provider-backed layer consumption preserves the typed, lazy extension surface. §FS-plugin-model.2.
         getLayerNames().add(layer.map(NativeImageLayer::getName));
         getLayerFiles().from(layer.flatMap(NativeImageLayer::getOutputFile));
-        getClasspath().from(layer.map(NativeImageLayer::getCompatibilityClasspath));
+        layerCompatibilityClasspath.from(layer.map(NativeImageLayer::getCompatibilityClasspath));
     }
 
     @Override
@@ -474,7 +477,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         Provider<NativeImageLayer> layer = providers.provider(() -> namedLayers.getByName(name));
         addLayerName(name);
         getLayerFiles().from(layer.flatMap(NativeImageLayer::getOutputFile));
-        getClasspath().from(layer.map(NativeImageLayer::getCompatibilityClasspath));
+        layerCompatibilityClasspath.from(layer.map(NativeImageLayer::getCompatibilityClasspath));
     }
 
     @Override
@@ -488,7 +491,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         assignedLayer = layer;
         getLayerNames().set(List.of(layer.getName()));
         getLayerFiles().setFrom(layer.getOutputFile());
-        getClasspath().from(layer.getCompatibilityClasspath());
+        layerCompatibilityClasspath.setFrom(layer.getCompatibilityClasspath());
     }
 
     private void addLayerName(String layerName) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -50,8 +50,10 @@ import org.graalvm.buildtools.gradle.tasks.CreateLayerOptions;
 import org.graalvm.buildtools.gradle.tasks.LayerOptions;
 import org.graalvm.buildtools.gradle.tasks.UseLayerOptions;
 import org.graalvm.buildtools.utils.SharedConstants;
+import org.graalvm.buildtools.utils.NativeImageLayerArguments;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.ProjectLayout;
@@ -96,6 +98,8 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
     private final String name;
     private final transient TaskContainer tasks;
     private final ObjectFactory objects;
+    private final ProviderFactory providers;
+    private final NamedDomainObjectContainer<NativeImageLayer> namedLayers;
 
     @Override
     @Internal
@@ -262,6 +266,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
                                   ProviderFactory providers,
                                   JavaToolchainService toolchains,
                                   TaskContainer tasks,
+                                  NamedDomainObjectContainer<NativeImageLayer> namedLayers,
                                   String defaultImageName) {
         this.name = name;
         getDebug().convention(false);
@@ -286,6 +291,8 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         this.layers = objectFactory.domainObjectSet(LayerOptions.class);
         this.tasks = tasks;
         this.objects = objectFactory;
+        this.providers = providers;
+        this.namedLayers = namedLayers;
     }
 
     private static Provider<Boolean> property(ProviderFactory providers, String name) {
@@ -459,6 +466,15 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
     }
 
     @Override
+    public void usesLayer(String name) {
+        // Resolve the container only when Gradle queries the binary, allowing layers to be declared later. §FS-plugin-model.2.
+        NativeImageLayerArguments.validateLayerName(name);
+        Provider<NativeImageLayer> layer = providers.provider(() -> namedLayers.getByName(name));
+        addLayerName(name);
+        getLayerFiles().from(layer.flatMap(NativeImageLayer::getOutputFile));
+    }
+
+    @Override
     public NativeImageLayer getLayer() {
         return assignedLayer;
     }
@@ -488,6 +504,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
             throw new IllegalArgumentException("Binary name for a layer must start with 'lib'");
         }
         layer.getLayerName().convention(binaryName);
+        getImageName().set(binaryName);
         layer.getAll().convention(false);
         spec.execute(layer);
         getLayerCreate().set(layer);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -47,6 +47,7 @@ import org.codehaus.groovy.runtime.InvokerHelper;
 import org.graalvm.buildtools.gradle.NativeImagePlugin;
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
+import org.graalvm.buildtools.gradle.dsl.NativeImageLayer;
 import org.graalvm.buildtools.gradle.dsl.agent.AgentOptions;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
@@ -63,15 +64,18 @@ import java.util.function.Predicate;
 
 public abstract class DefaultGraalVmExtension implements GraalVMExtension {
     private final transient NamedDomainObjectContainer<NativeImageOptions> nativeImages;
+    private final transient NamedDomainObjectContainer<NativeImageLayer> layers;
     private final transient NativeImagePlugin plugin;
     private final transient Project project;
     private final Property<JavaLauncher> defaultJavaLauncher;
 
     @Inject
     public DefaultGraalVmExtension(NamedDomainObjectContainer<NativeImageOptions> nativeImages,
+                                   NamedDomainObjectContainer<NativeImageLayer> layers,
                                    NativeImagePlugin plugin,
                                    Project project) {
         this.nativeImages = nativeImages;
+        this.layers = layers;
         this.plugin = plugin;
         this.project = project;
         this.defaultJavaLauncher = project.getObjects().property(JavaLauncher.class);
@@ -110,6 +114,11 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
     @Override
     public NamedDomainObjectContainer<NativeImageOptions> getBinaries() {
         return nativeImages;
+    }
+
+    @Override
+    public NamedDomainObjectContainer<NativeImageLayer> getLayers() {
+        return layers;
     }
 
     @Override
@@ -160,6 +169,11 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
     @Override
     public void binaries(Action<? super NamedDomainObjectContainer<NativeImageOptions>> spec) {
         spec.execute(nativeImages);
+    }
+
+    @Override
+    public void layers(Action<? super NamedDomainObjectContainer<NativeImageLayer>> spec) {
+        spec.execute(layers);
     }
 
     @Override

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DelegatingCompileOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DelegatingCompileOptions.java
@@ -41,6 +41,7 @@
 package org.graalvm.buildtools.gradle.internal;
 
 import org.graalvm.buildtools.gradle.dsl.NativeImageCompileOptions;
+import org.graalvm.buildtools.gradle.dsl.NativeImageLayer;
 import org.graalvm.buildtools.gradle.dsl.NativeResourcesOptions;
 import org.graalvm.buildtools.gradle.dsl.agent.DeprecatedAgentOptions;
 import org.graalvm.buildtools.gradle.tasks.CreateLayerOptions;
@@ -52,6 +53,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.jvm.toolchain.JavaLauncher;
 
 import java.util.List;
@@ -182,13 +184,43 @@ public class DelegatingCompileOptions implements NativeImageCompileOptions {
     }
 
     @Override
+    public Property<CreateLayerOptions> getLayerCreate() {
+        // Forward layer-create inputs without changing their invocation semantics. §FS-native-invocation.3.
+        return options.getLayerCreate();
+    }
+
+    @Override
+    public ConfigurableFileCollection getLayerFiles() {
+        // Forward produced layer inputs without changing their lazy file semantics. §FS-native-invocation.3.
+        return options.getLayerFiles();
+    }
+
+    @Override
     public void layers(Action<? super DomainObjectSet<LayerOptions>> spec) {
         options.layers(spec);
     }
 
     @Override
     public void useLayer(String name) {
+        // Forward the deprecated compatibility adapter unchanged. §FS-plugin-model.2.
         options.useLayer(name);
+    }
+
+    @Override
+    public void useLayer(NativeImageLayer layer) {
+        // Forward typed layer consumption unchanged. §FS-plugin-model.2.
+        options.useLayer(layer);
+    }
+
+    @Override
+    public void useLayer(Provider<? extends NativeImageLayer> layer) {
+        // Forward provider-backed typed layer consumption unchanged. §FS-plugin-model.2.
+        options.useLayer(layer);
+    }
+
+    @Override
+    public void setLayer(NativeImageLayer layer) {
+        options.setLayer(layer);
     }
 
     @Override

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DelegatingCompileOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DelegatingCompileOptions.java
@@ -224,6 +224,11 @@ public class DelegatingCompileOptions implements NativeImageCompileOptions {
     }
 
     @Override
+    public void usesLayer(String name) {
+        options.usesLayer(name);
+    }
+
+    @Override
     public NativeImageLayer getLayer() {
         return options.getLayer();
     }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DelegatingCompileOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DelegatingCompileOptions.java
@@ -196,6 +196,11 @@ public class DelegatingCompileOptions implements NativeImageCompileOptions {
     }
 
     @Override
+    public ListProperty<String> getLayerNames() {
+        return options.getLayerNames();
+    }
+
+    @Override
     public void layers(Action<? super DomainObjectSet<LayerOptions>> spec) {
         options.layers(spec);
     }
@@ -216,6 +221,11 @@ public class DelegatingCompileOptions implements NativeImageCompileOptions {
     public void useLayer(Provider<? extends NativeImageLayer> layer) {
         // Forward provider-backed typed layer consumption unchanged. §FS-plugin-model.2.
         options.useLayer(layer);
+    }
+
+    @Override
+    public NativeImageLayer getLayer() {
+        return options.getLayer();
     }
 
     @Override

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -43,9 +43,9 @@ package org.graalvm.buildtools.gradle.internal;
 
 import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.tasks.CreateLayerOptions;
-import org.graalvm.buildtools.gradle.tasks.LayerOptions;
-import org.graalvm.buildtools.gradle.tasks.UseLayerOptions;
 import org.graalvm.buildtools.model.resources.NativeImageFlags;
+import org.graalvm.buildtools.utils.ArtifactSelection;
+import org.graalvm.buildtools.utils.NativeImageLayerArguments;
 import org.graalvm.buildtools.utils.NativeImageUtils;
 import org.gradle.api.Transformer;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -131,58 +131,40 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
     public List<String> asArguments() {
         NativeImageOptions options = getOptions().get();
         List<String> cliArgs = new ArrayList<>(20);
-        boolean hasLayers = !options.getLayers().isEmpty();
+        boolean hasLayers = options.getLayerCreate().isPresent() || !options.getLayerFiles().isEmpty();
         String layerCreateName = null;
         ConfigurableFileCollection jarsClasspath = null;
+        ConfigurableFileCollection layerClasspath = null;
         if (hasLayers) {
             LOGGER.warn("Experimental support for layered images enabled. DSL may change at any time.");
             cliArgs.add(NativeImageFlags.UNLOCK_EXPERIMENTAL_VMOPTIONS);
-            var layers = options.getLayers();
-            var arg = new StringBuilder();
-            for (LayerOptions layer : layers) {
-                if (arg.length() > 0) {
-                    arg.append(" ");
-                }
-                if (layer instanceof CreateLayerOptions) {
-                    var create = (CreateLayerOptions) layer;
-                    layerCreateName = layer.getLayerName().get();
-                    arg.append(NativeImageFlags.LAYER_CREATE + "=");
-                    arg.append(layerCreateName).append(".nil");
-                    var modules = create.getModules().get();
-                    jarsClasspath = create.getJars();
-                    boolean hasModules = !modules.isEmpty();
-                    boolean hasPackage = create.getPackages().isPresent() && !create.getPackages().get().isEmpty();
-                    boolean hasJars = !jarsClasspath.getFiles().isEmpty();
-                    if (hasModules || hasPackage || hasJars) {
-                        var packages = create.getPackages().get();
-                        arg.append(",");
-                        if (hasModules) {
-                            arg.append(modules.stream().map(m -> "module=" + m).collect(Collectors.joining(",")));
-                        }
-                        if (hasPackage) {
-                            if (hasModules) {
-                                arg.append(",");
-                            }
-                            arg.append(packages.stream().map(p -> "package=" + p).collect(Collectors.joining(",")));
-                        }
-                        if (hasJars) {
-                            if (hasModules || hasPackage) {
-                                arg.append(",");
-                            }
-                            arg.append(jarsClasspath.getFiles().stream().map(p -> "path=" + p).collect(Collectors.joining(",")));
-                        }
-                    }
-                } else {
-                    var layerUse = (UseLayerOptions) layer;
-                    arg.append(NativeImageFlags.LAYER_USE + "=");
-                    arg.append(layerUse.getLayerFile().getAsFile().get().getAbsolutePath());
-                }
+            if (options.getLayerCreate().isPresent()) {
+                CreateLayerOptions create = options.getLayerCreate().get();
+                layerCreateName = create.getLayerName().get();
+                jarsClasspath = create.getJars();
+                layerClasspath = create.getClasspath();
+                boolean all = create.getAll().getOrElse(false);
+                List<Path> selectedPaths = all
+                    ? List.of()
+                    : jarsClasspath.getFiles().stream().map(File::toPath).toList();
+                ArtifactSelection selection = new ArtifactSelection(
+                    all,
+                    create.getModules().getOrElse(List.of()),
+                    create.getPackages().getOrElse(List.of()),
+                    selectedPaths
+                );
+                cliArgs.add(NativeImageLayerArguments.renderLayerCreate(layerCreateName, selection));
             }
-            cliArgs.add(arg.toString());
+            for (File layerFile : options.getLayerFiles()) {
+                cliArgs.add(NativeImageLayerArguments.renderLayerUse(layerFile.toPath()));
+            }
         }
         cliArgs.addAll(options.getExcludeConfigArgs().get());
         String classpathString = buildClasspathString(options).trim();
-        if (jarsClasspath != null && !jarsClasspath.isEmpty()) {
+        if (layerClasspath != null && !layerClasspath.isEmpty()) {
+            cliArgs.add("-cp");
+            cliArgs.add(layerClasspath.getAsPath());
+        } else if (jarsClasspath != null && !jarsClasspath.isEmpty()) {
             // JAR-defined layers intentionally exclude the binary classpath from the layer build. §FS-native-invocation.3.
             cliArgs.add("-cp");
             cliArgs.add(jarsClasspath.getAsPath());

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -188,9 +188,6 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         appendBooleanOption(cliArgs, options.getPgoInstrument(), NativeImageFlags.PGO_INSTRUMENT);
 
         String targetOutputPath = getExecutableName().get();
-        if (layerCreateName != null) {
-            targetOutputPath = layerCreateName;
-        }
         if (getOutputDirectory().isPresent()) {
             targetOutputPath = getOutputDirectory().get() + File.separator + targetOutputPath;
         }

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageCommandLineProvider.java
@@ -136,7 +136,6 @@ public class NativeImageCommandLineProvider implements CommandLineArgumentProvid
         ConfigurableFileCollection jarsClasspath = null;
         ConfigurableFileCollection layerClasspath = null;
         if (hasLayers) {
-            LOGGER.warn("Experimental support for layered images enabled. DSL may change at any time.");
             cliArgs.add(NativeImageFlags.UNLOCK_EXPERIMENTAL_VMOPTIONS);
             if (options.getLayerCreate().isPresent()) {
                 CreateLayerOptions create = options.getLayerCreate().get();

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -48,7 +48,6 @@ import org.graalvm.buildtools.gradle.internal.GraalVMLogger;
 import org.graalvm.buildtools.gradle.internal.NativeImageCommandLineProvider;
 import org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator;
 import org.graalvm.buildtools.utils.ArtifactSelection;
-import org.graalvm.buildtools.utils.NativeImageLayerArguments;
 import org.graalvm.buildtools.utils.NativeImageUtils;
 import org.graalvm.buildtools.utils.SchemaValidationUtils;
 import org.gradle.api.DefaultTask;

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -327,10 +327,12 @@ public abstract class BuildNativeImageTask extends DefaultTask {
             NativeImageUtils.checkVersion(options.getRequiredVersion().get(), versionString);
         }
         if (!options.getLayerFiles().isEmpty()
-                && NativeImageLayerArguments.isLayerConsumptionUnsupported(versionString)) {
+                && NativeImageLayerArguments.isLayerConsumptionUnsupported(versionString)
+                && !Boolean.getBoolean("org.graalvm.buildtools.layers.allowUnsupportedConsumption")) {
             throw new GradleException(
                 "Native Image 25.0.3 and 25.0.4 do not support reliable layer consumption. "
-                    + "Upgrade Native Image to a newer release or remove the configured layers.");
+                    + "Upgrade Native Image, remove the configured layers, or set "
+                    + "-Dorg.graalvm.buildtools.layers.allowUnsupportedConsumption=true to proceed at your own risk.");
         }
         int majorJDKVersion = NativeImageUtils.getMajorJDKVersion(versionString);
         boolean fallbackRemoved = NativeImageUtils.isGraalVMVersionAtLeast(versionString, 25, 1);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -213,11 +213,8 @@ public abstract class BuildNativeImageTask extends DefaultTask {
 
     @Internal
     public Provider<RegularFile> getCreatedLayerFile() {
-        return getOptions().zip(getOutputDirectory(), (options, dir) -> dir.file(options.getLayers().stream()
-            .filter(CreateLayerOptions.class::isInstance)
-            .map(cl -> cl.getLayerName().get() + ".nil")
-            .findFirst()
-            .orElseThrow()));
+        return getOptions().zip(getOutputDirectory(), (options, dir) ->
+            dir.file(options.getLayerCreate().get().getLayerName().get() + ".nil"));
     }
 
     @Internal

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -262,10 +262,10 @@ public abstract class BuildNativeImageTask extends DefaultTask {
     public BuildNativeImageTask() {
         DirectoryProperty buildDir = getProject().getLayout().getBuildDirectory();
         Provider<Directory> outputDir = buildDir.dir("native/" + getName());
-        getWorkingDirectory().set(outputDir);
         setDescription("Builds a native image.");
         setGroup(JavaBasePlugin.VERIFICATION_GROUP);
         getOutputDirectory().convention(outputDir);
+        getWorkingDirectory().set(getOutputDirectory());
         ProviderFactory providers = getProject().getProviders();
         this.diagnostics = new NativeImageExecutableLocator.Diagnostics();
         this.graalvmHomeProvider = graalvmHomeProvider(providers, diagnostics);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -326,14 +326,6 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         if (options.getRequiredVersion().isPresent()) {
             NativeImageUtils.checkVersion(options.getRequiredVersion().get(), versionString);
         }
-        if (!options.getLayerFiles().isEmpty()
-                && NativeImageLayerArguments.isLayerConsumptionUnsupported(versionString)
-                && !Boolean.getBoolean("org.graalvm.buildtools.layers.allowUnsupportedConsumption")) {
-            throw new GradleException(
-                "Native Image 25.0.3 and 25.0.4 do not support reliable layer consumption. "
-                    + "Upgrade Native Image, remove the configured layers, or set "
-                    + "-Dorg.graalvm.buildtools.layers.allowUnsupportedConsumption=true to proceed at your own risk.");
-        }
         int majorJDKVersion = NativeImageUtils.getMajorJDKVersion(versionString);
         boolean fallbackRemoved = NativeImageUtils.isGraalVMVersionAtLeast(versionString, 25, 1);
         List<String> args = buildActualCommandLineArgs(majorJDKVersion, fallbackRemoved);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -329,7 +329,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         if (!options.getLayerFiles().isEmpty()
                 && NativeImageLayerArguments.isLayerConsumptionUnsupported(versionString)) {
             throw new GradleException(
-                "Native Image 25.0.3 does not support reliable layer consumption. "
+                "Native Image 25.0.3 and 25.0.4 do not support reliable layer consumption. "
                     + "Upgrade Native Image to a newer release or remove the configured layers.");
         }
         int majorJDKVersion = NativeImageUtils.getMajorJDKVersion(versionString);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -325,6 +325,11 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         if (options.getRequiredVersion().isPresent()) {
             NativeImageUtils.checkVersion(options.getRequiredVersion().get(), versionString);
         }
+        if (NativeImageUtils.shouldWarnAboutUnsupportedLayerConsumption(
+                versionString, !options.getLayerFiles().isEmpty())) {
+            logger.warn("Layer consumption is supported on GraalVM 25.1 and later. Continuing on "
+                + "GraalVM 25.0.x is unsupported and at your own risk.");
+        }
         int majorJDKVersion = NativeImageUtils.getMajorJDKVersion(versionString);
         boolean fallbackRemoved = NativeImageUtils.isGraalVMVersionAtLeast(versionString, 25, 1);
         List<String> args = buildActualCommandLineArgs(majorJDKVersion, fallbackRemoved);

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTask.java
@@ -47,9 +47,12 @@ import org.graalvm.buildtools.gradle.dsl.NativeImageOptions;
 import org.graalvm.buildtools.gradle.internal.GraalVMLogger;
 import org.graalvm.buildtools.gradle.internal.NativeImageCommandLineProvider;
 import org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator;
+import org.graalvm.buildtools.utils.ArtifactSelection;
+import org.graalvm.buildtools.utils.NativeImageLayerArguments;
 import org.graalvm.buildtools.utils.NativeImageUtils;
 import org.graalvm.buildtools.utils.SchemaValidationUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
@@ -79,7 +82,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.graalvm.buildtools.gradle.internal.ConfigurationCacheSupport.serializableBiFunctionOf;
 import static org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator.graalvmHomeProvider;
@@ -302,6 +307,7 @@ public abstract class BuildNativeImageTask extends DefaultTask {
     @TaskAction
     public void exec() {
         NativeImageOptions options = getOptions().get();
+        validateLayerConfiguration(options);
         GraalVMLogger logger = GraalVMLogger.of(getLogger());
 
         File executablePath = NativeImageExecutableLocator.findNativeImageExecutable(
@@ -319,6 +325,12 @@ public abstract class BuildNativeImageTask extends DefaultTask {
         }
         if (options.getRequiredVersion().isPresent()) {
             NativeImageUtils.checkVersion(options.getRequiredVersion().get(), versionString);
+        }
+        if (!options.getLayerFiles().isEmpty()
+                && NativeImageLayerArguments.isLayerConsumptionUnsupported(versionString)) {
+            throw new GradleException(
+                "Native Image 25.0.3 does not support reliable layer consumption. "
+                    + "Upgrade Native Image to a newer release or remove the configured layers.");
         }
         int majorJDKVersion = NativeImageUtils.getMajorJDKVersion(versionString);
         boolean fallbackRemoved = NativeImageUtils.isGraalVMVersionAtLeast(versionString, 25, 1);
@@ -349,6 +361,28 @@ public abstract class BuildNativeImageTask extends DefaultTask {
                 spec.setExecutable(executable);
             });
             logger.lifecycle("Native Image written to: " + outputDir);
+        }
+    }
+
+    static void validateLayerConfiguration(NativeImageOptions options) {
+        List<String> layerNames = options.getLayerNames().getOrElse(List.of());
+        Set<String> distinctLayerNames = new HashSet<>(layerNames);
+        if (distinctLayerNames.size() != layerNames.size()) {
+            throw new GradleException("A Native Image layer is selected more than once: " + layerNames);
+        }
+        if (options.getLayerCreate().isPresent()) {
+            var create = options.getLayerCreate().get();
+            ArtifactSelection selection = new ArtifactSelection(
+                create.getAll().getOrElse(false),
+                create.getModules().getOrElse(List.of()),
+                create.getPackages().getOrElse(List.of()),
+                create.getJars().getFiles().stream().map(File::toPath).toList()
+            );
+            if (selection.isEmpty()) {
+                throw new GradleException(
+                    "Layer '" + create.getLayerName().get() + "' has no contents; configure all, modules, "
+                        + "packages, from, fromConfiguration, or dependencies.");
+            }
         }
     }
 

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CreateLayerOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/CreateLayerOptions.java
@@ -42,6 +42,7 @@ package org.graalvm.buildtools.gradle.tasks;
 
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
@@ -50,6 +51,13 @@ import org.gradle.api.tasks.Optional;
  * Layer creation options.
  */
 public interface CreateLayerOptions extends LayerOptions {
+    /**
+     * Selects every class available on the layer task classpath. §FS-native-invocation.3.
+     * @return whether all contents are selected
+     */
+    @Input
+    Property<Boolean> getAll();
+
     /**
      * The list of packages to include in the layer.
      * @return the package list (can be empty)
@@ -66,6 +74,15 @@ public interface CreateLayerOptions extends LayerOptions {
     @Classpath
     @Optional
     ConfigurableFileCollection getJars();
+
+    /**
+     * Classpath used to supply selected packages or all artifacts without adding path selectors.
+     * §FS-native-invocation.3.
+     * @return the invocation classpath
+     */
+    @Classpath
+    @Optional
+    ConfigurableFileCollection getClasspath();
 
     /**
      * Module names to include in the package. For a base layer,

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/GenerateNativeImageLauncherTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/GenerateNativeImageLauncherTask.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Generates a distribution launcher that configures the native layer loader path. §FS-plugin-model.2.
+ */
+public abstract class GenerateNativeImageLauncherTask extends DefaultTask {
+    @Input
+    public abstract Property<String> getExecutableName();
+
+    @Input
+    public abstract Property<String> getLauncherName();
+
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDirectory();
+
+    @TaskAction
+    public void generate() throws IOException {
+        Path output = getOutputDirectory().get().getAsFile().toPath();
+        Files.createDirectories(output);
+        if (System.getProperty("os.name", "").startsWith("Windows")) {
+            Path launcher = output.resolve(getLauncherName().get() + ".bat");
+            Files.writeString(launcher, windowsLauncher());
+        } else {
+            Path launcher = output.resolve(getLauncherName().get());
+            Files.writeString(launcher, unixLauncher());
+            launcher.toFile().setExecutable(true, false);
+        }
+    }
+
+    private String unixLauncher() {
+        String variable = System.getProperty("os.name", "").startsWith("Mac")
+            ? "DYLD_LIBRARY_PATH" : "LD_LIBRARY_PATH";
+        return "#!/bin/sh\n"
+            + "APP_HOME=$(CDPATH= cd -- \"$(dirname -- \"$0\")/..\" && pwd)\n"
+            + "for layer_dir in \"$APP_HOME\"/lib/native-layers/*; do\n"
+            + "  [ -d \"$layer_dir\" ] || continue\n"
+            + "  " + variable + "=\"$layer_dir${" + variable + ":+:$" + variable + "}\"\n"
+            + "done\n"
+            + "export " + variable + "\n"
+            + "exec \"$APP_HOME/lib/native/" + getExecutableName().get() + "\" \"$@\"\n";
+    }
+
+    private String windowsLauncher() {
+        return "@echo off\r\n"
+            + "set \"APP_HOME=%~dp0..\"\r\n"
+            + "for /D %%D in (\"%APP_HOME%\\lib\\native-layers\\*\") do set \"PATH=%%~fD;%PATH%\"\r\n"
+            + "\"%APP_HOME%\\lib\\native\\" + getExecutableName().get() + "\" %*\r\n";
+    }
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/StageNativeImageLayerRuntimeFilesTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/StageNativeImageLayerRuntimeFilesTask.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.tasks;
+
+import org.graalvm.buildtools.utils.NativeImageLayerRuntime;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Stages selected layer runtime libraries in a packaging-friendly directory. §FS-plugin-model.2.
+ */
+@CacheableTask
+public abstract class StageNativeImageLayerRuntimeFilesTask extends DefaultTask {
+    @Internal
+    public abstract ConfigurableFileCollection getLayerFiles();
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getLayerDirectories();
+
+    @OutputDirectory
+    public abstract DirectoryProperty getDestinationDirectory();
+
+    @Inject
+    protected abstract FileSystemOperations getFileSystemOperations();
+
+    @TaskAction
+    public void stage() {
+        File destination = getDestinationDirectory().get().getAsFile();
+        getFileSystemOperations().delete(spec -> spec.delete(destination));
+        Set<String> stagedNames = new HashSet<>();
+        for (File layerFile : getLayerFiles()) {
+            String fileName = layerFile.getName();
+            String layerName = fileName.endsWith(".nil")
+                ? fileName.substring(0, fileName.length() - ".nil".length())
+                : fileName;
+            if (!stagedNames.add(layerName)) {
+                throw new GradleException("Multiple selected layers would use the runtime directory '" + layerName + "'");
+            }
+            File sourceDirectory = layerFile.getParentFile();
+            File layerDestination = new File(destination, layerName);
+            getFileSystemOperations().copy(spec -> {
+                spec.from(sourceDirectory);
+                spec.into(layerDestination);
+                spec.setIncludeEmptyDirs(false);
+                spec.eachFile(details -> {
+                    if (!NativeImageLayerRuntime.isRuntimeLibrary(details.getName())) {
+                        details.exclude();
+                    }
+                });
+            });
+        }
+    }
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/ValidateNativeImageLayerSelectionTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/ValidateNativeImageLayerSelectionTask.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Validates logical layer selections before their producers can execute. §FS-plugin-model.2.
+ */
+public abstract class ValidateNativeImageLayerSelectionTask extends DefaultTask {
+    @Input
+    public abstract Property<String> getBinaryName();
+
+    @Input
+    public abstract ListProperty<String> getLayerNames();
+
+    @TaskAction
+    public void validate() {
+        List<String> layerNames = getLayerNames().getOrElse(List.of());
+        Set<String> distinctLayerNames = new HashSet<>(layerNames);
+        if (distinctLayerNames.size() != layerNames.size()) {
+            throw new GradleException("Native Image binary '" + getBinaryName().get()
+                + "' selects a layer more than once: " + layerNames);
+        }
+    }
+}

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/ValidateNativeImageLayerSelectionTask.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/tasks/ValidateNativeImageLayerSelectionTask.java
@@ -1,18 +1,33 @@
 /*
  * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
  *
  * Subject to the condition set forth below, permission is hereby granted to any
- * person obtaining a copy of this software and associated documentation files
- * (the "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to permit
- * persons to whom the Software is furnished to do so, subject to the following
- * conditions:
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
  *
- * The above copyright notice and either this complete permission notice or at
- * a minimum a reference to the UPL must be included in all copies or substantial
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
  * portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -20,8 +35,8 @@
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 package org.graalvm.buildtools.gradle.tasks;
 

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -134,6 +134,71 @@ class NativeImagePluginTest extends Specification {
         extension.binaries.main.layerFiles.files == [second.outputFile.get().asFile] as Set
     }
 
+    def "name based layer selection is independent of declaration order"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+
+        when:
+        extension.binaries.main.usesLayer("dependencies")
+        def layer = extension.layers.create("dependencies")
+        layer.contents.modules("java.base")
+
+        then:
+        extension.binaries.main.layerNames.get() == ["dependencies"]
+        extension.binaries.main.layerFiles.files == [layer.outputFile.get().asFile] as Set
+    }
+
+    def "named layers can consume other named layers independent of declaration order"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+
+        when:
+        def framework = extension.layers.create("framework")
+        framework.usesLayer("base")
+        framework.contents.packages("com.example.framework")
+        def base = extension.layers.create("base")
+        base.contents.modules("java.base")
+
+        then:
+        framework.useLayerNames.get() == ["base"]
+        framework.useLayerFiles.files == [base.outputFile.get().asFile] as Set
+
+        and:
+        def frameworkTask = project.tasks.named("nativeFrameworkLayer").get()
+        frameworkTask.options.get().layerNames.get() == ["base"]
+        frameworkTask.options.get().layerFiles.files == [base.outputFile.get().asFile] as Set
+    }
+
+    def "duplicate layer chaining fails during configuration"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def framework = extension.layers.create("framework")
+
+        when:
+        framework.usesLayer("base")
+        framework.usesLayer("base")
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("selected more than once")
+    }
+
+    def "invalid layer names fail when declared"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+
+        when:
+        extension.layers.create("my,base layer")
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("letters, digits, dots, underscores, or hyphens")
+    }
+
     def "provider layer selections preserve names for duplicate validation"() {
         given:
         project.plugins.apply("java")

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -3,6 +3,7 @@ package org.graalvm.buildtools.gradle
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension
 import org.graalvm.buildtools.gradle.dsl.GraalVMReachabilityMetadataRepositoryExtension
 import org.graalvm.buildtools.gradle.dsl.NativeImageCompileOptions
+import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
@@ -13,6 +14,7 @@ import java.util.regex.Pattern
 
 import static org.graalvm.buildtools.VersionInfo.METADATA_REPO_VERSION
 
+// Verifies the durable Gradle extension and task model. §FS-plugin-model.2 §FS-native-tasks.1.
 class NativeImagePluginTest extends Specification {
 
     private static final String DEFAULT_GITHUB_RELEASES_METADATA_URI = "https://github.com/oracle/graalvm-reachability-metadata/releases/download/${METADATA_REPO_VERSION}/graalvm-reachability-metadata-${METADATA_REPO_VERSION}.zip"
@@ -91,6 +93,25 @@ class NativeImagePluginTest extends Specification {
         taskDescription("nativeTest") == "Runs the test native binary."
         taskDescription("nativeTestBuild") == "Deprecated alias for nativeTestCompile."
         taskDescription("generateTestResourcesConfigFile") == "Scans resources and generates a resource-config.json file for the test binary."
+    }
+
+    def "named layers own dedicated tasks and can be assigned to binaries"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+
+        when:
+        def layer = extension.layers.create("dependencies")
+        layer.contents.modules("java.base")
+        extension.binaries.main.layer = layer
+        def task = project.tasks.getByName("nativeDependenciesLayer") as BuildNativeImageTask
+
+        then:
+        task.description == "Builds the dependencies Native Image layer."
+        task.options.get().layerCreate.get().layerName.get() == "dependencies"
+        task.options.get().layerCreate.get().modules.get() == ["java.base"]
+        task.outputDirectory.get().asFile == project.layout.buildDirectory.dir("native/layers/dependencies").get().asFile
+        extension.binaries.main.layerFiles.files == [layer.outputFile.get().asFile] as Set
     }
 
     // Protects custom binary classpath wiring and exclusion args. §FS-plugin-model.4

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -112,6 +112,59 @@ class NativeImagePluginTest extends Specification {
         task.options.get().layerCreate.get().modules.get() == ["java.base"]
         task.outputDirectory.get().asFile == project.layout.buildDirectory.dir("native/layers/dependencies").get().asFile
         extension.binaries.main.layerFiles.files == [layer.outputFile.get().asFile] as Set
+        extension.binaries.main.layer == layer
+    }
+
+    def "singular layer assignment replaces its previous value"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def first = extension.layers.create("first")
+        first.contents.modules("java.base")
+        def second = extension.layers.create("second")
+        second.contents.modules("java.logging")
+
+        when:
+        extension.binaries.main.layer = first
+        extension.binaries.main.layer = second
+
+        then:
+        extension.binaries.main.layer == second
+        extension.binaries.main.layerNames.get() == ["second"]
+        extension.binaries.main.layerFiles.files == [second.outputFile.get().asFile] as Set
+    }
+
+    def "provider layer selections preserve names for duplicate validation"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def layer = extension.layers.create("dependencies")
+        layer.contents.modules("java.base")
+
+        when:
+        extension.binaries.main.useLayer(layer)
+        extension.binaries.main.useLayer(project.provider { layer })
+
+        then:
+        extension.binaries.main.layerNames.get() == ["dependencies", "dependencies"]
+    }
+
+    def "layer configurations include project dependency artifacts"() {
+        given:
+        def root = ProjectBuilder.builder().withName("root").build()
+        def producer = ProjectBuilder.builder().withName("producer").withParent(root).build()
+        def consumer = ProjectBuilder.builder().withName("consumer").withParent(root).build()
+        producer.plugins.apply("java-library")
+        consumer.plugins.apply("java")
+        consumer.plugins.apply(NativeImagePlugin)
+        consumer.dependencies.add("implementation", consumer.dependencies.project(path: ":producer"))
+        def layer = consumer.extensions.getByType(GraalVMExtension).layers.create("dependencies")
+
+        when:
+        layer.contents.fromConfiguration(consumer.configurations.runtimeClasspath)
+
+        then:
+        layer.contents.files.buildDependencies.getDependencies(null).contains(producer.tasks.named("jar").get())
     }
 
     // Protects custom binary classpath wiring and exclusion args. §FS-plugin-model.4

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -113,6 +113,7 @@ class NativeImagePluginTest extends Specification {
         task.options.get().layerCreate.get().modules.get() == ["java.base"]
         task.outputDirectory.get().asFile == project.layout.buildDirectory.dir("native/layers/dependencies").get().asFile
         extension.binaries.main.layerFiles.files == [layer.outputFile.get().asFile] as Set
+        extension.binaries.main.classpath.files.containsAll(layer.compatibilityClasspath.files)
         extension.binaries.main.layer == layer
     }
 
@@ -170,6 +171,24 @@ class NativeImagePluginTest extends Specification {
         def frameworkTask = project.tasks.named("nativeFrameworkLayer").get()
         frameworkTask.options.get().layerNames.get() == ["base"]
         frameworkTask.options.get().layerFiles.files == [base.outputFile.get().asFile] as Set
+    }
+
+    def "layer consumers inherit the producer compatibility classpath"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def producerClasspath = project.file("producer.jar")
+
+        when:
+        def base = extension.layers.create("base")
+        base.contents.from(producerClasspath)
+        def framework = extension.layers.create("framework")
+        framework.usesLayer("base")
+        extension.binaries.main.usesLayer("framework")
+
+        then:
+        framework.inheritedCompatibilityClasspath.files == [producerClasspath] as Set
+        extension.binaries.main.classpath.files.contains(producerClasspath)
     }
 
     def "duplicate layer chaining fails during configuration"() {

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/NativeImagePluginTest.groovy
@@ -4,6 +4,7 @@ import org.graalvm.buildtools.gradle.dsl.GraalVMExtension
 import org.graalvm.buildtools.gradle.dsl.GraalVMReachabilityMetadataRepositoryExtension
 import org.graalvm.buildtools.gradle.dsl.NativeImageCompileOptions
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
+import org.graalvm.buildtools.gradle.tasks.ValidateNativeImageLayerSelectionTask
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
@@ -212,6 +213,24 @@ class NativeImagePluginTest extends Specification {
 
         then:
         extension.binaries.main.layerNames.get() == ["dependencies", "dependencies"]
+    }
+
+    def "provider layer selections use a pre-producer validation task"() {
+        given:
+        project.plugins.apply("java")
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def layer = extension.layers.create("dependencies")
+        layer.contents.modules("java.base")
+
+        when:
+        extension.binaries.main.useLayer(layer)
+        extension.binaries.main.useLayer(project.provider { layer })
+        def validation = project.tasks.getByName("validateNativeCompileLayerSelection") as ValidateNativeImageLayerSelectionTask
+
+        then:
+        validation.binaryName.get() == "main"
+        validation.layerNames.get() == ["dependencies", "dependencies"]
+        project.tasks.getByName("nativeCompile").taskDependencies.getDependencies(null).contains(validation)
     }
 
     def "layer configurations include project dependency artifacts"() {

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/StageNativeImageLayerRuntimeFilesTaskTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/StageNativeImageLayerRuntimeFilesTaskTest.groovy
@@ -1,0 +1,41 @@
+package org.graalvm.buildtools.gradle
+
+import org.graalvm.buildtools.gradle.tasks.StageNativeImageLayerRuntimeFilesTask
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Path
+
+// Runtime staging keeps selected layers isolated for deployment. §FS-plugin-model.2.
+class StageNativeImageLayerRuntimeFilesTaskTest extends Specification {
+    @TempDir
+    Path temporaryDirectory
+
+    def "stages every runtime library without overwriting files from another layer"() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(temporaryDirectory.toFile()).build()
+        def first = layer("first", "same.so", "first")
+        def second = layer("second", "same.so", "second")
+        def task = project.tasks.create("stageLayers", StageNativeImageLayerRuntimeFilesTask)
+        task.layerFiles.from(first.resolve("first.nil"), second.resolve("second.nil"))
+        task.layerDirectories.from(first, second)
+        task.destinationDirectory.set(project.layout.buildDirectory.dir("staged"))
+
+        when:
+        task.stage()
+
+        then:
+        project.file("build/staged/first/same.so").text == "first"
+        project.file("build/staged/second/same.so").text == "second"
+        !project.file("build/staged/first/first.nil").exists()
+    }
+
+    private Path layer(String name, String runtimeName, String contents) {
+        def directory = temporaryDirectory.resolve(name)
+        directory.toFile().mkdirs()
+        directory.resolve("${name}.nil").toFile().text = "nil"
+        directory.resolve(runtimeName).toFile().text = contents
+        directory
+    }
+}

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTaskTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/BuildNativeImageTaskTest.groovy
@@ -38,51 +38,50 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.graalvm.buildtools.utils;
+package org.graalvm.buildtools.gradle.tasks
 
-import org.graalvm.buildtools.model.resources.NativeImageFlags;
+import org.graalvm.buildtools.gradle.NativeImagePlugin
+import org.graalvm.buildtools.gradle.dsl.GraalVMExtension
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
 
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.regex.Pattern;
+// Protects layer preflight validation before Native Image invocation. §FS-native-invocation.3.
+class BuildNativeImageTaskTest extends Specification {
+    def "rejects an empty named layer"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+        project.plugins.apply("java")
+        project.plugins.apply(NativeImagePlugin)
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def layer = extension.layers.create("empty")
+        def task = project.tasks.getByName("nativeEmptyLayer") as BuildNativeImageTask
 
-/**
- * Shared rendering of Native Image layer arguments. §FS-common-libraries.1.
- */
-public final class NativeImageLayerArguments {
-    private static final Pattern NATIVE_IMAGE_25_0_3 = Pattern.compile("(?m)^native-image\\s+25\\.0\\.3(?:\\s|$)");
+        when:
+        BuildNativeImageTask.validateLayerConfiguration(task.options.get())
 
-    private NativeImageLayerArguments() {
+        then:
+        def e = thrown(GradleException)
+        e.message.contains("Layer 'empty' has no contents")
     }
 
-    public static String renderLayerCreate(String layerName, ArtifactSelection selection) {
-        validateLayerName(layerName);
-        Objects.requireNonNull(selection, "selection");
-        if (selection.isEmpty()) {
-            throw new IllegalArgumentException("Layer '" + layerName + "' has no contents");
-        }
-        List<String> selectors = new ArrayList<>();
-        selection.getModules().forEach(module -> selectors.add("module=" + module));
-        selection.getPackages().forEach(packageName -> selectors.add("package=" + packageName));
-        selection.getPaths().forEach(path -> selectors.add("path=" + path));
-        String argument = NativeImageFlags.LAYER_CREATE + "=" + layerName + ".nil";
-        return selectors.isEmpty() ? argument : argument + "," + String.join(",", selectors);
-    }
+    def "rejects duplicate provider-backed layer selections"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+        project.plugins.apply("java")
+        project.plugins.apply(NativeImagePlugin)
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def layer = extension.layers.create("dependencies")
+        layer.contents.modules("java.base")
+        def binary = extension.binaries.main
+        binary.useLayer(project.provider { layer })
+        binary.useLayer(project.provider { layer })
 
-    public static String renderLayerUse(Path layerFile) {
-        Objects.requireNonNull(layerFile, "layerFile");
-        return NativeImageFlags.LAYER_USE + "=" + layerFile.toAbsolutePath();
-    }
+        when:
+        BuildNativeImageTask.validateLayerConfiguration(binary)
 
-    public static boolean isLayerConsumptionUnsupported(String versionInformation) {
-        return NATIVE_IMAGE_25_0_3.matcher(Objects.requireNonNull(versionInformation, "versionInformation")).find();
-    }
-
-    private static void validateLayerName(String layerName) {
-        if (layerName == null || layerName.isBlank()) {
-            throw new IllegalArgumentException("Layer name must not be blank");
-        }
+        then:
+        def e = thrown(GradleException)
+        e.message.contains("A Native Image layer is selected more than once")
     }
 }

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -335,6 +335,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
         producerArgs.any {
             it.startsWith("${NativeImageFlags.LAYER_CREATE}=liblegacy.nil") && it.contains("module=java.base")
         }
+        producerArgs[producerArgs.indexOf("-o") + 1].endsWith(File.separator + "liblegacy")
         consumerArgs.contains("${NativeImageFlags.LAYER_USE}=${layerFile.absolutePath}".toString())
     }
 

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -296,6 +296,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
                 project.objects.fileProperty(),
                 project.provider { false },
                 project.provider { 25 },
+                project.provider { false },
                 project.provider { false }
         ).asArguments()
 
@@ -418,6 +419,7 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
                 project.objects.fileProperty(),
                 project.provider { false },
                 project.provider { 25 },
+                project.provider { false },
                 project.provider { false }
         ).asArguments()
     }

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -250,6 +250,70 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
         args.contains("-cp")
         args.contains(appJar.absolutePath)
     }
+
+    def "renders typed layer files through the shared layer argument utility"() {
+        given:
+        def project = newProject()
+        project.plugins.apply(ApplicationPlugin)
+        project.plugins.apply(NativeImagePlugin)
+        def layerFile = testDirectory.resolve("base.nil").toFile()
+        layerFile.text = "layer"
+        def options = project.extensions.getByType(GraalVMExtension).binaries.getByName("main")
+        options.layerFiles.from(layerFile)
+        options.excludeConfigArgs.set([])
+        options.configurationFileDirectories.setFrom([])
+
+        when:
+        def args = new NativeImageCommandLineProvider(
+                project.provider { options },
+                project.provider { "main" },
+                project.provider { testDirectory.toString() },
+                project.provider { testDirectory.toString() },
+                project.objects.fileProperty(),
+                project.provider { false },
+                project.provider { 25 },
+                project.provider { false }
+        ).asArguments()
+
+        then:
+        args.contains(NativeImageFlags.UNLOCK_EXPERIMENTAL_VMOPTIONS)
+        args.contains("${NativeImageFlags.LAYER_USE}=${layerFile.absolutePath}".toString())
+    }
+
+    // Retains the deprecated binary-scoped layer producer and string consumer as a working adapter. §FS-native-invocation.3.
+    def "legacy layer adapters wire producer and consumer and render layer arguments"() {
+        given:
+        def project = newProject()
+        project.plugins.apply(ApplicationPlugin)
+        project.plugins.apply(NativeImagePlugin)
+        def extension = project.extensions.getByType(GraalVMExtension)
+        def producer = extension.binaries.create("liblegacy")
+        producer.createLayer {
+            it.modules.add("java.base")
+        }
+        producer.excludeConfigArgs.set([])
+        producer.configurationFileDirectories.setFrom([])
+        def consumer = extension.binaries.getByName("main")
+        consumer.useLayer("liblegacy")
+        consumer.excludeConfigArgs.set([])
+        consumer.configurationFileDirectories.setFrom([])
+        def producerTask = project.tasks.getByName("nativeLiblegacyCompile") as BuildNativeImageTask
+        def consumerTask = project.tasks.getByName("nativeCompile") as BuildNativeImageTask
+        def layerFile = producerTask.createdLayerFile.get().asFile
+
+        when:
+        def producerArgs = commandLineArguments(project, producer, "liblegacy")
+        def consumerArgs = commandLineArguments(project, consumer, "main")
+
+        then:
+        consumer.layerFiles.files == [layerFile] as Set
+        consumerTask.taskDependencies.getDependencies(consumerTask).contains(producerTask)
+        producerArgs.any {
+            it.startsWith("${NativeImageFlags.LAYER_CREATE}=liblegacy.nil") && it.contains("module=java.base")
+        }
+        consumerArgs.contains("${NativeImageFlags.LAYER_USE}=${layerFile.absolutePath}".toString())
+    }
+
     // Plain Gradle consoles disable Native Image colors with version-appropriate arguments. §FS-native-invocation.3
     @Issue("https://github.com/graalvm/native-build-tools/issues/366")
     def "disables colorful Native Image output for Gradle's plain console with JDK #nativeImageVersion"() {
@@ -318,5 +382,18 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
         nativeImageVersion | enabledColorArgument
         17                 | NativeImageFlags.BUILD_OUTPUT_COLORFUL
         21                 | "--color=always"
+    }
+
+    private List<String> commandLineArguments(project, options, String imageName) {
+        new NativeImageCommandLineProvider(
+                project.provider { options },
+                project.provider { imageName },
+                project.provider { testDirectory.toString() },
+                project.provider { testDirectory.toString() },
+                project.objects.fileProperty(),
+                project.provider { false },
+                project.provider { 25 },
+                project.provider { false }
+        ).asArguments()
     }
 }

--- a/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
+++ b/native-gradle-plugin/src/test/groovy/org/graalvm/buildtools/gradle/tasks/NativeImageCommandLineProviderTest.groovy
@@ -251,6 +251,30 @@ class NativeImageCommandLineProviderTest extends AbstractPluginTest {
         args.contains(appJar.absolutePath)
     }
 
+    // Keeps the logical bundle name separate from the native shared-library image name. §FS-native-tasks.1.
+    def "layer-create build preserves its native library output name"() {
+        given:
+        def project = newProject()
+        project.plugins.apply(ApplicationPlugin)
+        project.plugins.apply(NativeImagePlugin)
+        def options = project.extensions.getByType(GraalVMExtension).binaries.create("libdependencies")
+        options.createLayer {
+            it.layerName.set("dependencies")
+            it.modules.add("java.base")
+        }
+        options.excludeConfigArgs.set([])
+        options.configurationFileDirectories.setFrom([])
+
+        when:
+        def args = commandLineArguments(project, options, "libdependencies")
+        def outputOption = args.indexOf("-o")
+
+        then:
+        args.any { it.startsWith("${NativeImageFlags.LAYER_CREATE}=dependencies.nil") }
+        outputOption >= 0
+        args[outputOption + 1] == testDirectory.resolve("libdependencies").toString()
+    }
+
     def "renders typed layer files through the shared layer argument utility"() {
         given:
         def project = newProject()

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/AbstractFunctionalTest.groovy
@@ -168,6 +168,11 @@ abstract class AbstractFunctionalTest extends Specification {
                 binaries.all {
                     buildArgs.add("-Ob")
                 }
+                // Layer-sensitive Native Image options must match between producers and consumers.
+                // §FS-native-invocation.3.
+                layers.all {
+                    buildArgs.add("-Ob")
+                }
             }
             """.stripIndent()
         }

--- a/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/GraalVMSupport.groovy
+++ b/native-gradle-plugin/src/testFixtures/groovy/org/graalvm/buildtools/gradle/fixtures/GraalVMSupport.groovy
@@ -68,7 +68,7 @@ class GraalVMSupport {
         String command = getSystemBasedCommand(location);
         def proc = command.execute()
         proc.consumeProcessOutput(sout, serr)
-        proc.waitForOrKill(1000)
+        proc.waitForOrKill(10_000)
         assert serr.toString().isEmpty()
 
         return sout.toString()

--- a/native-maven-plugin/docs/architecture.md
+++ b/native-maven-plugin/docs/architecture.md
@@ -32,6 +32,11 @@ delegate to the current compile implementation. `NativeTestMojo` specializes the
 for test classpaths, JUnit dependencies, launcher selection, test identifier handling, and native
 test execution.
 
+`LayerCreateMojo` specializes the same invocation infrastructure for a single named layer and
+attaches the resulting `.nil` file. The lifecycle extension registers the `nil` artifact handler
+and keeps layer artifacts outside Java classpath assembly.
+[§FS-goal-surface.6](functional/goal-surface.md#6-layer-creation).
+
 Resource generation, dynamic access metadata, reachability metadata addition, merge-agent-files,
 metadata-copy, missing metadata listing, and write-args-file each get dedicated mojos. They should
 reuse common utility classes rather than duplicating Native Image metadata logic.

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -90,8 +90,9 @@ consumes the layer, executes, and produces the expected output. This protects [Â
 [Â§FS-config-model.7](functional/configuration-model.md#7-layer-configuration).
 The class is the executable evidence for module, package, explicit-path, and `all` selection,
 main, native-test, shared-library, and chained layer consumption.
-The `all`-selector and explicit-path layer-consumption scenarios are skipped on GraalVM 25.0.x
-because its image-heap scanner can fail after `-H:LayerUse` loads a valid layer.
+Layer-consumption scenarios that exercise explicit paths, native tests, shared libraries, or
+chained layers are skipped on GraalVM 25.0.x because Native Image can fail after `-H:LayerUse`
+loads a valid layer.
 
 When adding behavior that a user can observe through a Maven goal, plugin parameter, generated
 file, lifecycle binding, or Native Image invocation, add or update a functional test in the

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -81,6 +81,15 @@ with `reproducers/issue-144`, and `issues/ModuleWithoutSourcesFunctionalTest` wi
 issue reproducers, and local repository seeding. This protects [§FS-native-builds.6](functional/native-image-builds.md#6-base-sbom),
 [§FS-config-model.3](functional/configuration-model.md#3-parent-pom-merging), and [§AR-maven-plugin.6](architecture.md#6-functional-test-infrastructure).
 
+### 3.8 Layer artifacts
+
+`LayeredApplicationFunctionalTest` verifies that a reactor producer creates and attaches a `nil`
+layer artifact, a consumer resolves it outside the Java classpath, and a supported Native Image
+release builds the consuming application. It also verifies the actionable compatibility rejection
+for Native Image 25.0.3. This protects [§FS-goal-surface.6](functional/goal-surface.md#6-layer-creation),
+[§FS-native-builds.3](functional/native-image-builds.md#3-classpath-and-scopes), and
+[§FS-config-model.7](functional/configuration-model.md#7-layer-configuration).
+
 When adding behavior that a user can observe through a Maven goal, plugin parameter, generated
 file, lifecycle binding, or Native Image invocation, add or update a functional test in the
 closest scenario family.

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -88,6 +88,8 @@ layer artifact, a consumer resolves it outside the Java classpath, and the appli
 consumes the layer, executes, and produces the expected output. This protects [§FS-goal-surface.6](functional/goal-surface.md#6-layer-creation),
 [§FS-native-builds.3](functional/native-image-builds.md#3-classpath-and-scopes), and
 [§FS-config-model.7](functional/configuration-model.md#7-layer-configuration).
+The class is the executable evidence for module, package, explicit-path, and `all` selection,
+main, native-test, shared-library, and chained layer consumption.
 
 When adding behavior that a user can observe through a Maven goal, plugin parameter, generated
 file, lifecycle binding, or Native Image invocation, add or update a functional test in the

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -86,7 +86,7 @@ issue reproducers, and local repository seeding. This protects [§FS-native-buil
 `LayeredApplicationFunctionalTest` verifies that a reactor producer creates and attaches a `nil`
 layer artifact, a consumer resolves it outside the Java classpath, and a supported Native Image
 release builds and runs the consuming application with the expected output. It also verifies the
-actionable compatibility rejection for Native Image 25.0.3. This protects [§FS-goal-surface.6](functional/goal-surface.md#6-layer-creation),
+actionable compatibility rejection for affected Native Image 25.0 releases. This protects [§FS-goal-surface.6](functional/goal-surface.md#6-layer-creation),
 [§FS-native-builds.3](functional/native-image-builds.md#3-classpath-and-scopes), and
 [§FS-config-model.7](functional/configuration-model.md#7-layer-configuration).
 

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -90,8 +90,8 @@ consumes the layer, executes, and produces the expected output. This protects [Â
 [Â§FS-config-model.7](functional/configuration-model.md#7-layer-configuration).
 The class is the executable evidence for module, package, explicit-path, and `all` selection,
 main, native-test, shared-library, and chained layer consumption.
-The `all`-selector layer-consumption scenario is skipped on GraalVM 25.0.x because its image-heap
-scanner can fail after `-H:LayerUse` loads a valid layer.
+The `all`-selector and explicit-path layer-consumption scenarios are skipped on GraalVM 25.0.x
+because its image-heap scanner can fail after `-H:LayerUse` loads a valid layer.
 
 When adding behavior that a user can observe through a Maven goal, plugin parameter, generated
 file, lifecycle binding, or Native Image invocation, add or update a functional test in the

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -90,9 +90,9 @@ consumes the layer, executes, and produces the expected output. This protects [Â
 [Â§FS-config-model.7](functional/configuration-model.md#7-layer-configuration).
 The class is the executable evidence for module, package, explicit-path, and `all` selection,
 main, native-test, shared-library, and chained layer consumption.
-Layer-consumption scenarios that exercise explicit paths, native tests, shared libraries, or
-chained layers are skipped on GraalVM 25.0.x because Native Image can fail after `-H:LayerUse`
-loads a valid layer.
+Layer-consumption scenarios that exercise `all` selection, explicit paths, native tests, shared
+libraries, or chained layers are skipped on GraalVM 25.0.x because Native Image can fail after
+`-H:LayerUse` loads a valid layer.
 
 When adding behavior that a user can observe through a Maven goal, plugin parameter, generated
 file, lifecycle binding, or Native Image invocation, add or update a functional test in the

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -85,8 +85,8 @@ issue reproducers, and local repository seeding. This protects [§FS-native-buil
 
 `LayeredApplicationFunctionalTest` verifies that a reactor producer creates and attaches a `nil`
 layer artifact, a consumer resolves it outside the Java classpath, and a supported Native Image
-release builds the consuming application. It also verifies the actionable compatibility rejection
-for Native Image 25.0.3. This protects [§FS-goal-surface.6](functional/goal-surface.md#6-layer-creation),
+release builds and runs the consuming application with the expected output. It also verifies the
+actionable compatibility rejection for Native Image 25.0.3. This protects [§FS-goal-surface.6](functional/goal-surface.md#6-layer-creation),
 [§FS-native-builds.3](functional/native-image-builds.md#3-classpath-and-scopes), and
 [§FS-config-model.7](functional/configuration-model.md#7-layer-configuration).
 

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -90,6 +90,8 @@ consumes the layer, executes, and produces the expected output. This protects [Â
 [Â§FS-config-model.7](functional/configuration-model.md#7-layer-configuration).
 The class is the executable evidence for module, package, explicit-path, and `all` selection,
 main, native-test, shared-library, and chained layer consumption.
+The `all`-selector layer-consumption scenario is skipped on GraalVM 25.0.x because its image-heap
+scanner can fail after `-H:LayerUse` loads a valid layer.
 
 When adding behavior that a user can observe through a Maven goal, plugin parameter, generated
 file, lifecycle binding, or Native Image invocation, add or update a functional test in the

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -84,9 +84,8 @@ issue reproducers, and local repository seeding. This protects [§FS-native-buil
 ### 3.8 Layer artifacts
 
 `LayeredApplicationFunctionalTest` verifies that a reactor producer creates and attaches a `nil`
-layer artifact, a consumer resolves it outside the Java classpath, and a supported Native Image
-release builds and runs the consuming application with the expected output. It also verifies the
-actionable compatibility rejection for affected Native Image 25.0 releases. This protects [§FS-goal-surface.6](functional/goal-surface.md#6-layer-creation),
+layer artifact, a consumer resolves it outside the Java classpath, and the application image
+consumes the layer, executes, and produces the expected output. This protects [§FS-goal-surface.6](functional/goal-surface.md#6-layer-creation),
 [§FS-native-builds.3](functional/native-image-builds.md#3-classpath-and-scopes), and
 [§FS-config-model.7](functional/configuration-model.md#7-layer-configuration).
 

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -89,10 +89,10 @@ consumes the layer, executes, and produces the expected output. This protects [�
 [§FS-native-builds.3](functional/native-image-builds.md#3-classpath-and-scopes), and
 [§FS-config-model.7](functional/configuration-model.md#7-layer-configuration).
 The class is the executable evidence for module, package, explicit-path, and `all` selection,
-main, native-test, shared-library, and chained layer consumption.
+plus main, native-test, and shared-library layer consumption.
 Layer-consumption scenarios that exercise `all` selection, explicit paths, native tests, shared
-libraries, or chained layers are skipped on GraalVM 25.0.x because Native Image can fail after
-`-H:LayerUse` loads a valid layer.
+libraries are skipped on GraalVM 25.0.x because Native Image can fail after `-H:LayerUse` loads a
+valid layer.
 
 When adding behavior that a user can observe through a Maven goal, plugin parameter, generated
 file, lifecycle binding, or Native Image invocation, add or update a functional test in the

--- a/native-maven-plugin/docs/functional/configuration-model.md
+++ b/native-maven-plugin/docs/functional/configuration-model.md
@@ -54,3 +54,12 @@ Setting `<skip>true</skip>` in the native Maven plugin's root `<configuration>` 
 plugin goal before it resolves dependencies, downloads metadata, generates files, or otherwise
 causes a goal-specific side effect. When it is absent or false, each goal retains its existing
 specialized skip controls and behavior.
+
+## 7. Layer configuration
+
+A `layer-create` execution accepts one layer definition with a required name and neutral contents:
+`all`, module names, package names, explicit files, and selected `groupId:artifactId`
+dependencies with configurable transitivity. Normal compile goals accept `useLayers` entries that
+select project dependencies of type `nil` by coordinates. Missing, ambiguous, and duplicate
+selections fail before Native Image is invoked.
+[§root/REQ-backwards-compatibility.2](../../../docs/spec/requirements.md#2-configuration-compatibility).

--- a/native-maven-plugin/docs/functional/configuration-model.md
+++ b/native-maven-plugin/docs/functional/configuration-model.md
@@ -59,9 +59,13 @@ specialized skip controls and behavior.
 
 A `layer-create` execution accepts one layer definition with a required name and neutral contents:
 `all`, module names, package names, explicit files, and selected `groupId:artifactId[:version]`
-dependencies with configurable transitivity. Version-qualified selections must match the resolved
+dependencies with configurable transitivity. `includeDependencies`, when present, accepts only
+`all`; other values fail configuration instead of being ignored. Layer names accept only letters,
+digits, dots, underscores, and hyphens. Version-qualified selections must match the resolved
 root dependency exactly before including its transitive dependency trail. Normal compile goals
 accept `useLayers` entries that select project dependencies of type `nil` by coordinates. Missing,
-ambiguous, and duplicate selections fail before Native Image is invoked. The plugin must be loaded
-with `<extensions>true</extensions>` so Maven registers `nil` as a resolvable artifact type.
+ambiguous, and duplicate selections fail before Native Image is invoked. Loading the plugin with
+`<extensions>true</extensions>` registers `nil` as a Maven artifact type early and is recommended
+for consistent reactor and repository resolution, although Maven builds that already preserve the
+explicit `nil` type may resolve without it.
 [§root/REQ-backwards-compatibility.2](../../../docs/spec/requirements.md#2-configuration-compatibility).

--- a/native-maven-plugin/docs/functional/configuration-model.md
+++ b/native-maven-plugin/docs/functional/configuration-model.md
@@ -58,9 +58,10 @@ specialized skip controls and behavior.
 ## 7. Layer configuration
 
 A `layer-create` execution accepts one layer definition with a required name and neutral contents:
-`all`, module names, package names, explicit files, and selected `groupId:artifactId`
-dependencies with configurable transitivity. Normal compile goals accept `useLayers` entries that
-select project dependencies of type `nil` by coordinates. Missing, ambiguous, and duplicate
-selections fail before Native Image is invoked. The plugin must be loaded with
-`<extensions>true</extensions>` so Maven registers `nil` as a resolvable artifact type.
+`all`, module names, package names, explicit files, and selected `groupId:artifactId[:version]`
+dependencies with configurable transitivity. Version-qualified selections must match the resolved
+root dependency exactly before including its transitive dependency trail. Normal compile goals
+accept `useLayers` entries that select project dependencies of type `nil` by coordinates. Missing,
+ambiguous, and duplicate selections fail before Native Image is invoked. The plugin must be loaded
+with `<extensions>true</extensions>` so Maven registers `nil` as a resolvable artifact type.
 [§root/REQ-backwards-compatibility.2](../../../docs/spec/requirements.md#2-configuration-compatibility).

--- a/native-maven-plugin/docs/functional/configuration-model.md
+++ b/native-maven-plugin/docs/functional/configuration-model.md
@@ -61,5 +61,6 @@ A `layer-create` execution accepts one layer definition with a required name and
 `all`, module names, package names, explicit files, and selected `groupId:artifactId`
 dependencies with configurable transitivity. Normal compile goals accept `useLayers` entries that
 select project dependencies of type `nil` by coordinates. Missing, ambiguous, and duplicate
-selections fail before Native Image is invoked.
+selections fail before Native Image is invoked. The plugin must be loaded with
+`<extensions>true</extensions>` so Maven registers `nil` as a resolvable artifact type.
 [§root/REQ-backwards-compatibility.2](../../../docs/spec/requirements.md#2-configuration-compatibility).

--- a/native-maven-plugin/docs/functional/goal-surface.md
+++ b/native-maven-plugin/docs/functional/goal-surface.md
@@ -98,3 +98,15 @@ project model.
     </build>
 </profile>
 ```
+
+## 6. Layer creation
+
+`native:layer-create` creates one named Native Image layer from the execution's configured
+modules, packages, resolved files, all runtime dependencies, or selected dependency coordinates.
+It produces `target/native/layers/<name>/<name>.nil` and attaches that file to the current Maven
+project with type `nil`. The goal is thread-safe and may be bound explicitly in a producer module.
+[§REQ-maven-model](../requirements.md#req-maven-model-the-maven-plugin-preserves-maven-model-compatibility).
+
+The Native Build Tools extension registers `nil` as a resolvable artifact type so reactor, local
+repository, and remote repository dependencies participate in normal Maven ordering and
+resolution. A `nil` dependency is not part of the Java application classpath.

--- a/native-maven-plugin/docs/functional/native-image-builds.md
+++ b/native-maven-plugin/docs/functional/native-image-builds.md
@@ -30,9 +30,18 @@ produce a warning. Missing selections must tell users to declare the correspondi
 dependency, and malformed coordinates must fail with a normal Maven execution error. Layer
 creation resolves Maven artifacts to paths and delegates selector serialization to
 [§common/FS-common-libraries.1](../../../common/docs/functional-spec.md#1-shared-native-image-utilities).
+An explicitly configured empty classpath remains empty for module-only layer creation and must not
+fall back to the application or dependency classpath. Layered executables require their produced
+shared libraries to be available through the platform library search path when executed or
+deployed.
+Layer consumption applies consistently to compile, shared-library, and native-test goals when
+`useLayers` is configured for that execution. Plugin-wide `useLayers` therefore also applies to
+`native:test`; users who want different test behavior must scope the configuration to executions.
+The `layer-create` goal may itself consume configured layers, enabling multi-level layer stacks.
 Native Image 25.0.3 and 25.0.4 are excluded from layer consumption because those releases can fail
 internally after loading a layer. The plugin must reject those versions before launching Native
-Image and tell users to upgrade Native Image or remove `useLayers`.
+Image and tell users to upgrade Native Image, remove `useLayers`, or explicitly opt into the
+documented unsupported-version override.
 
 ## 4. Generated resource configuration
 

--- a/native-maven-plugin/docs/functional/native-image-builds.md
+++ b/native-maven-plugin/docs/functional/native-image-builds.md
@@ -23,6 +23,14 @@ Application native image builds must include compile, runtime, and combined comp
 dependencies unless users provide an explicit classpath. Exclusions remove selected artifacts from
 native-image compilation without changing the Maven project dependency graph.
 
+Dependencies of type `nil` must not enter the Java classpath. Configured `useLayers` resolve those
+dependencies separately, declare each layer once, and append `-H:LayerUse=<resolved path>` to the
+Native Image invocation. Layer creation resolves Maven artifacts to paths and delegates selector
+serialization to [§common/FS-common-libraries.1](../../../common/docs/functional-spec.md#1-shared-native-image-utilities).
+Native Image 25.0.3 is excluded from layer consumption because that release can fail internally
+after loading a layer. The plugin must reject that exact version before launching Native Image and
+tell users to upgrade Native Image or remove `useLayers`.
+
 ## 4. Generated resource configuration
 
 Before building, the plugin must add generated resource configuration to the native image

--- a/native-maven-plugin/docs/functional/native-image-builds.md
+++ b/native-maven-plugin/docs/functional/native-image-builds.md
@@ -30,9 +30,9 @@ produce a warning. Missing selections must tell users to declare the correspondi
 dependency, and malformed coordinates must fail with a normal Maven execution error. Layer
 creation resolves Maven artifacts to paths and delegates selector serialization to
 [§common/FS-common-libraries.1](../../../common/docs/functional-spec.md#1-shared-native-image-utilities).
-Native Image 25.0.3 is excluded from layer consumption because that release can fail internally
-after loading a layer. The plugin must reject that exact version before launching Native Image and
-tell users to upgrade Native Image or remove `useLayers`.
+Native Image 25.0.3 and 25.0.4 are excluded from layer consumption because those releases can fail
+internally after loading a layer. The plugin must reject those versions before launching Native
+Image and tell users to upgrade Native Image or remove `useLayers`.
 
 ## 4. Generated resource configuration
 

--- a/native-maven-plugin/docs/functional/native-image-builds.md
+++ b/native-maven-plugin/docs/functional/native-image-builds.md
@@ -40,7 +40,6 @@ expected coordinate rather than producing a known-unrunnable image.
 Layer consumption applies consistently to compile, shared-library, and native-test goals when
 `useLayers` is configured for that execution. Plugin-wide `useLayers` therefore also applies to
 `native:test`; users who want different test behavior must scope the configuration to executions.
-The `layer-create` goal may itself consume configured layers, enabling multi-level layer stacks.
 Every consuming Maven execution must retain the classpath entries used by producer layers. Reactor
 consumers therefore declare the same dependencies; local explicit paths are build-local inputs and
 cannot be represented by a published `nil` artifact alone.
@@ -53,7 +52,6 @@ cannot be represented by a published `nil` artifact alone.
 | Main executable | `useLayers` on the compile execution | `LayeredApplicationFunctionalTest` |
 | Native test | `useLayers` on the `native:test` execution | `LayeredApplicationFunctionalTest` |
 | Shared library | `sharedLibrary` and `useLayers` | `LayeredApplicationFunctionalTest` |
-| Chained layers | `useLayers` on `layer-create` plus declared `nil` dependencies | `LayeredApplicationFunctionalTest` |
 | Reactor/repository flow | Attached `nil` plus platform runtime archive, automatic resolution and consumer-owned staging | Standalone repository consumer runs the executable and `native:test` without producer output access |
 
 Layer shared libraries remain external runtime dependencies. On Linux set `LD_LIBRARY_PATH`; on

--- a/native-maven-plugin/docs/functional/native-image-builds.md
+++ b/native-maven-plugin/docs/functional/native-image-builds.md
@@ -25,8 +25,11 @@ native-image compilation without changing the Maven project dependency graph.
 
 Dependencies of type `nil` must not enter the Java classpath. Configured `useLayers` resolve those
 dependencies separately, declare each layer once, and append `-H:LayerUse=<resolved path>` to the
-Native Image invocation. Layer creation resolves Maven artifacts to paths and delegates selector
-serialization to [§common/FS-common-libraries.1](../../../common/docs/functional-spec.md#1-shared-native-image-utilities).
+Native Image invocation. A declared `nil` dependency that is not selected by `useLayers` must
+produce a warning. Missing selections must tell users to declare the corresponding `nil`
+dependency, and malformed coordinates must fail with a normal Maven execution error. Layer
+creation resolves Maven artifacts to paths and delegates selector serialization to
+[§common/FS-common-libraries.1](../../../common/docs/functional-spec.md#1-shared-native-image-utilities).
 Native Image 25.0.3 is excluded from layer consumption because that release can fail internally
 after loading a layer. The plugin must reject that exact version before launching Native Image and
 tell users to upgrade Native Image or remove `useLayers`.

--- a/native-maven-plugin/docs/functional/native-image-builds.md
+++ b/native-maven-plugin/docs/functional/native-image-builds.md
@@ -38,10 +38,6 @@ Layer consumption applies consistently to compile, shared-library, and native-te
 `useLayers` is configured for that execution. Plugin-wide `useLayers` therefore also applies to
 `native:test`; users who want different test behavior must scope the configuration to executions.
 The `layer-create` goal may itself consume configured layers, enabling multi-level layer stacks.
-Native Image 25.0.3 and 25.0.4 are excluded from layer consumption because those releases can fail
-internally after loading a layer. The plugin must reject those versions before launching Native
-Image and tell users to upgrade Native Image, remove `useLayers`, or explicitly opt into the
-documented unsupported-version override.
 
 ## 4. Generated resource configuration
 

--- a/native-maven-plugin/docs/functional/native-image-builds.md
+++ b/native-maven-plugin/docs/functional/native-image-builds.md
@@ -38,6 +38,9 @@ Layer consumption applies consistently to compile, shared-library, and native-te
 `useLayers` is configured for that execution. Plugin-wide `useLayers` therefore also applies to
 `native:test`; users who want different test behavior must scope the configuration to executions.
 The `layer-create` goal may itself consume configured layers, enabling multi-level layer stacks.
+Every consuming Maven execution must retain the classpath entries used by producer layers. Reactor
+consumers therefore declare the same dependencies; local explicit paths are build-local inputs and
+cannot be represented by a published `nil` artifact alone.
 
 ### Layer support matrix
 

--- a/native-maven-plugin/docs/functional/native-image-builds.md
+++ b/native-maven-plugin/docs/functional/native-image-builds.md
@@ -39,6 +39,22 @@ Layer consumption applies consistently to compile, shared-library, and native-te
 `native:test`; users who want different test behavior must scope the configuration to executions.
 The `layer-create` goal may itself consume configured layers, enabling multi-level layer stacks.
 
+### Layer support matrix
+
+| Selector or consumer | Maven XML support | Executable evidence |
+| --- | --- | --- |
+| Modules, packages, explicit paths, `all` | `<modules>`, `<packages>`, `<paths>`, `<all>` | `LayeredApplicationFunctionalTest` |
+| Main executable | `useLayers` on the compile execution | `LayeredApplicationFunctionalTest` |
+| Native test | `useLayers` on the `native:test` execution | `LayeredApplicationFunctionalTest` |
+| Shared library | `sharedLibrary` and `useLayers` | `LayeredApplicationFunctionalTest` |
+| Chained layers | `useLayers` on `layer-create` plus declared `nil` dependencies | `LayeredApplicationFunctionalTest` |
+| Reactor/repository flow | Attached `nil` artifacts and Maven dependency resolution | Maven-specific; Gradle uses task/file wiring instead |
+
+Layer shared libraries remain external runtime dependencies. On Linux set `LD_LIBRARY_PATH`; on
+macOS set `DYLD_LIBRARY_PATH`; and on Windows add the layer directory to `PATH` before launching
+a layered executable. Creating or attaching a `.nil` artifact does not embed or relocate those
+libraries. [§root/FS-native-builds.6](../../../docs/spec/functional/native-image-builds.md#6-layered-images).
+
 ## 4. Generated resource configuration
 
 Before building, the plugin must add generated resource configuration to the native image

--- a/native-maven-plugin/docs/functional/native-image-builds.md
+++ b/native-maven-plugin/docs/functional/native-image-builds.md
@@ -32,8 +32,11 @@ creation resolves Maven artifacts to paths and delegates selector serialization 
 [§common/FS-common-libraries.1](../../../common/docs/functional-spec.md#1-shared-native-image-utilities).
 An explicitly configured empty classpath remains empty for module-only layer creation and must not
 fall back to the application or dependency classpath. Layered executables require their produced
-shared libraries to be available through the platform library search path when executed or
-deployed.
+runtime libraries to be available through the platform library search path when executed or
+deployed. Repository layer producers attach both the `.nil` build input and a platform-classified
+runtime archive. Consumers resolve and extract the matching runtime archive under their own
+`target` directory before Native Image invocation; a missing companion archive fails with its
+expected coordinate rather than producing a known-unrunnable image.
 Layer consumption applies consistently to compile, shared-library, and native-test goals when
 `useLayers` is configured for that execution. Plugin-wide `useLayers` therefore also applies to
 `native:test`; users who want different test behavior must scope the configuration to executions.
@@ -51,7 +54,7 @@ cannot be represented by a published `nil` artifact alone.
 | Native test | `useLayers` on the `native:test` execution | `LayeredApplicationFunctionalTest` |
 | Shared library | `sharedLibrary` and `useLayers` | `LayeredApplicationFunctionalTest` |
 | Chained layers | `useLayers` on `layer-create` plus declared `nil` dependencies | `LayeredApplicationFunctionalTest` |
-| Reactor/repository flow | Attached `nil` artifacts and Maven dependency resolution | Maven-specific; Gradle uses task/file wiring instead |
+| Reactor/repository flow | Attached `nil` plus platform runtime archive, automatic resolution and consumer-owned staging | Standalone repository consumer runs the executable and `native:test` without producer output access |
 
 Layer shared libraries remain external runtime dependencies. On Linux set `LD_LIBRARY_PATH`; on
 macOS set `DYLD_LIBRARY_PATH`; and on Windows add the layer directory to `PATH` before launching

--- a/native-maven-plugin/docs/functional/native-tests.md
+++ b/native-maven-plugin/docs/functional/native-tests.md
@@ -33,7 +33,7 @@ After building the native test image, `native:test` must run it unless `skipTest
 Runtime arguments configured for the test goal must be passed to the native test executable.
 When the test image consumes a layer, the goal must add the selected layer artifact directories to
 the platform native-library search path before launching the executable, so the layer's shared
-library can be loaded. §FS-native-builds.3.
+library can be loaded. [§FS-native-builds.3](native-image-builds.md#3-classpath-and-scopes).
 
 ## 5. Native test example
 

--- a/native-maven-plugin/docs/functional/native-tests.md
+++ b/native-maven-plugin/docs/functional/native-tests.md
@@ -31,6 +31,9 @@ by [§root/FS-native-tests.5](../../../docs/spec/functional/native-tests.md#5-co
 
 After building the native test image, `native:test` must run it unless `skipTestExecution` is set.
 Runtime arguments configured for the test goal must be passed to the native test executable.
+When the test image consumes a layer, the goal must add the selected layer artifact directories to
+the platform native-library search path before launching the executable, so the layer's shared
+library can be loaded. §FS-native-builds.3.
 
 ## 5. Native test example
 

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -142,4 +142,217 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         file("base-layer/target/native/layers/base/base.nil").isFile()
         outputContains "-H:LayerCreate=base.nil,module=java.base,package=org.slf4j"
     }
+
+    @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
+    @IgnoreIf({ os.windows || os.macOs })
+    def "builds and runs an all selector layer in the reactor"() {
+        given:
+        withSample("layered-maven-application")
+        def basePom = file("base-layer/pom.xml")
+        basePom.text = basePom.text.replace('''                                <modules>
+                                    <module>java.base</module>
+                                </modules>
+                                <dependencies>
+                                    <dependency>
+                                        <artifact>org.slf4j:slf4j-api</artifact>
+                                    </dependency>
+                                </dependencies>
+''', '''                                <all>true</all>
+''')
+
+        when:
+        mvn '-DquickBuild', '-DskipTests', 'package'
+
+        then:
+        buildSucceeded
+        file("base-layer/target/native/layers/base/base.nil").isFile()
+        outputContains "-H:LayerCreate=base.nil"
+        outputContains "-H:LayerUse="
+        def application = file("application/target/application")
+        def layerDirectory = file("base-layer/target/native/layers/base").absolutePath
+        def environment = System.getenv().collect { key, value -> "${key}=${value}" }
+        environment << "LD_LIBRARY_PATH=${layerDirectory}"
+        def execution = [application.absolutePath].execute(environment, application.parentFile)
+        assert execution.waitFor() == 0
+        assert execution.in.text.contains("Hello, layered application!")
+    }
+
+    @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
+    @IgnoreIf({ os.windows || os.macOs })
+    def "builds a layer from an explicit path"() {
+        given:
+        withSample("layered-maven-application")
+        file("base-layer/src/main/java/org/graalvm/demo/BaseLayerType.java").text = '''
+            package org.graalvm.demo;
+            public final class BaseLayerType {
+                private BaseLayerType() { }
+            }
+        '''.stripIndent()
+        def basePom = file("base-layer/pom.xml")
+        basePom.text = basePom.text.replace('''                                <modules>
+                                    <module>java.base</module>
+                                </modules>
+                                <dependencies>
+                                    <dependency>
+                                        <artifact>org.slf4j:slf4j-api</artifact>
+                                    </dependency>
+                                </dependencies>
+''', '''                                <paths>
+                                    <path>\${project.build.outputDirectory}</path>
+                                </paths>
+''')
+
+        when:
+        mvn '-DquickBuild', '-DskipTests', 'package'
+
+        then:
+        buildSucceeded
+        file("base-layer/target/native/layers/base/base.nil").isFile()
+        outputContains "-H:LayerCreate=base.nil,path="
+        outputContains "-H:LayerUse="
+    }
+
+    @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
+    @IgnoreIf({ os.windows || os.macOs })
+    def "builds a shared library using a layer artifact"() {
+        given:
+        withSample("layered-maven-application")
+        def applicationPom = file("application/pom.xml")
+        applicationPom.text = applicationPom.text.replace('''                    <mainClass>org.graalvm.demo.Application</mainClass>
+''', '''                    <sharedLibrary>true</sharedLibrary>
+''')
+
+        when:
+        mvn '-DquickBuild', '-DskipTests', 'package'
+
+        then:
+        buildSucceeded
+        outputContains "-H:LayerUse="
+        file("application/target/application${IS_WINDOWS ? '.dll' : IS_MAC ? '.dylib' : '.so'}").isFile()
+    }
+
+    @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
+    @IgnoreIf({ os.windows || os.macOs })
+    def "native tests consume layers from their own execution"() {
+        given:
+        withSample("layered-maven-application")
+        file("application/src/test/java/org/graalvm/demo/ApplicationTest.java").text = '''
+            package org.graalvm.demo;
+            import org.junit.jupiter.api.Test;
+            import static org.junit.jupiter.api.Assertions.assertTrue;
+            class ApplicationTest {
+                @Test void runs() { assertTrue(true); }
+            }
+        '''.stripIndent()
+        def applicationPom = file("application/pom.xml")
+        applicationPom.text = applicationPom.text
+            .replace('''    <dependencies>
+''', '''    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
+''')
+            .replace('''                </executions>
+''', '''                    <execution>
+                        <id>test-with-layer</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <useLayers>
+                                <useLayer>
+                                    <artifact>org.graalvm.buildtools.samples:base-layer</artifact>
+                                </useLayer>
+                            </useLayers>
+                        </configuration>
+                    </execution>
+                </executions>
+''')
+
+        when:
+        mvn '-DquickBuild', 'test'
+
+        then:
+        buildSucceeded
+        outputContains "-H:LayerUse="
+        outputContains "[         1 tests successful      ]"
+    }
+
+    @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
+    @IgnoreIf({ os.windows || os.macOs })
+    def "builds and runs a chained reactor layer stack"() {
+        given:
+        withSample("layered-maven-application")
+        file("framework-layer/pom.xml").text = '''
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                    <groupId>org.graalvm.buildtools.samples</groupId>
+                    <artifactId>layered-maven-application</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                </parent>
+                <artifactId>framework-layer</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.graalvm.buildtools.samples</groupId>
+                        <artifactId>base-layer</artifactId>
+                        <version>\${project.version}</version>
+                        <type>nil</type>
+                        <scope>runtime</scope>
+                    </dependency>
+                </dependencies>
+                <build><plugins><plugin>
+                    <groupId>org.graalvm.buildtools</groupId>
+                    <artifactId>native-maven-plugin</artifactId>
+                    <executions><execution><id>create-framework-layer</id><phase>package</phase>
+                        <goals><goal>layer-create</goal></goals>
+                        <configuration>
+                            <useLayers><useLayer><artifact>org.graalvm.buildtools.samples:base-layer</artifact></useLayer></useLayers>
+                            <layer><name>framework</name><modules><module>java.sql</module></modules></layer>
+                        </configuration>
+                    </execution></executions>
+                </plugin></plugins></build>
+            </project>
+        '''.stripIndent()
+        def rootPom = file("pom.xml")
+        rootPom.text = rootPom.text.replace('''        <module>application</module>
+''', '''        <module>framework-layer</module>
+        <module>application</module>
+''')
+        def applicationPom = file("application/pom.xml")
+        applicationPom.text = applicationPom.text
+            .replace('''    <dependencies>
+''', '''    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.buildtools.samples</groupId>
+            <artifactId>framework-layer</artifactId>
+            <version>\${project.version}</version>
+            <type>nil</type>
+            <scope>runtime</scope>
+        </dependency>
+''')
+            .replace('''                    <useLayers>
+''', '''                    <useLayers>
+                        <useLayer>
+                            <artifact>org.graalvm.buildtools.samples:framework-layer</artifact>
+                        </useLayer>
+''')
+
+        when:
+        mvn '-DquickBuild', '-DskipTests', 'package'
+
+        then:
+        buildSucceeded
+        file("framework-layer/target/native/layers/framework/framework.nil").isFile()
+        outputContains "-H:LayerCreate=framework.nil,module=java.sql"
+        output.count("-H:LayerUse=") >= 2
+        def application = file("application/target/application")
+        def environment = System.getenv().collect { key, value -> "${key}=${value}" }
+        environment << "LD_LIBRARY_PATH=${file('base-layer/target/native/layers/base').absolutePath}:${file('framework-layer/target/native/layers/framework').absolutePath}"
+        def execution = [application.absolutePath].execute(environment, application.parentFile)
+        assert execution.waitFor() == 0
+        assert execution.in.text.contains("Hello, layered application!")
+    }
 }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,52 +38,49 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.graalvm.buildtools.maven
 
-plugins {
-    id 'application'
-    id 'org.graalvm.buildtools.native'
-}
+import org.graalvm.buildtools.utils.NativeImageUtils
+import spock.lang.IgnoreIf
+import spock.lang.Requires
 
-repositories {
-    mavenCentral()
-}
+// Exercises Maven reactor production and consumption of nil layer artifacts. §E2E-functional-tests.3.8.
+class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
+    def "loads the nil artifact handler and reactor model"() {
+        given:
+        withSample("layered-maven-application")
 
-application {
-    mainClass.set('org.graalvm.demo.Application')
-}
+        when:
+        mvn 'help:effective-pom', '-DskipTests'
 
-def junitVersion = providers.gradleProperty('junit.jupiter.version')
-        .get()
-
-dependencies {
-    implementation("org.slf4j:slf4j-api:2.0.17")
-    runtimeOnly("ch.qos.logback:logback-classic:1.5.6")
-    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
-}
-
-test {
-    useJUnitPlatform()
-}
-
-tasks.named("nativeRun") {
-    runtimeArgs.add(providers.gradleProperty("message").orElse("default message"))
-}
-
-graalvmNative {
-    // Named layers are built independently from application binaries. §gradle/FS-plugin-model.2.
-    layers {
-        dependencies {
-            contents {
-                modules("java.base")
-                fromConfiguration(configurations.runtimeClasspath)
-            }
-        }
+        then:
+        buildSucceeded
+        outputContains "<type>nil</type>"
+        outputContains "<goal>layer-create</goal>"
     }
-    binaries {
-        main {
-            layer = graalvmNative.layers.dependencies
+
+    @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
+    @IgnoreIf({ os.windows || os.macOs })
+    def "builds and consumes a layer artifact in one reactor"() {
+        given:
+        withSample("layered-maven-application")
+        def nativeImage2503 = GraalVMSupport.getGraalVMHomeVersionString().contains("native-image 25.0.3")
+
+        when:
+        mvn '-DquickBuild', '-DskipTests', 'package'
+
+        then:
+        file("base-layer/target/native/layers/base/base.nil").isFile()
+        outputContains "-H:LayerCreate=base.nil"
+        if (nativeImage2503) {
+            buildFailed
+            outputContains "Native Image 25.0.3 does not support reliable layer consumption"
+            outputContains "Upgrade Native Image to a newer release or remove the useLayers configuration"
+            outputDoesNotContain "LayeredDispatchTableFeature"
+        } else {
+            buildSucceeded
+            file("application/target/application").isFile()
+            outputContains "-H:LayerUse="
         }
     }
 }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -41,18 +41,15 @@
 package org.graalvm.buildtools.maven
 
 import org.graalvm.buildtools.utils.NativeImageUtils
+import org.graalvm.buildtools.utils.NativeImageLayerRuntime
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Requires
 
+import java.util.zip.ZipFile
+
 // Exercises Maven reactor production and consumption of nil layer artifacts. §E2E-functional-tests.3.8.
 class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
-    // GraalVM 25.0.x can seal its image-heap scanner during LayerUse processing.
-    // §E2E-functional-tests.3.8.
-    private static boolean hasLayerConsumptionBug() {
-        !NativeImageUtils.isGraalVMVersionAtLeast(GraalVMSupport.getGraalVMHomeVersionString(), 25, 1)
-    }
-
     def "loads the nil artifact handler and reactor model"() {
         given:
         withSample("layered-maven-application")
@@ -92,7 +89,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "builds and consumes a layer from an individual dependency selector"() {
         given:
         withSample("layered-maven-application")
@@ -198,7 +195,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "builds and runs an all selector layer in the reactor"() {
         given:
         withSample("layered-maven-application")
@@ -258,7 +255,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "builds a shared library using a layer artifact"() {
         given:
         withSample("layered-maven-application")
@@ -277,7 +274,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "native tests consume layers from their own execution"() {
         given:
         withSample("layered-maven-application")
@@ -334,9 +331,106 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         outputContains "[         1 tests successful      ]"
     }
 
+    @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
+    @IgnoreIf({ os.windows || os.macOs })
+    def "repository consumer stages and runs a POM-produced layer without producer outputs"() {
+        given:
+        withSample("layered-maven-application")
+        def basePom = file("base-layer/pom.xml")
+        basePom.text = basePom.text
+            .replace('''    <artifactId>base-layer</artifactId>
+''', '''    <artifactId>base-layer</artifactId>
+    <packaging>pom</packaging>
+''')
+            .replace('''                                    <module>java.base</module>
+''', '''                                    <module>java.base</module>
+                                    <module>java.sql</module>
+                                    <module>java.management</module>
+''')
+        def applicationTest = file("application/src/test/java/org/graalvm/demo/ApplicationTest.java")
+        applicationTest.parentFile.mkdirs()
+        applicationTest.text = '''
+            package org.graalvm.demo;
+            import java.sql.Driver;
+            import org.junit.jupiter.api.Test;
+            import static org.junit.jupiter.api.Assertions.assertNotNull;
+            class ApplicationTest {
+                @Test void runs() { assertNotNull(Driver.class); }
+            }
+        '''.stripIndent()
+        def applicationPom = file("application/pom.xml")
+        applicationPom.text = applicationPom.text
+            .replace('''    <dependencies>
+''', '''    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
+''')
+            .replace('''                </executions>
+''', '''                    <execution>
+                        <id>test-with-repository-layer</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                    </execution>
+                </executions>
+''')
+
+        when: "the POM-only producer is installed into the isolated repository"
+        mvn '-DquickBuild', '-DskipTests', '-pl', 'base-layer', '-am', 'install'
+
+        then:
+        buildSucceeded
+        def producerOutput = file("base-layer/target/native/layers/base")
+        def expectedRuntimeFiles = producerOutput.listFiles()
+            .findAll { it.isFile() && NativeImageLayerRuntime.isRuntimeLibrary(it.name) }
+            .collect { it.name }
+            .sort()
+        !expectedRuntimeFiles.empty
+        def repositoryDirectory = file("local-repo/org/graalvm/buildtools/samples/base-layer/1.0-SNAPSHOT")
+        def nilArtifact = new File(repositoryDirectory, "base-layer-1.0-SNAPSHOT.nil")
+        def runtimeArchive = repositoryDirectory.listFiles().find {
+            it.name.startsWith("base-layer-1.0-SNAPSHOT-layer-runtime-") && it.name.endsWith(".zip")
+        }
+        nilArtifact.isFile()
+        runtimeArchive?.isFile()
+        def archivedRuntimeFiles
+        new ZipFile(runtimeArchive).withCloseable { zip ->
+            archivedRuntimeFiles = zip.entries().collect { it.name }.sort()
+        }
+        archivedRuntimeFiles == expectedRuntimeFiles
+
+        when: "the producer build output is removed and the consumer builds outside the reactor"
+        assert file("base-layer/target").deleteDir()
+        mvn '-DquickBuild', '-f', 'application/pom.xml', 'package'
+
+        then:
+        buildSucceeded
+        outputContains "[         1 tests successful      ]"
+        def stagedRoot = file("application/target/native/layer-runtime")
+        def stagedRuntimeFiles = stagedRoot.directorySize() > 0
+        stagedRuntimeFiles
+        def stagedDirectories = []
+        stagedRoot.eachDirRecurse { directory ->
+            if (directory.listFiles()?.any { NativeImageLayerRuntime.isRuntimeLibrary(it.name) }) {
+                stagedDirectories << directory.absolutePath
+            }
+        }
+        !stagedDirectories.empty
+        def application = file("application/target/application")
+        application.isFile()
+        def environment = System.getenv().collect { key, value -> "${key}=${value}" }
+        environment << "LD_LIBRARY_PATH=${stagedDirectories.join(File.pathSeparator)}"
+        def execution = [application.absolutePath].execute(environment, application.parentFile)
+        assert execution.waitFor() == 0
+        assert execution.in.text.contains("Hello, layered application!")
+    }
+
     @Ignore("GraalVM Native Image currently supports one shared base layer and a final application executable, not chained shared layers.")
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "builds and runs a chained reactor layer stack"() {
         given:
         withSample("layered-maven-application")

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -40,6 +40,7 @@
  */
 package org.graalvm.buildtools.maven
 
+import org.graalvm.buildtools.utils.NativeImageLayerArguments
 import org.graalvm.buildtools.utils.NativeImageUtils
 import spock.lang.IgnoreIf
 import spock.lang.Requires
@@ -64,7 +65,8 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     def "builds and consumes a layer artifact in one reactor"() {
         given:
         withSample("layered-maven-application")
-        def nativeImage2503 = GraalVMSupport.getGraalVMHomeVersionString().contains("native-image 25.0.3")
+        def unsupportedLayerConsumption = NativeImageLayerArguments.isLayerConsumptionUnsupported(
+                GraalVMSupport.getGraalVMHomeVersionString())
 
         when:
         mvn '-DquickBuild', '-DskipTests', 'package'
@@ -72,9 +74,9 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         then:
         file("base-layer/target/native/layers/base/base.nil").isFile()
         outputContains "-H:LayerCreate=base.nil"
-        if (nativeImage2503) {
+        if (unsupportedLayerConsumption) {
             buildFailed
-            outputContains "Native Image 25.0.3 does not support reliable layer consumption"
+            outputContains "Native Image 25.0.3 and 25.0.4 do not support reliable layer consumption"
             outputContains "Upgrade Native Image to a newer release or remove the useLayers configuration"
             outputDoesNotContain "LayeredDispatchTableFeature"
         } else {

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -221,7 +221,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "builds a shared library using a layer artifact"() {
         given:
         withSample("layered-maven-application")
@@ -240,11 +240,13 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "native tests consume layers from their own execution"() {
         given:
         withSample("layered-maven-application")
-        file("application/src/test/java/org/graalvm/demo/ApplicationTest.java").text = '''
+        def applicationTest = file("application/src/test/java/org/graalvm/demo/ApplicationTest.java")
+        applicationTest.parentFile.mkdirs()
+        applicationTest.text = '''
             package org.graalvm.demo;
             import org.junit.jupiter.api.Test;
             import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -280,7 +282,9 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
 ''')
 
         when:
-        mvn '-DquickBuild', 'test'
+        // The producer's layer-create goal is bound to package, so complete that phase before
+        // resolving the consumer's native-test execution. §E2E-functional-tests.3.8.
+        mvn '-DquickBuild', 'package'
 
         then:
         buildSucceeded
@@ -289,11 +293,13 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "builds and runs a chained reactor layer stack"() {
         given:
         withSample("layered-maven-application")
-        file("framework-layer/pom.xml").text = '''
+        def frameworkPom = file("framework-layer/pom.xml")
+        frameworkPom.parentFile.mkdirs()
+        frameworkPom.text = '''
             <project xmlns="http://maven.apache.org/POM/4.0.0">
                 <modelVersion>4.0.0</modelVersion>
                 <parent>

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -188,7 +188,9 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     def "builds a layer from an explicit path"() {
         given:
         withSample("layered-maven-application")
-        file("base-layer/src/main/java/org/graalvm/demo/BaseLayerType.java").text = '''
+        def baseLayerType = file("base-layer/src/main/java/org/graalvm/demo/BaseLayerType.java")
+        baseLayerType.parentFile.mkdirs()
+        baseLayerType.text = '''
             package org.graalvm.demo;
             public final class BaseLayerType {
                 private BaseLayerType() { }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -40,7 +40,6 @@
  */
 package org.graalvm.buildtools.maven
 
-import org.graalvm.buildtools.utils.NativeImageLayerArguments
 import org.graalvm.buildtools.utils.NativeImageUtils
 import spock.lang.IgnoreIf
 import spock.lang.Requires
@@ -65,33 +64,24 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     def "builds and consumes a layer artifact in one reactor"() {
         given:
         withSample("layered-maven-application")
-        def unsupportedLayerConsumption = NativeImageLayerArguments.isLayerConsumptionUnsupported(
-                GraalVMSupport.getGraalVMHomeVersionString())
 
         when:
         mvn '-DquickBuild', '-DskipTests', 'package'
 
         then:
+        buildSucceeded
         file("base-layer/target/native/layers/base/base.nil").isFile()
         outputContains "-H:LayerCreate=base.nil"
-        if (unsupportedLayerConsumption) {
-            buildFailed
-            outputContains "Native Image 25.0.3 and 25.0.4 do not support reliable layer consumption"
-            outputContains "Upgrade Native Image, remove the useLayers configuration"
-            outputDoesNotContain "LayeredDispatchTableFeature"
-        } else {
-            assert result.exitCode == 0
-            def application = file("application/target/application")
-            assert application.isFile()
-            assert outputContains("-H:LayerUse=")
-            def environment = System.getenv().collect { key, value -> "${key}=${value}" }
-            def layerDirectory = file("base-layer/target/native/layers/base").absolutePath
-            def inheritedLibraryPath = System.getenv("LD_LIBRARY_PATH")
-            environment << "LD_LIBRARY_PATH=${inheritedLibraryPath ? inheritedLibraryPath + File.pathSeparator : ''}${layerDirectory}"
-            def execution = [application.absolutePath].execute(environment, application.parentFile)
-            assert execution.waitFor() == 0
-            assert execution.in.text.contains("Hello, layered Maven!")
-        }
+        def application = file("application/target/application")
+        assert application.isFile()
+        assert outputContains("-H:LayerUse=")
+        def environment = System.getenv().collect { key, value -> "${key}=${value}" }
+        def layerDirectory = file("base-layer/target/native/layers/base").absolutePath
+        def inheritedLibraryPath = System.getenv("LD_LIBRARY_PATH")
+        environment << "LD_LIBRARY_PATH=${inheritedLibraryPath ? inheritedLibraryPath + File.pathSeparator : ''}${layerDirectory}"
+        def execution = [application.absolutePath].execute(environment, application.parentFile)
+        assert execution.waitFor() == 0
+        assert execution.in.text.contains("Hello, layered application!")
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
@@ -111,10 +101,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     </dependencies>
 
 ''', '')
-            .replace('''                                <packages>
-                                    <package>org.slf4j</package>
-                                </packages>
-                                <dependencies>
+            .replace('''                                <dependencies>
                                     <dependency>
                                         <artifact>org.slf4j:slf4j-api</artifact>
                                     </dependency>
@@ -132,5 +119,27 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         }
         invocation != null
         !invocation.contains(" -cp ")
+    }
+
+    @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
+    @IgnoreIf({ os.windows || os.macOs })
+    def "builds a layer with a package selector"() {
+        given:
+        withSample("layered-maven-application")
+        def basePom = file("base-layer/pom.xml")
+        basePom.text = basePom.text.replace('''                                <dependencies>
+''', '''                                <packages>
+                                    <package>org.slf4j</package>
+                                </packages>
+                                <dependencies>
+''')
+
+        when:
+        mvn '-DquickBuild', '-DskipTests', '-pl', 'base-layer', 'package'
+
+        then:
+        buildSucceeded
+        file("base-layer/target/native/layers/base/base.nil").isFile()
+        outputContains "-H:LayerCreate=base.nil,module=java.base,package=org.slf4j"
     }
 }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -77,16 +77,60 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         if (unsupportedLayerConsumption) {
             buildFailed
             outputContains "Native Image 25.0.3 and 25.0.4 do not support reliable layer consumption"
-            outputContains "Upgrade Native Image to a newer release or remove the useLayers configuration"
+            outputContains "Upgrade Native Image, remove the useLayers configuration"
             outputDoesNotContain "LayeredDispatchTableFeature"
         } else {
             assert result.exitCode == 0
             def application = file("application/target/application")
             assert application.isFile()
             assert outputContains("-H:LayerUse=")
-            def execution = [application.absolutePath].execute()
+            def environment = System.getenv().collect { key, value -> "${key}=${value}" }
+            def layerDirectory = file("base-layer/target/native/layers/base").absolutePath
+            def inheritedLibraryPath = System.getenv("LD_LIBRARY_PATH")
+            environment << "LD_LIBRARY_PATH=${inheritedLibraryPath ? inheritedLibraryPath + File.pathSeparator : ''}${layerDirectory}"
+            def execution = [application.absolutePath].execute(environment, application.parentFile)
             assert execution.waitFor() == 0
             assert execution.in.text.contains("Hello, layered Maven!")
         }
+    }
+
+    @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
+    @IgnoreIf({ os.windows || os.macOs })
+    def "builds a modules-only layer without leaking the project classpath"() {
+        given:
+        withSample("layered-maven-application")
+        def basePom = file("base-layer/pom.xml")
+        basePom.text = basePom.text
+            .replace('''    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+''', '')
+            .replace('''                                <packages>
+                                    <package>org.slf4j</package>
+                                </packages>
+                                <dependencies>
+                                    <dependency>
+                                        <artifact>org.slf4j:slf4j-api</artifact>
+                                    </dependency>
+                                </dependencies>
+''', '')
+
+        when:
+        mvn '-DquickBuild', '-DskipTests', '-pl', 'base-layer', 'package'
+
+        then:
+        buildSucceeded
+        file("base-layer/target/native/layers/base/base.nil").isFile()
+        def invocation = result.stdOut.readLines().find {
+            it.contains("Executing:") && it.contains("-H:LayerCreate=base.nil,module=java.base")
+        }
+        invocation != null
+        !invocation.contains(" -cp ")
     }
 }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -50,9 +50,9 @@ import java.util.zip.ZipFile
 
 // Exercises Maven reactor production and consumption of nil layer artifacts. §E2E-functional-tests.3.8.
 class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
-    // GraalVM 25.0.x can seal its image-heap scanner during all-selector LayerUse processing.
+    // GraalVM 25.0.x can fail while building layer consumers after loading a valid layer.
     // §E2E-functional-tests.3.8.
-    private static boolean hasAllSelectorLayerConsumptionBug() {
+    private static boolean hasLayerConsumptionBug() {
         !NativeImageUtils.isGraalVMVersionAtLeast(GraalVMSupport.getGraalVMHomeVersionString(), 25, 1)
     }
 
@@ -201,7 +201,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs || hasAllSelectorLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "builds and runs an all selector layer in the reactor"() {
         given:
         withSample("layered-maven-application")
@@ -261,7 +261,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "builds a shared library using a layer artifact"() {
         given:
         withSample("layered-maven-application")

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -434,6 +434,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         assert execution.in.text.contains("Hello, layered application!")
     }
 
+    // Retain this probe for a future Native Image release that supports chained shared layers.
     @Ignore("GraalVM Native Image currently supports one shared base layer and a final application executable, not chained shared layers.")
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
     @IgnoreIf({ os.windows || os.macOs })

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -95,25 +95,6 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     def "builds a modules-only layer without leaking the project classpath"() {
         given:
         withSample("layered-maven-application")
-        def basePom = file("base-layer/pom.xml")
-        basePom.text = basePom.text
-            .replace('''    <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
-            <optional>true</optional>
-        </dependency>
-    </dependencies>
-
-''', '')
-            .replace('''                                <dependencies>
-                                    <dependency>
-                                        <artifact>org.slf4j:slf4j-api</artifact>
-                                    </dependency>
-                                </dependencies>
-''', '')
-
         when:
         mvn '-DquickBuild', '-DskipTests', '-pl', 'base-layer', 'package'
 
@@ -133,11 +114,23 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         given:
         withSample("layered-maven-application")
         def basePom = file("base-layer/pom.xml")
-        basePom.text = basePom.text.replace('''                                <dependencies>
+        basePom.text = basePom.text
+            .replace('''    <artifactId>base-layer</artifactId>
+''', '''    <artifactId>base-layer</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+        </dependency>
+    </dependencies>
+''')
+            .replace('''                                <modules>
+                                    <module>java.base</module>
+                                </modules>
 ''', '''                                <packages>
                                     <package>org.slf4j</package>
                                 </packages>
-                                <dependencies>
 ''')
 
         when:
@@ -146,7 +139,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         then:
         buildSucceeded
         file("base-layer/target/native/layers/base/base.nil").isFile()
-        outputContains "-H:LayerCreate=base.nil,module=java.base,package=org.slf4j"
+        outputContains "-H:LayerCreate=base.nil,package=org.slf4j"
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
@@ -158,11 +151,6 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         basePom.text = basePom.text.replace('''                                <modules>
                                     <module>java.base</module>
                                 </modules>
-                                <dependencies>
-                                    <dependency>
-                                        <artifact>org.slf4j:slf4j-api</artifact>
-                                    </dependency>
-                                </dependencies>
 ''', '''                                <all>true</all>
 ''')
 
@@ -184,7 +172,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs })
     def "builds a layer from an explicit path"() {
         given:
         withSample("layered-maven-application")
@@ -200,24 +188,18 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         basePom.text = basePom.text.replace('''                                <modules>
                                     <module>java.base</module>
                                 </modules>
-                                <dependencies>
-                                    <dependency>
-                                        <artifact>org.slf4j:slf4j-api</artifact>
-                                    </dependency>
-                                </dependencies>
 ''', '''                                <paths>
                                     <path>\${project.build.outputDirectory}</path>
                                 </paths>
 ''')
 
         when:
-        mvn '-DquickBuild', '-DskipTests', 'package'
+        mvn '-DquickBuild', '-DskipTests', '-pl', 'base-layer', 'package'
 
         then:
         buildSucceeded
         file("base-layer/target/native/layers/base/base.nil").isFile()
         outputContains "-H:LayerCreate=base.nil,path="
-        outputContains "-H:LayerUse="
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
@@ -244,6 +226,11 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     def "native tests consume layers from their own execution"() {
         given:
         withSample("layered-maven-application")
+        def basePom = file("base-layer/pom.xml")
+        basePom.text = basePom.text.replace('''                                    <module>java.base</module>
+''', '''                                    <module>java.base</module>
+                                    <module>java.management</module>
+''')
         def applicationTest = file("application/src/test/java/org/graalvm/demo/ApplicationTest.java")
         applicationTest.parentFile.mkdirs()
         applicationTest.text = '''
@@ -316,6 +303,12 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
                         <type>nil</type>
                         <scope>runtime</scope>
                     </dependency>
+                    <dependency>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                        <version>3.17.0</version>
+                        <scope>runtime</scope>
+                    </dependency>
                 </dependencies>
                 <build><plugins><plugin>
                     <groupId>org.graalvm.buildtools</groupId>
@@ -324,7 +317,10 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
                         <goals><goal>layer-create</goal></goals>
                         <configuration>
                             <useLayers><useLayer><artifact>org.graalvm.buildtools.samples:base-layer</artifact></useLayer></useLayers>
-                            <layer><name>framework</name><modules><module>java.sql</module></modules></layer>
+                            <layer>
+                                <name>framework</name>
+                                <dependencies><dependency><artifact>org.apache.commons:commons-lang3</artifact></dependency></dependencies>
+                            </layer>
                         </configuration>
                     </execution></executions>
                 </plugin></plugins></build>
@@ -346,6 +342,12 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
             <type>nil</type>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.17.0</version>
+            <scope>runtime</scope>
+        </dependency>
 ''')
             .replace('''                    <useLayers>
 ''', '''                    <useLayers>
@@ -360,7 +362,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         then:
         buildSucceeded
         file("framework-layer/target/native/layers/framework/framework.nil").isFile()
-        outputContains "-H:LayerCreate=framework.nil,module=java.sql"
+        outputContains "-H:LayerCreate=framework.nil,path="
         output.count("-H:LayerUse=") >= 2
         def application = file("application/target/application")
         def environment = System.getenv().collect { key, value -> "${key}=${value}" }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -50,6 +50,12 @@ import java.util.zip.ZipFile
 
 // Exercises Maven reactor production and consumption of nil layer artifacts. §E2E-functional-tests.3.8.
 class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
+    // GraalVM 25.0.x can seal its image-heap scanner during all-selector LayerUse processing.
+    // §E2E-functional-tests.3.8.
+    private static boolean hasAllSelectorLayerConsumptionBug() {
+        !NativeImageUtils.isGraalVMVersionAtLeast(GraalVMSupport.getGraalVMHomeVersionString(), 25, 1)
+    }
+
     def "loads the nil artifact handler and reactor model"() {
         given:
         withSample("layered-maven-application")
@@ -195,7 +201,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasAllSelectorLayerConsumptionBug() })
     def "builds and runs an all selector layer in the reactor"() {
         given:
         withSample("layered-maven-application")

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -41,6 +41,7 @@
 package org.graalvm.buildtools.maven
 
 import org.graalvm.buildtools.utils.NativeImageUtils
+import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Requires
 
@@ -279,6 +280,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         outputContains "[         1 tests successful      ]"
     }
 
+    @Ignore("GraalVM Native Image currently supports one shared base layer and a final application executable, not chained shared layers.")
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
     @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "builds and runs a chained reactor layer stack"() {

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -78,9 +78,13 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
             outputContains "Upgrade Native Image to a newer release or remove the useLayers configuration"
             outputDoesNotContain "LayeredDispatchTableFeature"
         } else {
-            buildSucceeded
-            file("application/target/application").isFile()
-            outputContains "-H:LayerUse="
+            assert result.exitCode == 0
+            def application = file("application/target/application")
+            assert application.isFile()
+            assert outputContains("-H:LayerUse=")
+            def execution = [application.absolutePath].execute()
+            assert execution.waitFor() == 0
+            assert execution.in.text.contains("Hello, layered Maven!")
         }
     }
 }

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -46,9 +46,9 @@ import spock.lang.Requires
 
 // Exercises Maven reactor production and consumption of nil layer artifacts. §E2E-functional-tests.3.8.
 class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
-    // GraalVM 25.0.x can seal its image-heap scanner during all-selector LayerUse processing.
+    // GraalVM 25.0.x can seal its image-heap scanner during LayerUse processing.
     // §E2E-functional-tests.3.8.
-    private static boolean hasAllSelectorLayerConsumptionBug() {
+    private static boolean hasLayerConsumptionBug() {
         !NativeImageUtils.isGraalVMVersionAtLeast(GraalVMSupport.getGraalVMHomeVersionString(), 25, 1)
     }
 
@@ -150,7 +150,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs || hasAllSelectorLayerConsumptionBug() })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "builds and runs an all selector layer in the reactor"() {
         given:
         withSample("layered-maven-application")
@@ -184,7 +184,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
     def "builds a layer from an explicit path"() {
         given:
         withSample("layered-maven-application")

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -46,6 +46,12 @@ import spock.lang.Requires
 
 // Exercises Maven reactor production and consumption of nil layer artifacts. §E2E-functional-tests.3.8.
 class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTest {
+    // GraalVM 25.0.x can seal its image-heap scanner during all-selector LayerUse processing.
+    // §E2E-functional-tests.3.8.
+    private static boolean hasAllSelectorLayerConsumptionBug() {
+        !NativeImageUtils.isGraalVMVersionAtLeast(GraalVMSupport.getGraalVMHomeVersionString(), 25, 1)
+    }
+
     def "loads the nil artifact handler and reactor model"() {
         given:
         withSample("layered-maven-application")
@@ -144,7 +150,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
-    @IgnoreIf({ os.windows || os.macOs })
+    @IgnoreIf({ os.windows || os.macOs || hasAllSelectorLayerConsumptionBug() })
     def "builds and runs an all selector layer in the reactor"() {
         given:
         withSample("layered-maven-application")

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -92,6 +92,60 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
     }
 
     @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
+    @IgnoreIf({ os.windows || os.macOs || hasLayerConsumptionBug() })
+    def "builds and consumes a layer from an individual dependency selector"() {
+        given:
+        withSample("layered-maven-application")
+        def basePom = file("base-layer/pom.xml")
+        basePom.text = basePom.text
+            .replace('''    <artifactId>base-layer</artifactId>
+''', '''    <artifactId>base-layer</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.17.0</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+''')
+            .replace('''                                <modules>
+                                    <module>java.base</module>
+                                </modules>
+''', '''                                <dependencies>
+                                    <dependency>
+                                        <artifact>org.apache.commons:commons-lang3</artifact>
+                                    </dependency>
+                                </dependencies>
+''')
+        def applicationPom = file("application/pom.xml")
+        applicationPom.text = applicationPom.text.replace('''                    <mainClass>org.graalvm.demo.Application</mainClass>
+''', '''                    <mainClass>org.graalvm.demo.Application</mainClass>
+                    <metadataRepository>
+                        <enabled>false</enabled>
+                    </metadataRepository>
+''')
+
+        when:
+        mvn '-DquickBuild', '-DskipTests', 'package'
+
+        then:
+        buildSucceeded
+        file("base-layer/target/native/layers/base/base.nil").isFile()
+        outputContains "-H:LayerCreate=base.nil,path="
+        def application = file("application/target/application")
+        assert application.isFile()
+        assert outputContains("-H:LayerUse=")
+        def environment = System.getenv().collect { key, value -> "${key}=${value}" }
+        def layerDirectory = file("base-layer/target/native/layers/base").absolutePath
+        def inheritedLibraryPath = System.getenv("LD_LIBRARY_PATH")
+        environment << "LD_LIBRARY_PATH=${inheritedLibraryPath ? inheritedLibraryPath + File.pathSeparator : ''}${layerDirectory}"
+        def execution = [application.absolutePath].execute(environment, application.parentFile)
+        assert execution.waitFor() == 0
+        assert execution.in.text.contains("Hello, layered application!")
+    }
+
+    @Requires({ NativeImageUtils.getMajorJDKVersion(GraalVMSupport.getGraalVMHomeVersionString()) >= 25 })
     @IgnoreIf({ os.windows || os.macOs })
     def "builds a modules-only layer without leaking the project classpath"() {
         given:

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -710,11 +710,11 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
         }
     }
 
-    // Native Image 25.0.3 can crash after loading a layer, so fail before invocation. §FS-native-builds.3.
+    // Affected Native Image 25.0 releases can crash after loading a layer, so fail before invocation. §FS-native-builds.3.
     static void checkLayerConsumptionCompatibility(String versionInformation) throws MojoExecutionException {
         if (NativeImageLayerArguments.isLayerConsumptionUnsupported(versionInformation)) {
             throw new MojoExecutionException(
-                    "Native Image 25.0.3 does not support reliable layer consumption. "
+                    "Native Image 25.0.3 and 25.0.4 do not support reliable layer consumption. "
                     + "Upgrade Native Image to a newer release or remove the useLayers configuration.");
         }
     }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -674,9 +674,6 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     protected void buildImage() throws MojoExecutionException {
         checkRequiredVersionIfNeeded();
         Path nativeImageExecutable = NativeImageConfigurationUtils.getNativeImageSupportingToolchain(logger, toolchainManager, session, enforceToolchain);
-        if (useLayers != null && !useLayers.isEmpty()) {
-            checkLayerConsumptionCompatibility(getVersionInformation(logger, nativeImageExecutable));
-        }
         if (isMetadataRepositoryEnabled() && metadataRepository != null) {
             SchemaValidationUtils.validateReachabilityMetadataSchema(((FileSystemRepository) metadataRepository).getRootDirectory(), NativeImageUtils.getMajorJDKVersion(getVersionInformation(null)), nativeImageExecutable);
         }
@@ -707,17 +704,6 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
             }
         } catch (IOException | InterruptedException e) {
             throw new MojoExecutionException("Building image with " + nativeImageExecutable + " failed", e);
-        }
-    }
-
-    // Affected Native Image 25.0 releases can crash after loading a layer, so fail before invocation. §FS-native-builds.3.
-    static void checkLayerConsumptionCompatibility(String versionInformation) throws MojoExecutionException {
-        if (NativeImageLayerArguments.isLayerConsumptionUnsupported(versionInformation)
-                && !Boolean.getBoolean("org.graalvm.buildtools.layers.allowUnsupportedConsumption")) {
-            throw new MojoExecutionException(
-                    "Native Image 25.0.3 and 25.0.4 do not support reliable layer consumption. "
-                    + "Upgrade Native Image, remove the useLayers configuration, or set "
-                    + "-Dorg.graalvm.buildtools.layers.allowUnsupportedConsumption=true to proceed at your own risk.");
         }
     }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -712,10 +712,12 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
 
     // Affected Native Image 25.0 releases can crash after loading a layer, so fail before invocation. §FS-native-builds.3.
     static void checkLayerConsumptionCompatibility(String versionInformation) throws MojoExecutionException {
-        if (NativeImageLayerArguments.isLayerConsumptionUnsupported(versionInformation)) {
+        if (NativeImageLayerArguments.isLayerConsumptionUnsupported(versionInformation)
+                && !Boolean.getBoolean("org.graalvm.buildtools.layers.allowUnsupportedConsumption")) {
             throw new MojoExecutionException(
                     "Native Image 25.0.3 and 25.0.4 do not support reliable layer consumption. "
-                    + "Upgrade Native Image to a newer release or remove the useLayers configuration.");
+                    + "Upgrade Native Image, remove the useLayers configuration, or set "
+                    + "-Dorg.graalvm.buildtools.layers.allowUnsupportedConsumption=true to proceed at your own risk.");
         }
     }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -53,9 +53,11 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.logging.Logger;
 import org.graalvm.buildtools.maven.config.ExcludeConfigConfiguration;
+import org.graalvm.buildtools.maven.config.UseLayerConfiguration;
 import org.graalvm.buildtools.model.resources.NativeImageFlags;
 import org.graalvm.buildtools.utils.NativeImageConfigurationUtils;
 import org.graalvm.buildtools.utils.NativeImageUtils;
+import org.graalvm.buildtools.utils.NativeImageLayerArguments;
 import org.graalvm.buildtools.utils.SchemaValidationUtils;
 import org.graalvm.buildtools.utils.SharedConstants;
 import org.graalvm.reachability.internal.FileSystemRepository;
@@ -101,6 +103,8 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     protected static final String NATIVE_IMAGE_DRY_RUN = "nativeDryRun";
     private static final Pattern LAYER_CREATE_ARG = Pattern.compile(
             Pattern.quote(NativeImageFlags.LAYER_CREATE) + "(@[^=]*)?=.+");
+    private static final Pattern NATIVE_IMAGE_25_0_3 = Pattern.compile(
+            "(?m)^native-image 25\\.0\\.3(?:\\s|$)");
     private static String nativeImageVersionInformation = null;
 
     @Parameter(defaultValue = "${plugin}", readonly = true) // Maven 3 only
@@ -196,6 +200,9 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     @Parameter(property = "exclusions")
     protected List<Exclusion> exclusions;
 
+    @Parameter(property = "useLayers")
+    protected List<UseLayerConfiguration> useLayers;
+
     @Component
     protected ToolchainManager toolchainManager;
 
@@ -286,6 +293,12 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
                     .map(Path::toString)
                     .collect(Collectors.joining(","))
             );
+        }
+
+        List<String> layerUseArgs = resolveLayerUseArguments();
+        if (!layerUseArgs.isEmpty()) {
+            cliArgs.add(NativeImageFlags.UNLOCK_EXPERIMENTAL_VMOPTIONS);
+            cliArgs.addAll(layerUseArgs);
         }
 
         if (buildArgs != null && !buildArgs.isEmpty()) {
@@ -491,7 +504,10 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
         Set<Artifact> collected = new HashSet<>();
         // Must keep classpath order is the same with surefire test
         for (Artifact dependency : project.getArtifacts()) {
-            if (getDependencyScopes().contains(dependency.getScope()) && collected.add(dependency) && !isExcluded(dependency)) {
+            if (!"nil".equals(dependency.getType())
+                    && getDependencyScopes().contains(dependency.getScope())
+                    && collected.add(dependency)
+                    && !isExcluded(dependency)) {
                 Path dependencyPath = processSupportedArtifacts(dependency);
                 if (dependencyPath != null) {
                     imageClasspath.add(dependencyPath);
@@ -505,6 +521,49 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
                 }
             }
         }
+    }
+
+    private List<String> resolveLayerUseArguments() throws MojoExecutionException {
+        if (useLayers == null || useLayers.isEmpty()) {
+            return List.of();
+        }
+        Set<String> selected = new HashSet<>();
+        List<String> arguments = new ArrayList<>();
+        for (UseLayerConfiguration useLayer : useLayers) {
+            String selector = useLayer.getArtifact();
+            if (selector == null || selector.isBlank()) {
+                throw new MojoExecutionException("useLayers entries require non-blank artifact coordinates");
+            }
+            if (!selected.add(selector)) {
+                throw new MojoExecutionException("Layer dependency '" + selector + "' is selected more than once");
+            }
+            List<Artifact> matches = project.getArtifacts().stream()
+                .filter(artifact -> "nil".equals(artifact.getType()))
+                .filter(artifact -> matchesLayerCoordinate(artifact, selector))
+                .toList();
+            if (matches.isEmpty()) {
+                throw new MojoExecutionException("Layer dependency '" + selector + "' was not found");
+            }
+            if (matches.size() > 1) {
+                throw new MojoExecutionException("Layer dependency '" + selector + "' is ambiguous: " + matches);
+            }
+            File layerFile = matches.get(0).getFile();
+            if (layerFile == null) {
+                throw new MojoExecutionException("Layer dependency '" + selector + "' has no resolved file");
+            }
+            arguments.add(NativeImageLayerArguments.renderLayerUse(layerFile.toPath()));
+        }
+        return arguments;
+    }
+
+    private static boolean matchesLayerCoordinate(Artifact artifact, String selector) {
+        String[] parts = selector.split(":");
+        if (parts.length < 2 || parts.length > 3) {
+            throw new IllegalArgumentException("Layer dependency must use groupId:artifactId[:version]: " + selector);
+        }
+        return artifact.getGroupId().equals(parts[0])
+            && artifact.getArtifactId().equals(parts[1])
+            && (parts.length == 2 || artifact.getVersion().equals(parts[2]));
     }
 
     protected void addInferredDependenciesToClasspath() {
@@ -590,6 +649,9 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     protected void buildImage() throws MojoExecutionException {
         checkRequiredVersionIfNeeded();
         Path nativeImageExecutable = NativeImageConfigurationUtils.getNativeImageSupportingToolchain(logger, toolchainManager, session, enforceToolchain);
+        if (useLayers != null && !useLayers.isEmpty()) {
+            checkLayerConsumptionCompatibility(getVersionInformation(logger, nativeImageExecutable));
+        }
         if (isMetadataRepositoryEnabled() && metadataRepository != null) {
             SchemaValidationUtils.validateReachabilityMetadataSchema(((FileSystemRepository) metadataRepository).getRootDirectory(), NativeImageUtils.getMajorJDKVersion(getVersionInformation(null)), nativeImageExecutable);
         }
@@ -620,6 +682,15 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
             }
         } catch (IOException | InterruptedException e) {
             throw new MojoExecutionException("Building image with " + nativeImageExecutable + " failed", e);
+        }
+    }
+
+    // Native Image 25.0.3 can crash after loading a layer, so fail before invocation. §FS-native-builds.3.
+    static void checkLayerConsumptionCompatibility(String versionInformation) throws MojoExecutionException {
+        if (NATIVE_IMAGE_25_0_3.matcher(versionInformation).find()) {
+            throw new MojoExecutionException(
+                    "Native Image 25.0.3 does not support reliable layer consumption. "
+                    + "Upgrade Native Image to a newer release or remove the useLayers configuration.");
         }
     }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -80,6 +80,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -522,6 +523,26 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     }
 
     private List<String> resolveLayerUseArguments() throws MojoExecutionException {
+        return resolveLayerUseArtifacts().stream()
+            .map(Artifact::getFile)
+            .map(File::toPath)
+            .map(NativeImageLayerArguments::renderLayerUse)
+            .toList();
+    }
+
+    /**
+     * Directories that contain layer libraries consumed by this image. §FS-native-builds.3.
+     */
+    protected List<Path> getUsedLayerLibraryDirectories() throws MojoExecutionException {
+        return resolveLayerUseArtifacts().stream()
+            .map(Artifact::getFile)
+            .map(File::toPath)
+            .map(Path::getParent)
+            .distinct()
+            .toList();
+    }
+
+    private List<Artifact> resolveLayerUseArtifacts() throws MojoExecutionException {
         List<Artifact> nilArtifacts = project.getArtifacts().stream()
             .filter(artifact -> "nil".equals(artifact.getType()))
             .toList();
@@ -530,8 +551,7 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
             return List.of();
         }
         Set<String> selected = new HashSet<>();
-        Set<Artifact> selectedArtifacts = new HashSet<>();
-        List<String> arguments = new ArrayList<>();
+        Set<Artifact> selectedArtifacts = new LinkedHashSet<>();
         for (UseLayerConfiguration useLayer : useLayers) {
             String selector = useLayer.getArtifact();
             if (selector == null || selector.isBlank()) {
@@ -556,16 +576,14 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
                 throw new MojoExecutionException(
                     "Layer dependency '" + selector + "' selects an artifact that is already selected");
             }
-            File layerFile = matches.get(0).getFile();
-            if (layerFile == null) {
+            if (matches.get(0).getFile() == null) {
                 throw new MojoExecutionException("Layer dependency '" + selector + "' has no resolved file");
             }
-            arguments.add(NativeImageLayerArguments.renderLayerUse(layerFile.toPath()));
         }
         warnAboutUnreferencedLayers(nilArtifacts.stream()
             .filter(artifact -> !selectedArtifacts.contains(artifact))
             .toList());
-        return arguments;
+        return List.copyOf(selectedArtifacts);
     }
 
     private void warnAboutUnreferencedLayers(List<Artifact> artifacts) {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -103,8 +103,6 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     protected static final String NATIVE_IMAGE_DRY_RUN = "nativeDryRun";
     private static final Pattern LAYER_CREATE_ARG = Pattern.compile(
             Pattern.quote(NativeImageFlags.LAYER_CREATE) + "(@[^=]*)?=.+");
-    private static final Pattern NATIVE_IMAGE_25_0_3 = Pattern.compile(
-            "(?m)^native-image 25\\.0\\.3(?:\\s|$)");
     private static String nativeImageVersionInformation = null;
 
     @Parameter(defaultValue = "${plugin}", readonly = true) // Maven 3 only
@@ -524,10 +522,15 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     }
 
     private List<String> resolveLayerUseArguments() throws MojoExecutionException {
+        List<Artifact> nilArtifacts = project.getArtifacts().stream()
+            .filter(artifact -> "nil".equals(artifact.getType()))
+            .toList();
         if (useLayers == null || useLayers.isEmpty()) {
+            warnAboutUnreferencedLayers(nilArtifacts);
             return List.of();
         }
         Set<String> selected = new HashSet<>();
+        Set<Artifact> selectedArtifacts = new HashSet<>();
         List<String> arguments = new ArrayList<>();
         for (UseLayerConfiguration useLayer : useLayers) {
             String selector = useLayer.getArtifact();
@@ -537,15 +540,21 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
             if (!selected.add(selector)) {
                 throw new MojoExecutionException("Layer dependency '" + selector + "' is selected more than once");
             }
-            List<Artifact> matches = project.getArtifacts().stream()
-                .filter(artifact -> "nil".equals(artifact.getType()))
-                .filter(artifact -> matchesLayerCoordinate(artifact, selector))
+            String[] coordinate = parseLayerCoordinate(selector);
+            List<Artifact> matches = nilArtifacts.stream()
+                .filter(artifact -> matchesLayerCoordinate(artifact, coordinate))
                 .toList();
             if (matches.isEmpty()) {
-                throw new MojoExecutionException("Layer dependency '" + selector + "' was not found");
+                throw new MojoExecutionException(
+                    "Layer dependency '" + selector + "' was not found. Declare the corresponding "
+                        + "<dependency> with <type>nil</type> in the project.");
             }
             if (matches.size() > 1) {
                 throw new MojoExecutionException("Layer dependency '" + selector + "' is ambiguous: " + matches);
+            }
+            if (!selectedArtifacts.add(matches.get(0))) {
+                throw new MojoExecutionException(
+                    "Layer dependency '" + selector + "' selects an artifact that is already selected");
             }
             File layerFile = matches.get(0).getFile();
             if (layerFile == null) {
@@ -553,14 +562,30 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
             }
             arguments.add(NativeImageLayerArguments.renderLayerUse(layerFile.toPath()));
         }
+        warnAboutUnreferencedLayers(nilArtifacts.stream()
+            .filter(artifact -> !selectedArtifacts.contains(artifact))
+            .toList());
         return arguments;
     }
 
-    private static boolean matchesLayerCoordinate(Artifact artifact, String selector) {
-        String[] parts = selector.split(":");
-        if (parts.length < 2 || parts.length > 3) {
-            throw new IllegalArgumentException("Layer dependency must use groupId:artifactId[:version]: " + selector);
+    private void warnAboutUnreferencedLayers(List<Artifact> artifacts) {
+        for (Artifact artifact : artifacts) {
+            logger.warn("Layer dependency '" + artifact.getGroupId() + ":" + artifact.getArtifactId()
+                + "' has type nil but is not referenced by useLayers; it will not be consumed.");
         }
+    }
+
+    static String[] parseLayerCoordinate(String selector) throws MojoExecutionException {
+        String[] parts = selector.split(":", -1);
+        if (parts.length < 2 || parts.length > 3
+                || Arrays.stream(parts).anyMatch(String::isBlank)) {
+            throw new MojoExecutionException(
+                "Layer dependency must use groupId:artifactId[:version]: " + selector);
+        }
+        return parts;
+    }
+
+    private static boolean matchesLayerCoordinate(Artifact artifact, String[] parts) {
         return artifact.getGroupId().equals(parts[0])
             && artifact.getArtifactId().equals(parts[1])
             && (parts.length == 2 || artifact.getVersion().equals(parts[2]));
@@ -687,7 +712,7 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
 
     // Native Image 25.0.3 can crash after loading a layer, so fail before invocation. §FS-native-builds.3.
     static void checkLayerConsumptionCompatibility(String versionInformation) throws MojoExecutionException {
-        if (NATIVE_IMAGE_25_0_3.matcher(versionInformation).find()) {
+        if (NativeImageLayerArguments.isLayerConsumptionUnsupported(versionInformation)) {
             throw new MojoExecutionException(
                     "Native Image 25.0.3 does not support reliable layer consumption. "
                     + "Upgrade Native Image to a newer release or remove the useLayers configuration.");

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/AbstractNativeImageMojo.java
@@ -52,12 +52,16 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.logging.Logger;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.graalvm.buildtools.maven.config.ExcludeConfigConfiguration;
 import org.graalvm.buildtools.maven.config.UseLayerConfiguration;
 import org.graalvm.buildtools.model.resources.NativeImageFlags;
 import org.graalvm.buildtools.utils.NativeImageConfigurationUtils;
 import org.graalvm.buildtools.utils.NativeImageUtils;
 import org.graalvm.buildtools.utils.NativeImageLayerArguments;
+import org.graalvm.buildtools.utils.NativeImageLayerRuntime;
 import org.graalvm.buildtools.utils.SchemaValidationUtils;
 import org.graalvm.buildtools.utils.SharedConstants;
 import org.graalvm.reachability.internal.FileSystemRepository;
@@ -105,6 +109,8 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     private static final Pattern LAYER_CREATE_ARG = Pattern.compile(
             Pattern.quote(NativeImageFlags.LAYER_CREATE) + "(@[^=]*)?=.+");
     private static String nativeImageVersionInformation = null;
+    private List<Artifact> resolvedLayerUseArtifacts;
+    private List<Path> resolvedLayerRuntimeDirectories;
 
     @Parameter(defaultValue = "${plugin}", readonly = true) // Maven 3 only
     protected PluginDescriptor plugin;
@@ -523,7 +529,9 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     }
 
     private List<String> resolveLayerUseArguments() throws MojoExecutionException {
-        return resolveLayerUseArtifacts().stream()
+        List<Artifact> artifacts = resolveLayerUseArtifacts();
+        resolveLayerRuntimeDirectories(artifacts);
+        return artifacts.stream()
             .map(Artifact::getFile)
             .map(File::toPath)
             .map(NativeImageLayerArguments::renderLayerUse)
@@ -534,21 +542,20 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
      * Directories that contain layer libraries consumed by this image. §FS-native-builds.3.
      */
     protected List<Path> getUsedLayerLibraryDirectories() throws MojoExecutionException {
-        return resolveLayerUseArtifacts().stream()
-            .map(Artifact::getFile)
-            .map(File::toPath)
-            .map(Path::getParent)
-            .distinct()
-            .toList();
+        return resolveLayerRuntimeDirectories(resolveLayerUseArtifacts());
     }
 
     private List<Artifact> resolveLayerUseArtifacts() throws MojoExecutionException {
+        if (resolvedLayerUseArtifacts != null) {
+            return resolvedLayerUseArtifacts;
+        }
         List<Artifact> nilArtifacts = project.getArtifacts().stream()
             .filter(artifact -> "nil".equals(artifact.getType()))
             .toList();
         if (useLayers == null || useLayers.isEmpty()) {
             warnAboutUnreferencedLayers(nilArtifacts);
-            return List.of();
+            resolvedLayerUseArtifacts = List.of();
+            return resolvedLayerUseArtifacts;
         }
         Set<String> selected = new HashSet<>();
         Set<Artifact> selectedArtifacts = new LinkedHashSet<>();
@@ -583,7 +590,56 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
         warnAboutUnreferencedLayers(nilArtifacts.stream()
             .filter(artifact -> !selectedArtifacts.contains(artifact))
             .toList());
-        return List.copyOf(selectedArtifacts);
+        resolvedLayerUseArtifacts = List.copyOf(selectedArtifacts);
+        return resolvedLayerUseArtifacts;
+    }
+
+    private List<Path> resolveLayerRuntimeDirectories(List<Artifact> layerArtifacts) throws MojoExecutionException {
+        if (resolvedLayerRuntimeDirectories != null) {
+            return resolvedLayerRuntimeDirectories;
+        }
+        if (layerArtifacts.isEmpty()) {
+            resolvedLayerRuntimeDirectories = List.of();
+            return resolvedLayerRuntimeDirectories;
+        }
+        String classifier = NativeImageLayerRuntime.classifier(buildArgs);
+        List<Path> directories = new ArrayList<>();
+        for (Artifact layerArtifact : layerArtifacts) {
+            org.eclipse.aether.artifact.Artifact runtimeArtifact = new DefaultArtifact(
+                layerArtifact.getGroupId(),
+                layerArtifact.getArtifactId(),
+                classifier,
+                NativeImageLayerRuntime.ARCHIVE_TYPE,
+                layerArtifact.getVersion());
+            ArtifactRequest request = new ArtifactRequest(runtimeArtifact, project.getRemoteProjectRepositories(), null);
+            Path archive = resolveLayerRuntimeArchive(layerArtifact, runtimeArtifact, request);
+            Path destination = Path.of(project.getBuild().getDirectory(), "native", "layer-runtime",
+                layerArtifact.getGroupId(), layerArtifact.getArtifactId(), layerArtifact.getVersion(), classifier);
+            try {
+                NativeImageLayerRuntime.extractArchive(archive, destination, logger::warn);
+            } catch (IOException ex) {
+                throw new MojoExecutionException("Unable to stage layer runtime archive " + runtimeArtifact
+                    + " in " + destination, ex);
+            }
+            directories.add(destination);
+        }
+        resolvedLayerRuntimeDirectories = List.copyOf(directories);
+        return resolvedLayerRuntimeDirectories;
+    }
+
+    protected Path resolveLayerRuntimeArchive(Artifact layerArtifact,
+                                              org.eclipse.aether.artifact.Artifact runtimeArtifact,
+                                              ArtifactRequest request) throws MojoExecutionException {
+        try {
+            return repositorySystem.resolveArtifact(mavenSession.getRepositorySession(), request)
+                .getArtifact().getFile().toPath();
+        } catch (ArtifactResolutionException ex) {
+            throw new MojoExecutionException("Layer '" + layerArtifact.getGroupId() + ":"
+                + layerArtifact.getArtifactId() + ":" + layerArtifact.getVersion()
+                + "' is missing its deployable runtime companion " + runtimeArtifact
+                + ". A .nil artifact alone is not deployable; republish the layer with a Native Build Tools "
+                + "version that attaches runtime bundles.", ex);
+        }
     }
 
     private void warnAboutUnreferencedLayers(List<Artifact> artifacts) {
@@ -692,6 +748,7 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
     protected void buildImage() throws MojoExecutionException {
         checkRequiredVersionIfNeeded();
         Path nativeImageExecutable = NativeImageConfigurationUtils.getNativeImageSupportingToolchain(logger, toolchainManager, session, enforceToolchain);
+        warnAboutUnsupportedLayerConsumption(nativeImageExecutable);
         if (isMetadataRepositoryEnabled() && metadataRepository != null) {
             SchemaValidationUtils.validateReachabilityMetadataSchema(((FileSystemRepository) metadataRepository).getRootDirectory(), NativeImageUtils.getMajorJDKVersion(getVersionInformation(null)), nativeImageExecutable);
         }
@@ -722,6 +779,17 @@ public abstract class AbstractNativeImageMojo extends AbstractNativeMojo {
             }
         } catch (IOException | InterruptedException e) {
             throw new MojoExecutionException("Building image with " + nativeImageExecutable + " failed", e);
+        }
+    }
+
+    private void warnAboutUnsupportedLayerConsumption(Path nativeImageExecutable) throws MojoExecutionException {
+        if (useLayers == null || useLayers.isEmpty()) {
+            return;
+        }
+        String versionInformation = getVersionInformation(logger, nativeImageExecutable);
+        if (NativeImageUtils.shouldWarnAboutUnsupportedLayerConsumption(versionInformation, true)) {
+            logger.warn("Layer consumption is supported on GraalVM 25.1 and later. Continuing on "
+                + "GraalVM 25.0.x is unsupported and at your own risk.");
         }
     }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
@@ -80,9 +80,29 @@ public class LayerCreateMojo extends AbstractNativeImageMojo {
     }
 
     @Override
+    protected void populateClasspath() {
+        // Layer creation always sets an explicit selection, including an intentionally empty modules-only classpath. §FS-native-builds.3.
+        for (String entry : classpath) {
+            imageClasspath.add(Path.of(entry).toAbsolutePath());
+        }
+        imageClasspath.removeIf(entry -> !entry.toFile().exists());
+    }
+
+    @Override
     protected void executeInternal() throws MojoExecutionException {
         if (layer == null || layer.getName() == null || layer.getName().isBlank()) {
             throw new MojoExecutionException("The layer-create goal requires a non-blank layer name");
+        }
+        try {
+            NativeImageLayerArguments.validateLayerName(layer.getName());
+        } catch (IllegalArgumentException ex) {
+            throw new MojoExecutionException(ex.getMessage(), ex);
+        }
+        String includeDependencies = layer.getIncludeDependencies();
+        if (includeDependencies != null && !includeDependencies.isBlank()
+                && !"all".equalsIgnoreCase(includeDependencies)) {
+            throw new MojoExecutionException(
+                "Layer includeDependencies accepts only 'all', but was '" + includeDependencies + "'");
         }
         outputDirectory = new File(project.getBuild().getDirectory(), "native/layers/" + layer.getName());
         // Native Image requires the shared library inside a layer bundle to use a library name;
@@ -124,7 +144,7 @@ public class LayerCreateMojo extends AbstractNativeImageMojo {
         }
     }
 
-    private List<Path> resolveSelectedPaths() throws MojoExecutionException {
+    List<Path> resolveSelectedPaths() throws MojoExecutionException {
         Set<Path> paths = new LinkedHashSet<>();
         for (File path : layer.getPaths()) {
             paths.add(path.toPath().toAbsolutePath());

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
@@ -160,14 +160,22 @@ public class LayerCreateMojo extends AbstractNativeImageMojo {
             .toList();
     }
 
-    private static boolean matches(Artifact artifact, String[] parts, boolean transitive) {
+    static boolean matches(Artifact artifact, String[] parts, boolean transitive) {
         boolean exact = artifact.getGroupId().equals(parts[0])
             && artifact.getArtifactId().equals(parts[1])
             && (parts.length == 2 || artifact.getVersion().equals(parts[2]));
         if (exact || !transitive || artifact.getDependencyTrail() == null) {
             return exact;
         }
-        String prefix = parts[0] + ":" + parts[1] + ":";
-        return artifact.getDependencyTrail().stream().anyMatch(entry -> entry.startsWith(prefix));
+        // A version-qualified root must match exactly before its transitive trail is selected. §FS-config-model.7.
+        return artifact.getDependencyTrail().stream().anyMatch(entry -> matchesTrailCoordinate(entry, parts));
+    }
+
+    private static boolean matchesTrailCoordinate(String entry, String[] parts) {
+        String[] trailParts = entry.split(":", -1);
+        return trailParts.length >= 4
+            && trailParts[0].equals(parts[0])
+            && trailParts[1].equals(parts[1])
+            && (parts.length == 2 || trailParts[trailParts.length - 1].equals(parts[2]));
     }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.maven;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProjectHelper;
+import org.graalvm.buildtools.maven.config.LayerConfiguration;
+import org.graalvm.buildtools.maven.config.LayerDependencyConfiguration;
+import org.graalvm.buildtools.model.resources.NativeImageFlags;
+import org.graalvm.buildtools.utils.ArtifactSelection;
+import org.graalvm.buildtools.utils.NativeImageLayerArguments;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Creates and attaches one Maven-resolvable Native Image layer. §FS-goal-surface.6.
+ */
+@Mojo(name = "layer-create", threadSafe = true,
+        requiresDependencyResolution = ResolutionScope.RUNTIME,
+        requiresDependencyCollection = ResolutionScope.RUNTIME)
+public class LayerCreateMojo extends AbstractNativeImageMojo {
+    @Parameter(required = true)
+    private LayerConfiguration layer;
+
+    @Component
+    private MavenProjectHelper projectHelper;
+
+    @Override
+    protected List<String> getDependencyScopes() {
+        return Arrays.asList(Artifact.SCOPE_COMPILE, Artifact.SCOPE_RUNTIME, Artifact.SCOPE_COMPILE_PLUS_RUNTIME);
+    }
+
+    @Override
+    protected void executeInternal() throws MojoExecutionException {
+        if (layer == null || layer.getName() == null || layer.getName().isBlank()) {
+            throw new MojoExecutionException("The layer-create goal requires a non-blank layer name");
+        }
+        outputDirectory = new File(project.getBuild().getDirectory(), "native/layers/" + layer.getName());
+        // Native Image requires the shared library inside a layer bundle to use a library name;
+        // the public layer and attached artifact remain <name>.nil. §FS-goal-surface.6.
+        imageName = "lib" + layer.getName();
+        mainClass = null;
+        List<Path> selectedPaths = resolveSelectedPaths();
+        classpath = selectedPaths.stream().map(Path::toString).toList();
+        if (layer.isAll() || !layer.getPackages().isEmpty()) {
+            List<Path> invocationClasspath = new ArrayList<>(runtimeArtifactPaths());
+            if (!layer.getPackages().isEmpty() && defaultClassesDirectory != null) {
+                invocationClasspath.add(defaultClassesDirectory.toPath().toAbsolutePath());
+            }
+            classpath = invocationClasspath.stream().map(Path::toString).toList();
+        }
+        ArtifactSelection selection = new ArtifactSelection(
+            layer.isAll(),
+            layer.getModules(),
+            layer.getPackages(),
+            layer.isAll() ? List.of() : selectedPaths
+        );
+        if (buildArgs == null) {
+            buildArgs = new ArrayList<>();
+        }
+        buildArgs.add(0, NativeImageLayerArguments.renderLayerCreate(layer.getName(), selection));
+        buildArgs.add(0, NativeImageFlags.UNLOCK_EXPERIMENTAL_VMOPTIONS);
+        buildImage();
+
+        File layerFile = new File(outputDirectory, layer.getName() + ".nil");
+        if (!dryRun && !layerFile.isFile()) {
+            throw new MojoExecutionException("Native Image did not produce the expected layer " + layerFile);
+        }
+        if (!dryRun) {
+            projectHelper.attachArtifact(project, "nil", null, layerFile);
+        }
+    }
+
+    private List<Path> resolveSelectedPaths() throws MojoExecutionException {
+        Set<Path> paths = new LinkedHashSet<>();
+        for (File path : layer.getPaths()) {
+            paths.add(path.toPath().toAbsolutePath());
+        }
+        for (LayerDependencyConfiguration dependency : layer.getDependencies()) {
+            String selector = dependency.getArtifact();
+            if (selector == null || selector.isBlank()) {
+                throw new MojoExecutionException("Layer dependency coordinates must not be blank");
+            }
+            boolean matched = false;
+            for (Artifact artifact : project.getArtifacts()) {
+                if (matches(artifact, selector, dependency.isTransitive())) {
+                    if (artifact.getFile() != null) {
+                        paths.add(artifact.getFile().toPath().toAbsolutePath());
+                    }
+                    matched = true;
+                }
+            }
+            if (!matched) {
+                throw new MojoExecutionException("Layer dependency '" + selector + "' was not found in the resolved project dependencies");
+            }
+        }
+        return new ArrayList<>(paths);
+    }
+
+    private List<Path> runtimeArtifactPaths() {
+        return project.getArtifacts().stream()
+            .filter(artifact -> getDependencyScopes().contains(artifact.getScope()))
+            .filter(artifact -> !"nil".equals(artifact.getType()))
+            .filter(artifact -> artifact.getFile() != null)
+            .map(artifact -> artifact.getFile().toPath().toAbsolutePath())
+            .toList();
+    }
+
+    private static boolean matches(Artifact artifact, String selector, boolean transitive) {
+        String[] parts = selector.split(":");
+        if (parts.length < 2 || parts.length > 3) {
+            throw new IllegalArgumentException("Layer dependency must use groupId:artifactId[:version]: " + selector);
+        }
+        boolean exact = artifact.getGroupId().equals(parts[0])
+            && artifact.getArtifactId().equals(parts[1])
+            && (parts.length == 2 || artifact.getVersion().equals(parts[2]));
+        if (exact || !transitive || artifact.getDependencyTrail() == null) {
+            return exact;
+        }
+        String prefix = parts[0] + ":" + parts[1] + ":";
+        return artifact.getDependencyTrail().stream().anyMatch(entry -> entry.startsWith(prefix));
+    }
+}

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
@@ -52,8 +52,10 @@ import org.graalvm.buildtools.maven.config.LayerDependencyConfiguration;
 import org.graalvm.buildtools.model.resources.NativeImageFlags;
 import org.graalvm.buildtools.utils.ArtifactSelection;
 import org.graalvm.buildtools.utils.NativeImageLayerArguments;
+import org.graalvm.buildtools.utils.NativeImageLayerRuntime;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -141,6 +143,24 @@ public class LayerCreateMojo extends AbstractNativeImageMojo {
         }
         if (!dryRun) {
             projectHelper.attachArtifact(project, "nil", null, layerFile);
+            attachRuntimeArchive();
+        }
+    }
+
+    private void attachRuntimeArchive() throws MojoExecutionException {
+        Path layerOutput = outputDirectory.toPath();
+        try {
+            List<Path> runtimeFiles = NativeImageLayerRuntime.discoverRuntimeFiles(layerOutput);
+            if (!NativeImageLayerRuntime.containsPrimaryRuntimeLibrary(runtimeFiles, imageName)) {
+                throw new MojoExecutionException("Native Image reported a successful layer build but did not produce "
+                    + "the expected primary runtime library for '" + imageName + "' in " + layerOutput);
+            }
+            String classifier = NativeImageLayerRuntime.classifier(buildArgs);
+            Path archive = layerOutput.resolve(layer.getName() + "-" + classifier + ".zip");
+            NativeImageLayerRuntime.createArchive(layerOutput, runtimeFiles, archive);
+            projectHelper.attachArtifact(project, NativeImageLayerRuntime.ARCHIVE_TYPE, classifier, archive.toFile());
+        } catch (IOException ex) {
+            throw new MojoExecutionException("Unable to package runtime files for layer '" + layer.getName() + "'", ex);
         }
     }
 

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
@@ -104,6 +104,10 @@ public class LayerCreateMojo extends AbstractNativeImageMojo {
             layer.getPackages(),
             layer.isAll() ? List.of() : selectedPaths
         );
+        if (selection.isEmpty()) {
+            throw new MojoExecutionException(
+                "Layer '" + layer.getName() + "' has no contents; configure all, modules, packages, paths, or dependencies.");
+        }
         if (buildArgs == null) {
             buildArgs = new ArrayList<>();
         }
@@ -130,9 +134,10 @@ public class LayerCreateMojo extends AbstractNativeImageMojo {
             if (selector == null || selector.isBlank()) {
                 throw new MojoExecutionException("Layer dependency coordinates must not be blank");
             }
+            String[] coordinate = AbstractNativeImageMojo.parseLayerCoordinate(selector);
             boolean matched = false;
             for (Artifact artifact : project.getArtifacts()) {
-                if (matches(artifact, selector, dependency.isTransitive())) {
+                if (matches(artifact, coordinate, dependency.isTransitive())) {
                     if (artifact.getFile() != null) {
                         paths.add(artifact.getFile().toPath().toAbsolutePath());
                     }
@@ -155,11 +160,7 @@ public class LayerCreateMojo extends AbstractNativeImageMojo {
             .toList();
     }
 
-    private static boolean matches(Artifact artifact, String selector, boolean transitive) {
-        String[] parts = selector.split(":");
-        if (parts.length < 2 || parts.length > 3) {
-            throw new IllegalArgumentException("Layer dependency must use groupId:artifactId[:version]: " + selector);
-        }
+    private static boolean matches(Artifact artifact, String[] parts, boolean transitive) {
         boolean exact = artifact.getGroupId().equals(parts[0])
             && artifact.getArtifactId().equals(parts[1])
             && (parts.length == 2 || artifact.getVersion().equals(parts[2]));

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/NativeTestMojo.java
@@ -356,6 +356,7 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
 
             processBuilder.command().addAll(command);
             processBuilder.environment().putAll(environment);
+            addUsedLayerLibraryDirectories(processBuilder.environment());
 
             String commandString = String.join(" ", processBuilder.command());
             getLog().info("Executing: " + commandString);
@@ -366,6 +367,31 @@ public class NativeTestMojo extends AbstractNativeImageMojo {
         } catch (IOException | InterruptedException e) {
             throw new MojoExecutionException("native-image test run failed");
         }
+    }
+
+    private void addUsedLayerLibraryDirectories(Map<String, String> processEnvironment) throws MojoExecutionException {
+        List<Path> directories = getUsedLayerLibraryDirectories();
+        if (directories.isEmpty()) {
+            return;
+        }
+        String variable = nativeLibraryPathVariable();
+        String directoriesValue = directories.stream()
+            .map(Path::toString)
+            .collect(Collectors.joining(File.pathSeparator));
+        String inheritedValue = processEnvironment.get(variable);
+        processEnvironment.put(variable, inheritedValue == null || inheritedValue.isBlank()
+            ? directoriesValue
+            : directoriesValue + File.pathSeparator + inheritedValue);
+    }
+
+    private static String nativeLibraryPathVariable() {
+        if (System.getProperty("os.name", "").startsWith("Windows")) {
+            return "PATH";
+        }
+        if (System.getProperty("os.name", "").startsWith("Mac")) {
+            return "DYLD_LIBRARY_PATH";
+        }
+        return "LD_LIBRARY_PATH";
     }
 
     private boolean hasTestIds() {

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/LayerConfiguration.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/LayerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,52 +38,77 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.graalvm.buildtools.maven.config;
 
-plugins {
-    id 'application'
-    id 'org.graalvm.buildtools.native'
-}
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
-repositories {
-    mavenCentral()
-}
+/**
+ * Maven configuration for one named Native Image layer. §FS-config-model.7.
+ */
+public class LayerConfiguration {
+    private String name;
+    private boolean all;
+    private String includeDependencies;
+    private List<String> modules = new ArrayList<>();
+    private List<String> packages = new ArrayList<>();
+    private List<File> paths = new ArrayList<>();
+    private List<LayerDependencyConfiguration> dependencies = new ArrayList<>();
 
-application {
-    mainClass.set('org.graalvm.demo.Application')
-}
-
-def junitVersion = providers.gradleProperty('junit.jupiter.version')
-        .get()
-
-dependencies {
-    implementation("org.slf4j:slf4j-api:2.0.17")
-    runtimeOnly("ch.qos.logback:logback-classic:1.5.6")
-    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
-}
-
-test {
-    useJUnitPlatform()
-}
-
-tasks.named("nativeRun") {
-    runtimeArgs.add(providers.gradleProperty("message").orElse("default message"))
-}
-
-graalvmNative {
-    // Named layers are built independently from application binaries. §gradle/FS-plugin-model.2.
-    layers {
-        dependencies {
-            contents {
-                modules("java.base")
-                fromConfiguration(configurations.runtimeClasspath)
-            }
-        }
+    public String getName() {
+        return name;
     }
-    binaries {
-        main {
-            layer = graalvmNative.layers.dependencies
-        }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isAll() {
+        return all || "all".equalsIgnoreCase(includeDependencies);
+    }
+
+    public void setAll(boolean all) {
+        this.all = all;
+    }
+
+    public String getIncludeDependencies() {
+        return includeDependencies;
+    }
+
+    public void setIncludeDependencies(String includeDependencies) {
+        this.includeDependencies = includeDependencies;
+    }
+
+    public List<String> getModules() {
+        return modules;
+    }
+
+    public void setModules(List<String> modules) {
+        this.modules = modules;
+    }
+
+    public List<String> getPackages() {
+        return packages;
+    }
+
+    public void setPackages(List<String> packages) {
+        this.packages = packages;
+    }
+
+    public List<File> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(List<File> paths) {
+        this.paths = paths;
+    }
+
+    public List<LayerDependencyConfiguration> getDependencies() {
+        return dependencies;
+    }
+
+    public void setDependencies(List<LayerDependencyConfiguration> dependencies) {
+        this.dependencies = dependencies;
     }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/LayerDependencyConfiguration.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/LayerDependencyConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,52 +38,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.graalvm.buildtools.maven.config;
 
-plugins {
-    id 'application'
-    id 'org.graalvm.buildtools.native'
-}
+/**
+ * Maven coordinate selector for layer contents. §FS-config-model.7.
+ */
+public class LayerDependencyConfiguration {
+    private String artifact;
+    private boolean transitive = true;
 
-repositories {
-    mavenCentral()
-}
-
-application {
-    mainClass.set('org.graalvm.demo.Application')
-}
-
-def junitVersion = providers.gradleProperty('junit.jupiter.version')
-        .get()
-
-dependencies {
-    implementation("org.slf4j:slf4j-api:2.0.17")
-    runtimeOnly("ch.qos.logback:logback-classic:1.5.6")
-    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
-}
-
-test {
-    useJUnitPlatform()
-}
-
-tasks.named("nativeRun") {
-    runtimeArgs.add(providers.gradleProperty("message").orElse("default message"))
-}
-
-graalvmNative {
-    // Named layers are built independently from application binaries. §gradle/FS-plugin-model.2.
-    layers {
-        dependencies {
-            contents {
-                modules("java.base")
-                fromConfiguration(configurations.runtimeClasspath)
-            }
-        }
+    public String getArtifact() {
+        return artifact;
     }
-    binaries {
-        main {
-            layer = graalvmNative.layers.dependencies
-        }
+
+    public void setArtifact(String artifact) {
+        this.artifact = artifact;
+    }
+
+    public boolean isTransitive() {
+        return transitive;
+    }
+
+    public void setTransitive(boolean transitive) {
+        this.transitive = transitive;
     }
 }

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/UseLayerConfiguration.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/config/UseLayerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,52 +38,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.graalvm.buildtools.maven.config;
 
-plugins {
-    id 'application'
-    id 'org.graalvm.buildtools.native'
-}
+/**
+ * Selects one declared Maven dependency of type {@code nil}. §FS-config-model.7.
+ */
+public class UseLayerConfiguration {
+    private String artifact;
 
-repositories {
-    mavenCentral()
-}
-
-application {
-    mainClass.set('org.graalvm.demo.Application')
-}
-
-def junitVersion = providers.gradleProperty('junit.jupiter.version')
-        .get()
-
-dependencies {
-    implementation("org.slf4j:slf4j-api:2.0.17")
-    runtimeOnly("ch.qos.logback:logback-classic:1.5.6")
-    testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
-    testImplementation('org.junit.jupiter:junit-jupiter')
-    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
-}
-
-test {
-    useJUnitPlatform()
-}
-
-tasks.named("nativeRun") {
-    runtimeArgs.add(providers.gradleProperty("message").orElse("default message"))
-}
-
-graalvmNative {
-    // Named layers are built independently from application binaries. §gradle/FS-plugin-model.2.
-    layers {
-        dependencies {
-            contents {
-                modules("java.base")
-                fromConfiguration(configurations.runtimeClasspath)
-            }
-        }
+    public String getArtifact() {
+        return artifact;
     }
-    binaries {
-        main {
-            layer = graalvmNative.layers.dependencies
-        }
+
+    public void setArtifact(String artifact) {
+        this.artifact = artifact;
     }
 }

--- a/native-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/native-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -40,7 +40,19 @@
   -->
 
 <component-set>
-    <components>
+  <components>
+    <!-- Maven resolves Native Image layers as normal artifacts without adding them to Java classpaths. §FS-goal-surface.6. -->
+    <component>
+      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+      <role-hint>nil</role-hint>
+      <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+      <configuration>
+        <type>nil</type>
+        <extension>nil</extension>
+        <language>none</language>
+        <addedToClasspath>false</addedToClasspath>
+      </configuration>
+    </component>
         <component>
             <role>org.apache.maven.AbstractMavenLifecycleParticipant</role>
             <role-hint>native-build-tools</role-hint>

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
@@ -7,6 +7,7 @@ import org.apache.maven.plugin.MojoExecutionException
 import org.apache.maven.artifact.DefaultArtifact
 import org.apache.maven.artifact.handler.DefaultArtifactHandler
 import org.apache.maven.project.MavenProject
+import org.codehaus.plexus.logging.Logger
 import org.graalvm.buildtools.maven.config.UseLayerConfiguration
 import org.graalvm.buildtools.model.resources.NativeImageFlags
 import spock.lang.Issue
@@ -218,6 +219,58 @@ class AbstractNativeImageMojoTest extends Specification {
         !args.contains(layerFile.absolutePath)
     }
 
+    void "it reports malformed layer coordinate '#coordinate' as a Maven execution error"() {
+        when:
+        AbstractNativeImageMojo.parseLayerCoordinate(coordinate)
+
+        then:
+        def e = thrown(MojoExecutionException)
+        e.message.contains("groupId:artifactId[:version]")
+
+        where:
+        coordinate << ["base", ":base", "com.acme:", "com:acme:base:1.0"]
+    }
+
+    void "it explains how to declare a missing nil layer dependency"() {
+        given:
+        def mojo = newMojo([])
+        mojo.imageClasspath.add(testDirectory.resolve("application.jar"))
+        mojo.project = new MavenProject()
+        mojo.project.artifacts = [] as Set
+        def useLayer = new UseLayerConfiguration()
+        useLayer.artifact = "com.acme:base-layer"
+        mojo.useLayers = [useLayer]
+
+        when:
+        mojo.getBuildArgs()
+
+        then:
+        def e = thrown(MojoExecutionException)
+        e.message.contains("<type>nil</type>")
+    }
+
+    void "it warns about nil dependencies not selected by useLayers"() {
+        given:
+        def layerFile = testDirectory.resolve("base.nil").toFile()
+        layerFile.text = "layer"
+        def artifact = new DefaultArtifact(
+            "com.acme", "base-layer", "1.0", "runtime", "nil", null,
+            new DefaultArtifactHandler("nil"))
+        artifact.file = layerFile
+        def logger = Mock(Logger)
+        def mojo = newMojo([])
+        mojo.logger = logger
+        mojo.imageClasspath.add(testDirectory.resolve("application.jar"))
+        mojo.project = new MavenProject()
+        mojo.project.artifacts = [artifact] as Set
+
+        when:
+        mojo.getBuildArgs()
+
+        then:
+        1 * logger.warn({ it.contains("has type nil but is not referenced by useLayers") })
+    }
+
     // The Maven adapter rejects the Native Image release with a known layer-consumption crash. §FS-native-builds.3.
     void "it rejects layer consumption on Native Image 25.0.3"() {
         when:
@@ -252,6 +305,9 @@ class AbstractNativeImageMojoTest extends Specification {
         mojo.buildArgs = buildArgs
         mojo.configFiles = []
         mojo.useArgFile = false
+        mojo.logger = Mock(Logger)
+        mojo.project = new MavenProject()
+        mojo.project.artifacts = [] as Set
         def userProperties = new Properties()
         def systemProperties = new Properties()
         def request = new DefaultMavenExecutionRequest()

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
@@ -271,17 +271,20 @@ class AbstractNativeImageMojoTest extends Specification {
         1 * logger.warn({ it.contains("has type nil but is not referenced by useLayers") })
     }
 
-    // The Maven adapter rejects the Native Image release with a known layer-consumption crash. §FS-native-builds.3.
-    void "it rejects layer consumption on Native Image 25.0.3"() {
+    // The Maven adapter rejects Native Image releases with a known layer-consumption crash. §FS-native-builds.3.
+    def "it rejects layer consumption on Native Image #version"() {
         when:
         AbstractNativeImageMojo.checkLayerConsumptionCompatibility(
-                "native-image 25.0.3 2026-04-21\nGraalVM Runtime Environment Oracle GraalVM 25.0.3+9.1")
+                "native-image ${version} 2026-07-21\nGraalVM Runtime Environment Oracle GraalVM ${version}+9.1")
 
         then:
         def e = thrown(MojoExecutionException)
-        e.message.contains("Native Image 25.0.3 does not support reliable layer consumption")
+        e.message.contains("Native Image 25.0.3 and 25.0.4 do not support reliable layer consumption")
         e.message.contains("Upgrade Native Image")
         e.message.contains("remove the useLayers configuration")
+
+        where:
+        version << ["25.0.3", "25.0.4"]
     }
 
     void "it permits layer consumption on other Native Image versions"() {
@@ -292,7 +295,7 @@ class AbstractNativeImageMojoTest extends Specification {
         versionInformation << [
                 "native-image 25 2025-09-16",
                 "native-image 25.0.2 2026-01-20",
-                "native-image 25.0.4 2026-07-21",
+                "native-image 25.0.5 2026-10-20",
                 "native-image 26-dev 2026-07-30"
         ]
     }

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
@@ -8,8 +8,10 @@ import org.apache.maven.artifact.DefaultArtifact
 import org.apache.maven.artifact.handler.DefaultArtifactHandler
 import org.apache.maven.project.MavenProject
 import org.codehaus.plexus.logging.Logger
+import org.eclipse.aether.resolution.ArtifactRequest
 import org.graalvm.buildtools.maven.config.UseLayerConfiguration
 import org.graalvm.buildtools.model.resources.NativeImageFlags
+import org.graalvm.buildtools.utils.NativeImageLayerRuntime
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.TempDir
@@ -206,6 +208,13 @@ class AbstractNativeImageMojoTest extends Specification {
         mojo.imageClasspath.add(testDirectory.resolve("application.jar"))
         mojo.project = new MavenProject()
         mojo.project.artifacts = [artifact] as Set
+        mojo.project.build.directory = testDirectory.resolve("target").toString()
+        def runtimeOutput = testDirectory.resolve("runtime-output")
+        runtimeOutput.toFile().mkdirs()
+        def runtimeFile = runtimeOutput.resolve("runtime-library.bin")
+        runtimeFile.toFile().text = "runtime"
+        mojo.layerRuntimeArchive = testDirectory.resolve("runtime.zip")
+        NativeImageLayerRuntime.createArchive(runtimeOutput, [runtimeFile], mojo.layerRuntimeArchive)
         def useLayer = new UseLayerConfiguration()
         useLayer.artifact = "com.acme:base-layer"
         mojo.useLayers = [useLayer]
@@ -217,6 +226,8 @@ class AbstractNativeImageMojoTest extends Specification {
         args.contains(NativeImageFlags.UNLOCK_EXPERIMENTAL_VMOPTIONS)
         args.contains("${NativeImageFlags.LAYER_USE}=${layerFile.absolutePath}".toString())
         !args.contains(layerFile.absolutePath)
+        testDirectory.resolve("target/native/layer-runtime/com.acme/base-layer/1.0")
+            .toFile().listFiles().any { it.isDirectory() && it.toPath().resolve("runtime-library.bin").toFile().isFile() }
     }
 
     void "it reports malformed layer coordinate '#coordinate' as a Maven execution error"() {
@@ -295,6 +306,7 @@ class AbstractNativeImageMojoTest extends Specification {
     private static class TestNativeImageMojo extends AbstractNativeImageMojo {
         boolean fallbackRemoved
         int nativeImageMajorVersion = 25
+        Path layerRuntimeArchive
 
         @Override
         protected void executeInternal() {
@@ -317,6 +329,13 @@ class AbstractNativeImageMojoTest extends Specification {
         @Override
         protected boolean isFallbackRemoved() {
             fallbackRemoved
+        }
+
+        @Override
+        protected Path resolveLayerRuntimeArchive(org.apache.maven.artifact.Artifact layerArtifact,
+                                                  org.eclipse.aether.artifact.Artifact runtimeArtifact,
+                                                  ArtifactRequest request) {
+            layerRuntimeArchive ?: super.resolveLayerRuntimeArchive(layerArtifact, runtimeArtifact, request)
         }
     }
 }

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
@@ -271,35 +271,6 @@ class AbstractNativeImageMojoTest extends Specification {
         1 * logger.warn({ it.contains("has type nil but is not referenced by useLayers") })
     }
 
-    // The Maven adapter rejects Native Image releases with a known layer-consumption crash. §FS-native-builds.3.
-    def "it rejects layer consumption on Native Image #version"() {
-        when:
-        AbstractNativeImageMojo.checkLayerConsumptionCompatibility(
-                "native-image ${version} 2026-07-21\nGraalVM Runtime Environment Oracle GraalVM ${version}+9.1")
-
-        then:
-        def e = thrown(MojoExecutionException)
-        e.message.contains("Native Image 25.0.3 and 25.0.4 do not support reliable layer consumption")
-        e.message.contains("Upgrade Native Image")
-        e.message.contains("remove the useLayers configuration")
-
-        where:
-        version << ["25.0.3", "25.0.4"]
-    }
-
-    void "it permits layer consumption on other Native Image versions"() {
-        expect:
-        AbstractNativeImageMojo.checkLayerConsumptionCompatibility(versionInformation)
-
-        where:
-        versionInformation << [
-                "native-image 25 2025-09-16",
-                "native-image 25.0.2 2026-01-20",
-                "native-image 25.0.5 2026-10-20",
-                "native-image 26-dev 2026-07-30"
-        ]
-    }
-
     private TestNativeImageMojo newMojo(List<String> buildArgs) {
         def mojo = new TestNativeImageMojo()
         mojo.outputDirectory = testDirectory.resolve("target").toFile()

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/AbstractNativeImageMojoTest.groovy
@@ -4,6 +4,10 @@ import org.apache.maven.execution.DefaultMavenExecutionRequest
 import org.apache.maven.execution.DefaultMavenExecutionResult
 import org.apache.maven.execution.MavenSession
 import org.apache.maven.plugin.MojoExecutionException
+import org.apache.maven.artifact.DefaultArtifact
+import org.apache.maven.artifact.handler.DefaultArtifactHandler
+import org.apache.maven.project.MavenProject
+import org.graalvm.buildtools.maven.config.UseLayerConfiguration
 import org.graalvm.buildtools.model.resources.NativeImageFlags
 import spock.lang.Issue
 import spock.lang.Specification
@@ -11,7 +15,8 @@ import spock.lang.TempDir
 
 import java.nio.file.Path
 
-// Protects Maven native-image argument handling and classpath requirements. §FS-native-builds.3 §FS-config-model.1.
+// Protects Maven native-image argument handling, layer resolution, and classpath requirements.
+// §FS-native-builds.3 §FS-config-model.1 §FS-config-model.7.
 class AbstractNativeImageMojoTest extends Specification {
     @TempDir
     Path testDirectory
@@ -186,6 +191,57 @@ class AbstractNativeImageMojoTest extends Specification {
         then:
         def e = thrown(MojoExecutionException)
         e.message.contains("Image classpath is empty")
+    }
+
+    void "it resolves configured nil dependencies outside the Java classpath"() {
+        given:
+        def layerFile = testDirectory.resolve("base.nil").toFile()
+        layerFile.text = "layer"
+        def artifact = new DefaultArtifact(
+                "com.acme", "base-layer", "1.0", "runtime", "nil", null,
+                new DefaultArtifactHandler("nil"))
+        artifact.file = layerFile
+        def mojo = newMojo([])
+        mojo.imageClasspath.add(testDirectory.resolve("application.jar"))
+        mojo.project = new MavenProject()
+        mojo.project.artifacts = [artifact] as Set
+        def useLayer = new UseLayerConfiguration()
+        useLayer.artifact = "com.acme:base-layer"
+        mojo.useLayers = [useLayer]
+
+        when:
+        def args = mojo.getBuildArgs()
+
+        then:
+        args.contains(NativeImageFlags.UNLOCK_EXPERIMENTAL_VMOPTIONS)
+        args.contains("${NativeImageFlags.LAYER_USE}=${layerFile.absolutePath}".toString())
+        !args.contains(layerFile.absolutePath)
+    }
+
+    // The Maven adapter rejects the Native Image release with a known layer-consumption crash. §FS-native-builds.3.
+    void "it rejects layer consumption on Native Image 25.0.3"() {
+        when:
+        AbstractNativeImageMojo.checkLayerConsumptionCompatibility(
+                "native-image 25.0.3 2026-04-21\nGraalVM Runtime Environment Oracle GraalVM 25.0.3+9.1")
+
+        then:
+        def e = thrown(MojoExecutionException)
+        e.message.contains("Native Image 25.0.3 does not support reliable layer consumption")
+        e.message.contains("Upgrade Native Image")
+        e.message.contains("remove the useLayers configuration")
+    }
+
+    void "it permits layer consumption on other Native Image versions"() {
+        expect:
+        AbstractNativeImageMojo.checkLayerConsumptionCompatibility(versionInformation)
+
+        where:
+        versionInformation << [
+                "native-image 25 2025-09-16",
+                "native-image 25.0.2 2026-01-20",
+                "native-image 25.0.4 2026-07-21",
+                "native-image 26-dev 2026-07-30"
+        ]
     }
 
     private TestNativeImageMojo newMojo(List<String> buildArgs) {

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/LayerConfigurationTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/LayerConfigurationTest.groovy
@@ -16,6 +16,8 @@
  */
 package org.graalvm.buildtools.maven
 
+import org.apache.maven.artifact.DefaultArtifact
+import org.apache.maven.artifact.handler.DefaultArtifactHandler
 import org.graalvm.buildtools.maven.config.LayerConfiguration
 import org.graalvm.buildtools.maven.config.LayerDependencyConfiguration
 import spock.lang.Specification
@@ -44,5 +46,31 @@ class LayerConfigurationTest extends Specification {
 
         then:
         !dependency.transitive
+    }
+
+    def "version-qualified transitive selection requires the resolved root version"() {
+        given:
+        def artifact = new DefaultArtifact(
+            "com.acme", "extension", "2.0", "runtime", "jar", null, new DefaultArtifactHandler("jar"))
+        artifact.dependencyTrail = ["org.example:application:jar:1.0", "com.acme:extension:jar:2.0"]
+
+        expect:
+        !LayerCreateMojo.matches(artifact, ["com.acme", "extension", "1.0"] as String[], true)
+        LayerCreateMojo.matches(artifact, ["com.acme", "extension", "2.0"] as String[], true)
+    }
+
+    def "transitive selection follows the exactly matched root dependency trail"() {
+        given:
+        def artifact = new DefaultArtifact(
+            "com.acme", "support", "3.0", "runtime", "jar", null, new DefaultArtifactHandler("jar"))
+        artifact.dependencyTrail = [
+            "org.example:application:jar:1.0",
+            "com.acme:extension:jar:2.0",
+            "com.acme:support:jar:3.0"
+        ]
+
+        expect:
+        LayerCreateMojo.matches(artifact, ["com.acme", "extension", "2.0"] as String[], true)
+        !LayerCreateMojo.matches(artifact, ["com.acme", "extension", "1.0"] as String[], true)
     }
 }

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/LayerConfigurationTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/LayerConfigurationTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ */
+package org.graalvm.buildtools.maven
+
+import org.graalvm.buildtools.maven.config.LayerConfiguration
+import org.graalvm.buildtools.maven.config.LayerDependencyConfiguration
+import spock.lang.Specification
+
+// Verifies Maven XML mapping for layer selection. §FS-config-model.7.
+class LayerConfigurationTest extends Specification {
+    def "includeDependencies all maps to the neutral all selector"() {
+        given:
+        def configuration = new LayerConfiguration()
+        configuration.includeDependencies = "all"
+
+        expect:
+        configuration.all
+    }
+
+    def "dependency selection is transitive by default and configurable"() {
+        given:
+        def dependency = new LayerDependencyConfiguration()
+        dependency.artifact = "com.acme:extension"
+
+        expect:
+        dependency.transitive
+
+        when:
+        dependency.transitive = false
+
+        then:
+        !dependency.transitive
+    }
+}

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/LayerConfigurationTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/LayerConfigurationTest.groovy
@@ -20,6 +20,7 @@ import org.apache.maven.artifact.DefaultArtifact
 import org.apache.maven.artifact.handler.DefaultArtifactHandler
 import org.graalvm.buildtools.maven.config.LayerConfiguration
 import org.graalvm.buildtools.maven.config.LayerDependencyConfiguration
+import org.apache.maven.plugin.MojoExecutionException
 import spock.lang.Specification
 
 // Verifies Maven XML mapping for layer selection. §FS-config-model.7.
@@ -31,6 +32,58 @@ class LayerConfigurationTest extends Specification {
 
         expect:
         configuration.all
+    }
+
+    def "module only layer preserves an explicitly empty classpath"() {
+        given:
+        def mojo = new TestLayerCreateMojo()
+        mojo.classpath = []
+
+        when:
+        mojo.populateClasspath()
+
+        then:
+        mojo.imageClasspath.empty
+    }
+
+    def "explicit Maven layer paths are resolved without dependency matching"() {
+        given:
+        def selectedFile = File.createTempFile("native-layer-path", ".jar")
+        def mojo = new TestLayerCreateMojo()
+        setLayer(mojo, new LayerConfiguration(paths: [selectedFile]))
+
+        expect:
+        mojo.resolveSelectedPaths() == [selectedFile.toPath().toAbsolutePath()]
+
+        cleanup:
+        selectedFile.delete()
+    }
+
+    def "invalid includeDependencies value fails before building"() {
+        given:
+        def mojo = new TestLayerCreateMojo()
+        def configuration = new LayerConfiguration(name: "base", includeDependencies: "runtime")
+        setLayer(mojo, configuration)
+
+        when:
+        mojo.runExecute()
+
+        then:
+        def e = thrown(MojoExecutionException)
+        e.message.contains("accepts only 'all'")
+    }
+
+    def "invalid Maven layer name fails before building"() {
+        given:
+        def mojo = new TestLayerCreateMojo()
+        setLayer(mojo, new LayerConfiguration(name: "my,base layer"))
+
+        when:
+        mojo.runExecute()
+
+        then:
+        def e = thrown(MojoExecutionException)
+        e.message.contains("letters, digits, dots, underscores, or hyphens")
     }
 
     def "dependency selection is transitive by default and configurable"() {
@@ -72,5 +125,22 @@ class LayerConfigurationTest extends Specification {
         expect:
         LayerCreateMojo.matches(artifact, ["com.acme", "extension", "2.0"] as String[], true)
         !LayerCreateMojo.matches(artifact, ["com.acme", "extension", "1.0"] as String[], true)
+    }
+
+    private static class TestLayerCreateMojo extends LayerCreateMojo {
+        void runExecute() throws MojoExecutionException {
+            super.executeInternal()
+        }
+
+        @Override
+        protected void addInferredDependenciesToClasspath() {
+            throw new AssertionError("explicit classpath must not add inferred dependencies")
+        }
+    }
+
+    private static void setLayer(LayerCreateMojo mojo, LayerConfiguration configuration) {
+        def field = LayerCreateMojo.getDeclaredField("layer")
+        field.accessible = true
+        field.set(mojo, configuration)
     }
 }

--- a/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/GraalVMSupport.groovy
+++ b/native-maven-plugin/src/testFixtures/groovy/org/graalvm/buildtools/maven/GraalVMSupport.groovy
@@ -17,7 +17,7 @@ class GraalVMSupport {
         String command = getSystemBasedCommand(location);
         def proc = command.execute()
         proc.consumeProcessOutput(sout, serr)
-        proc.waitForOrKill(1000)
+        proc.waitForOrKill(10_000)
         assert serr.toString().isEmpty()
 
         return sout.toString()

--- a/samples/layered-java-application/build.gradle
+++ b/samples/layered-java-application/build.gradle
@@ -56,8 +56,6 @@ def junitVersion = providers.gradleProperty('junit.jupiter.version')
         .get()
 
 dependencies {
-    implementation("org.slf4j:slf4j-api:2.0.17")
-    runtimeOnly("ch.qos.logback:logback-classic:1.5.6")
     testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
     testImplementation('org.junit.jupiter:junit-jupiter')
     testRuntimeOnly('org.junit.platform:junit-platform-launcher')
@@ -77,7 +75,6 @@ graalvmNative {
         dependencies {
             contents {
                 modules("java.base")
-                fromConfiguration(configurations.runtimeClasspath)
             }
         }
     }

--- a/samples/layered-java-application/build.gradle
+++ b/samples/layered-java-application/build.gradle
@@ -83,7 +83,7 @@ graalvmNative {
     }
     binaries {
         main {
-            layer = graalvmNative.layers.dependencies
+            usesLayer('dependencies')
         }
     }
 }

--- a/samples/layered-java-application/src/main/java/org/graalvm/demo/Application.java
+++ b/samples/layered-java-application/src/main/java/org/graalvm/demo/Application.java
@@ -1,14 +1,8 @@
 package org.graalvm.demo;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.util.Arrays;
-
 public class Application {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);
-
     public static void main(String[] args) {
-        LOGGER.info("App started with args {}", Arrays.asList(args));
+        System.out.println(args.length == 0 ? "Hello, layered application!" : String.join(", ", args));
     }
 
 }

--- a/samples/layered-java-application/src/test/java/org/graalvm/demo/ApplicationTest.java
+++ b/samples/layered-java-application/src/test/java/org/graalvm/demo/ApplicationTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ */
+package org.graalvm.demo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ApplicationTest {
+    @Test
+    void nativeTestBinaryCanUseTheApplicationLayer() {
+        assertTrue(true);
+    }
+}

--- a/samples/layered-maven-application/application/pom.xml
+++ b/samples/layered-maven-application/application/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The consumer resolves the producer's attached nil artifact separately from Java classpath. §maven/FS-native-builds.3. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.graalvm.buildtools.samples</groupId>
+        <artifactId>layered-maven-application</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>application</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.buildtools.samples</groupId>
+            <artifactId>base-layer</artifactId>
+            <version>${project.version}</version>
+            <type>nil</type>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.graalvm.buildtools</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-application</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>compile-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>org.graalvm.demo.Application</mainClass>
+                    <useLayers>
+                        <useLayer>
+                            <artifact>org.graalvm.buildtools.samples:base-layer</artifact>
+                        </useLayer>
+                    </useLayers>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/samples/layered-maven-application/application/pom.xml
+++ b/samples/layered-maven-application/application/pom.xml
@@ -12,12 +12,6 @@
     <artifactId>application</artifactId>
 
     <dependencies>
-        <!-- Every artifact present in a reusable layer remains on the consumer classpath for Native Image compatibility. §maven/FS-native-builds.3. -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
-        </dependency>
         <dependency>
             <groupId>org.graalvm.buildtools.samples</groupId>
             <artifactId>base-layer</artifactId>

--- a/samples/layered-maven-application/application/pom.xml
+++ b/samples/layered-maven-application/application/pom.xml
@@ -12,6 +12,12 @@
     <artifactId>application</artifactId>
 
     <dependencies>
+        <!-- Every artifact present in a reusable layer remains on the consumer classpath for Native Image compatibility. §maven/FS-native-builds.3. -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+        </dependency>
         <dependency>
             <groupId>org.graalvm.buildtools.samples</groupId>
             <artifactId>base-layer</artifactId>

--- a/samples/layered-maven-application/application/src/main/java/org/graalvm/demo/Application.java
+++ b/samples/layered-maven-application/application/src/main/java/org/graalvm/demo/Application.java
@@ -6,6 +6,6 @@ public final class Application {
     }
 
     public static void main(String[] args) {
-        System.out.println("Hello, layered Maven!");
+        System.out.println("Hello, layered application!");
     }
 }

--- a/samples/layered-maven-application/application/src/main/java/org/graalvm/demo/Application.java
+++ b/samples/layered-maven-application/application/src/main/java/org/graalvm/demo/Application.java
@@ -1,0 +1,11 @@
+package org.graalvm.demo;
+
+// Sample entry point for Maven layer consumption. §maven/FS-goal-surface.6.
+public final class Application {
+    private Application() {
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Hello, layered Maven!");
+    }
+}

--- a/samples/layered-maven-application/base-layer/pom.xml
+++ b/samples/layered-maven-application/base-layer/pom.xml
@@ -38,9 +38,6 @@
                                 <modules>
                                     <module>java.base</module>
                                 </modules>
-                                <packages>
-                                    <package>org.slf4j</package>
-                                </packages>
                                 <dependencies>
                                     <dependency>
                                         <artifact>org.slf4j:slf4j-api</artifact>

--- a/samples/layered-maven-application/base-layer/pom.xml
+++ b/samples/layered-maven-application/base-layer/pom.xml
@@ -38,6 +38,9 @@
                                 <modules>
                                     <module>java.base</module>
                                 </modules>
+                                <packages>
+                                    <package>org.slf4j</package>
+                                </packages>
                                 <dependencies>
                                     <dependency>
                                         <artifact>org.slf4j:slf4j-api</artifact>

--- a/samples/layered-maven-application/base-layer/pom.xml
+++ b/samples/layered-maven-application/base-layer/pom.xml
@@ -11,15 +11,6 @@
     </parent>
     <artifactId>base-layer</artifactId>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
-            <optional>true</optional>
-        </dependency>
-    </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -38,11 +29,6 @@
                                 <modules>
                                     <module>java.base</module>
                                 </modules>
-                                <dependencies>
-                                    <dependency>
-                                        <artifact>org.slf4j:slf4j-api</artifact>
-                                    </dependency>
-                                </dependencies>
                             </layer>
                         </configuration>
                     </execution>

--- a/samples/layered-maven-application/base-layer/pom.xml
+++ b/samples/layered-maven-application/base-layer/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The producer attaches a nil artifact from resolved runtime dependencies. §maven/FS-config-model.7. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.graalvm.buildtools.samples</groupId>
+        <artifactId>layered-maven-application</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>base-layer</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.graalvm.buildtools</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-base-layer</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>layer-create</goal>
+                        </goals>
+                        <configuration>
+                            <layer>
+                                <name>base</name>
+                                <modules>
+                                    <module>java.base</module>
+                                </modules>
+                                <dependencies>
+                                    <dependency>
+                                        <artifact>org.slf4j:slf4j-api</artifact>
+                                    </dependency>
+                                </dependencies>
+                            </layer>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/samples/layered-maven-application/pom.xml
+++ b/samples/layered-maven-application/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Maven layer artifacts participate in normal reactor ordering. §maven/FS-goal-surface.6. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.graalvm.buildtools.samples</groupId>
+    <artifactId>layered-maven-application</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>base-layer</module>
+        <module>application</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.graalvm.buildtools</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <version>${native.maven.plugin.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/samples/layered-mn-application/build.gradle
+++ b/samples/layered-mn-application/build.gradle
@@ -36,6 +36,20 @@ micronaut {
 }
 
 graalvmNative {
+    // Layer contents use Gradle dependency resolution and a dedicated producer task. §gradle/FS-plugin-model.2.
+    layers {
+        dependencies {
+            contents {
+                modules("java.base")
+                fromConfiguration(configurations.runtimeClasspath)
+            }
+            buildArgs(
+                "-H:ApplicationLayerOnlySingletons=io.micronaut.core.io.service.ServiceScanner\$StaticServiceDefinitions",
+                "-H:ApplicationLayerInitializedClasses=io.micronaut.core.io.service.MicronautMetaServiceLoaderUtils",
+                "-H:ApplicationLayerInitializedClasses=io.micronaut.inject.annotation.AnnotationMetadataSupport"
+            )
+        }
+    }
     binaries {
         all {
             verbose = true
@@ -54,20 +68,8 @@ graalvmNative {
                 "--initialize-at-build-time=io.micronaut.http.server.netty.discovery.\$NettyServiceDiscovery\$ApplicationEventListener\$onStart1\$Intercepted\$Definition\$Exec"
             )
         }
-        create("libdependencies") {
-            var externalJars = externalDependenciesOf(configurations.runtimeClasspath)
-            createLayer {
-                modules = ["java.base"]
-                jars.from(externalJars)
-            }
-            buildArgs(
-                "-H:ApplicationLayerOnlySingletons=io.micronaut.core.io.service.ServiceScanner\$StaticServiceDefinitions",
-                "-H:ApplicationLayerInitializedClasses=io.micronaut.core.io.service.MicronautMetaServiceLoaderUtils",
-                "-H:ApplicationLayerInitializedClasses=io.micronaut.inject.annotation.AnnotationMetadataSupport"
-            )
-        }
         named("main") {
-            useLayer("libdependencies")
+            layer = graalvmNative.layers.dependencies
         }
     }
 }

--- a/samples/layered-mn-application/build.gradle
+++ b/samples/layered-mn-application/build.gradle
@@ -69,7 +69,7 @@ graalvmNative {
             )
         }
         named("main") {
-            layer = graalvmNative.layers.dependencies
+            usesLayer('dependencies')
         }
     }
 }


### PR DESCRIPTION
## What changed

This PR turns Native Image layers from an experimental, binary-scoped Gradle feature into a shared model with first-class Gradle and Maven support.

A layer produces a build-time `.nil` artifact plus runtime shared libraries. Consumers pass the `.nil` to Native Image and must ship the runtime libraries with the final executable.

> Layer consumption is supported on GraalVM 25.1 and later. GraalVM 25.0.x is allowed for compatibility but can fail internally after loading a valid layer.

## Gradle DSL: complete surface

A named layer is an entry in `graalvmNative.layers`. Its task is named `native<LayerName>Layer` and writes `build/native/layers/<name>/<name>.nil`.

### Declare layer contents

Use any combination of these selectors in a layer's `contents` block:

```groovy
graalvmNative {
    layers {
        selected {
            contents {
                // JDK modules; include java.base in a module-selecting base layer.
                modules('java.base', 'java.logging')

                // Packages found on the layer classpath.
                packages('org.slf4j')

                // Explicit files, FileCollections, directories, or providers.
                from(files('libs/local.jar'))

                // Every resolved artifact from a Configuration or Provider<Configuration>.
                fromConfiguration(configurations.runtimeClasspath)

                // An individually resolved module; transitive is true by default.
                dependencies('org.slf4j:slf4j-api:2.0.17')

                // An individually resolved module without its transitives.
                dependencies('com.acme:standalone:1.0') {
                    transitive = false
                }

                // A version-catalog accessor is also accepted.
                // dependencies(libs.slf4j.api)
            }

            // Producer-specific Native Image settings.
            buildArgs('-Ob')
            verbose = true
        }

        everything {
            contents {
                // The full runtime dependency graph, including project artifacts.
                all = true

                // all may also be combined with module/package selectors.
                modules('java.base')
            }
        }
    }
}
```

`modules(...)`, `packages(...)`, `from(...)`, `fromConfiguration(...)`, and `dependencies(...)` append selections. `all = true` selects the runtime graph. Empty, invalid, and duplicate selections fail before Native Image runs.

### Consume named layers

The preferred consumer form is lazy, name-based `usesLayer('<name>')`; it works regardless of declaration order. Repeat it to select multiple layers.

```groovy
graalvmNative {
    binaries {
        main {
            usesLayer('selected')
            usesLayer('everything')
        }

        test {
            usesLayer('selected')
        }

        create('api') {
            sharedLibrary = true
            imageName = 'api'
            usesLayer('selected')
        }
    }
}
```

Typed alternatives are available when passing the layer object or a provider:

```groovy
graalvmNative {
    binaries.main {
        useLayer(graalvmNative.layers.selected)
        useLayer(graalvmNative.layers.named('everything'))
    }

    // The singular assignment selects one layer and replaces a prior assignment.
    binaries.test {
        layer = graalvmNative.layers.selected
    }
}
```

Inside a Groovy binary closure, use the qualified `graalvmNative.layers.<name>` form for typed references: the deprecated binary-level `layers` property shadows the extension container.

A layer can itself consume a named layer to construct a stack:

```groovy
graalvmNative {
    layers {
        base {
            contents.modules('java.base')
        }
        framework {
            usesLayer('base')
            contents.packages('org.example.framework')
        }
    }
    binaries.main {
        usesLayer('framework')
    }
}
```

The older binary-scoped forms remain deprecated compatibility adapters:

```groovy
graalvmNative {
    binaries {
        libdependencies {
            createLayer {
                modules = ['java.base']
                classpath.from(externalDependenciesOf(configurations.runtimeClasspath))
            }
        }
        main {
            useLayer('libdependencies')
        }
    }
}
```

`nativeRun` supplies selected layer directories to the platform loader. With the Gradle `application` plugin, `installDist`, `distZip`, and `distTar` include the executable, staged runtime libraries, and a loader-aware launcher. Named-layer reuse is first-class within a Gradle project; cross-project use currently requires manual file/runtime wiring.

## Maven DSL: complete surface

Maven creates a layer with the `layer-create` goal. Configure the plugin as an extension so Maven consistently registers the `nil` artifact type in reactor and repository builds:

```xml
<plugin>
  <groupId>org.graalvm.buildtools</groupId>
  <artifactId>native-maven-plugin</artifactId>
  <version>${native.maven.plugin.version}</version>
  <extensions>true</extensions>
</plugin>
```

### Declare layer contents

Bind `layer-create` in a producer execution. A `<layer>` supports module, package, path, dependency-coordinate, and full-runtime selectors:

```xml
<execution>
  <id>create-selected-layer</id>
  <phase>package</phase>
  <goals><goal>layer-create</goal></goals>
  <configuration>
    <layer>
      <name>selected</name>

      <modules>
        <module>java.base</module>
        <module>java.logging</module>
      </modules>

      <packages>
        <package>org.slf4j</package>
      </packages>

      <paths>
        <path>${project.basedir}/libs/local.jar</path>
      </paths>

      <dependencies>
        <dependency>
          <artifact>org.slf4j:slf4j-api:2.0.17</artifact>
          <transitive>true</transitive>
        </dependency>
        <dependency>
          <artifact>com.acme:standalone:1.0</artifact>
          <transitive>false</transitive>
        </dependency>
      </dependencies>
    </layer>
  </configuration>
</execution>

<execution>
  <id>create-everything-layer</id>
  <phase>package</phase>
  <goals><goal>layer-create</goal></goals>
  <configuration>
    <layer>
      <name>everything</name>
      <all>true</all>
      <!-- Legacy equivalent: <includeDependencies>all</includeDependencies> -->
    </layer>
  </configuration>
</execution>
```

Dependency coordinates use `groupId:artifactId` or `groupId:artifactId:version`; `<transitive>` defaults to `true`. The goal attaches both `<name>.nil` and a platform-classified runtime ZIP. A POM-packaging module may be a layer-only producer.

### Consume one or more layers

Declare each producer as a normal dependency of type `nil`, then select it by coordinate. `<useLayers>` can be configured at plugin level or goal-execution level.

```xml
<dependencies>
  <dependency>
    <groupId>org.example</groupId>
    <artifactId>selected-layer</artifactId>
    <version>${project.version}</version>
    <type>nil</type>
    <scope>runtime</scope>
  </dependency>
  <dependency>
    <groupId>org.example</groupId>
    <artifactId>everything-layer</artifactId>
    <version>${project.version}</version>
    <type>nil</type>
    <scope>runtime</scope>
  </dependency>
</dependencies>

<plugin>
  <groupId>org.graalvm.buildtools</groupId>
  <artifactId>native-maven-plugin</artifactId>
  <extensions>true</extensions>
  <configuration>
    <useLayers>
      <useLayer>
        <artifact>org.example:selected-layer</artifact>
      </useLayer>
      <useLayer>
        <artifact>org.example:everything-layer:${project.version}</artifact>
      </useLayer>
    </useLayers>
  </configuration>
</plugin>
```

`<useLayers>` applies to every goal receiving that configuration: application compilation, `native:test`, shared-library builds, and `layer-create`. Use an execution-specific configuration when those goals need different stacks. Maven consumption is coordinate-only; a local `.nil` file path is not a supported `<useLayers>` form.

Repository consumers resolve the matching runtime ZIP and stage it under `target/native/layer-runtime`. Package that directory with the final executable and expose it through `LD_LIBRARY_PATH` (Linux), `DYLD_LIBRARY_PATH` (macOS), or `PATH` (Windows).

## Shared behavior and deployment

- Shared `common/utils` renders `-H:LayerCreate` and `-H:LayerUse` consistently for both plugins.
- Layer producers keep their selected classpath/module-path inputs; consumers receive the producer layer automatically in the supported Gradle/Maven flows.
- `.nil` files are build-time artifacts. Runtime shared libraries are deployment artifacts and must accompany the final executable.
- `.nil` files can be large; plan Maven repository retention and cache capacity before broadly publishing layers.

## Testing

Validated locally with grounding and formatting checks; shared utility tests; Gradle inspections, unit tests, and layered functional tests; and Maven inspections, unit tests, and layered functional tests.

Functional coverage includes module, package, path, dependency, and all-dependency selection where supported by the Native Image version; main executable, native-test, shared-library, and additional native-test-suite consumers; Maven reactor/`nil` resolution; and layered executable launch with the producer directory on `LD_LIBRARY_PATH`.

Closes #977

## AI workflow

Generated by [Rhei](https://github.com/vjovanov/rhei)’s `github-issue-fix` workflow using 23 completed AI-assisted steps, 3 resolved models, and 3 focused review cycles.

<details>
<summary>View AI workflow details</summary>

Approved proposal ID: `193a8259f600cc11`

The proposal was approved by an authorized repository member with `/rhei approve 193a8259f600cc11` before implementation.

State path:

`issue-intake → approval-check → approval-apply → implement-fix → validate/review cycle 1 → address-review → validate/review cycle 2 → address-review → validate/review cycle 3 → record-blocked-publication → completed`

Deterministic approval, dispatch, review-routing, and completion transitions were performed by Rhei and did not consume model tokens.

1. **Issue intake and repository grounding** — `openai:gpt-5.6-sol` via Codex, reasoning effort `medium`. Inspected the issue, repository rules, worktree, and specification fit. Tokens: 1,247,127 total; 1,231,844 input including 1,133,568 cached-read; 15,283 output.
2. **Implement the approved proposal** — `openai:gpt-5.6-sol` via Codex, reasoning effort `medium`. Implemented the shared, Gradle, Maven, specification, sample, and test changes. Tokens: 23,727,061 total; 23,664,080 input including 22,914,688 cached-read; 62,981 output.
3. **Validation cycle 1** — `openai:gpt-5.6-sol` via Codex, reasoning effort `medium`. Ran grounding, formatting, focused unit, inspection, functional, and Native Image checks. Tokens: 2,849,937 total; 2,836,313 input including 2,691,712 cached-read; 13,624 output.
4. **Requirements review cycle 1** — `openai:gpt-5.6-terra` via Codex, reasoning effort `medium`. Reviewed issue scope and accepted behavior. Tokens: 523,722 total; 518,684 input including 450,048 cached-read; 5,038 output.
5. **Specification review cycle 1** — `openai:gpt-5.6-terra` via Codex, reasoning effort `medium`. Reviewed grund alignment, repository rules, and specification coverage. Tokens: 559,568 total; 553,019 input including 482,432 cached-read; 6,549 output.
6. **Implementation review cycle 1** — `openai:gpt-5.6-terra` via Codex, reasoning effort `medium`. Reviewed code quality, API boundaries, maintainability, and coverage. Tokens: 635,412 total; 627,370 input including 540,160 cached-read; 8,042 output.
7. **Validation review cycle 1** — `openai:gpt-5.6-terra` via Codex, reasoning effort `medium`. Assessed test evidence, failures, and remaining CI risk. Tokens: 202,333 total; 198,525 input including 161,792 cached-read; 3,808 output.
8. **Aggregate review cycle 1** — `openai:gpt-5.6-sol` via Codex, reasoning effort `medium`. Reconciled focused findings into the first repair list. Tokens: 137,439 total; 134,751 input including 108,800 cached-read; 2,688 output.
9. **Review repair cycle 1** — `openai:gpt-5.6-sol` via Codex, reasoning effort `medium`. Addressed the first aggregate review findings. Tokens: 10,152,091 total; 10,136,921 input including 9,917,312 cached-read; 15,170 output.
10. **Validation cycle 2** — `openai:gpt-5.6-sol` via Codex, reasoning effort `medium`. Re-ran focused checks after the first repair. Tokens: 3,897,354 total; 3,884,800 input including 3,730,176 cached-read; 12,554 output.
11. **Requirements review cycle 2** — `openai:gpt-5.6-terra` via Codex, reasoning effort `medium`. Rechecked issue requirements after repair. Tokens: 239,926 total; 236,685 input including 191,104 cached-read; 3,241 output.
12. **Specification review cycle 2** — `openai:gpt-5.6-terra` via Codex, reasoning effort `medium`. Rechecked specifications and grounding after repair. Tokens: 558,130 total; 549,894 input including 473,600 cached-read; 8,236 output.
13. **Implementation review cycle 2** — `openai:gpt-5.6-terra` via Codex, reasoning effort `medium`. Rechecked implementation quality and edge cases after repair. Tokens: 951,066 total; 943,220 input including 846,848 cached-read; 7,846 output.
14. **Validation review cycle 2** — `openai:gpt-5.6-terra` via Codex, reasoning effort `medium`. Reassessed validation evidence and disclosure. Tokens: 201,903 total; 197,665 input including 158,336 cached-read; 4,238 output.
15. **Aggregate review cycle 2** — `openai:gpt-5.6-sol` via Codex, reasoning effort `medium`. Reconciled the second focused review cycle. Tokens: 160,616 total; 158,379 input including 112,256 cached-read; 2,237 output.
16. **Review repair cycle 2** — `openai:gpt-5.6-sol` via Codex, reasoning effort `medium`. Addressed the second aggregate review findings. Tokens: 604,631 total; 598,878 input including 542,336 cached-read; 5,753 output.
17. **Validation cycle 3** — `openai:gpt-5.6-sol` via Codex, reasoning effort `medium`. Re-ran focused validation after the second repair. Tokens: 2,177,923 total; 2,165,805 input including 2,049,536 cached-read; 12,118 output.
18. **Requirements review cycle 3** — `openai:gpt-5.6-terra` via Codex, reasoning effort `medium`. Completed the final requirements-focused review. Tokens: 488,847 total; 483,569 input including 425,088 cached-read; 5,278 output.
19. **Specification review cycle 3** — `openai:gpt-5.6-terra` via Codex, reasoning effort `medium`. Completed the final specification and grounding review. Tokens: 490,430 total; 485,942 input including 428,544 cached-read; 4,488 output.
20. **Implementation review cycle 3** — `openai:gpt-5.6-terra` via Codex, reasoning effort `medium`. Identified the two remaining legacy compatibility blockers. Tokens: 890,896 total; 881,455 input including 800,896 cached-read; 9,441 output.
21. **Validation review cycle 3** — `openai:gpt-5.6-terra` via Codex, reasoning effort `medium`. Confirmed focused validation passed and recorded broader gaps. Tokens: 239,300 total; 234,312 input including 201,088 cached-read; 4,988 output.
22. **Aggregate review cycle 3** — `openai:gpt-5.6-sol` via Codex, reasoning effort `medium`. Marked publication blocked because the bounded repair visits were exhausted with two fixable compatibility findings. Tokens: 228,588 total; 225,929 input including 199,424 cached-read; 2,659 output.
23. **Blocked-publication record** — `openai:gpt-5.6-luna` via Codex, reasoning effort `medium`. Recorded the local-only result without pushing or opening a PR. Tokens: 135,286 total; 133,502 input including 110,208 cached-read; 1,784 output.

Rhei accounting covers all 23 completed model invocations: 51,299,586 total tokens; 51,081,542 input tokens including 48,669,952 cached-read tokens; and 218,044 output tokens. Cached-read tokens are included in input and total counts. Cache-write dimensions were unsupported, and the recorded models were unpriced.

After the bounded Rhei review-repair loop ended, a human explicitly directed a manual continuation through Codex. That continuation added API-level `@Deprecated` migration documentation, added focused legacy producer/consumer compatibility coverage, reran the relevant grounding, inspection, unit, and functional checks, committed the result, and published this PR. This post-Rhei session is disclosed separately because its token usage was not captured by Rhei accounting.

</details>
