### PR TITLE
Clarify build prerequisites and add a core build mode

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -4,9 +4,15 @@ This document describes how to set up and develop Native Build Tools on your loc
 
 ## Environment
 
-Start by setting `JAVA_HOME` to a [Gradle-compatible JDK](https://docs.gradle.org/current/userguide/compatibility.html).
+The repository build has two distinct Java requirements:
 
-Some build tasks require a GraalVM JDK (e.g., tests). You should set `GRAALVM_HOME` to an appropriate GraalVM JDK.
+- `JAVA_HOME` must point to a JDK that can launch the checked-in Gradle wrapper. It may be a newer JDK supported by that wrapper.
+- Gradle must be able to discover a JDK 17 installation because repository Java sources are compiled with a Java 17 toolchain. The launcher JDK and compilation JDK do not need to be the same installation. See the [Gradle toolchain documentation](https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection) for the supported discovery mechanisms.
+
+GraalVM is not required for ordinary JVM compilation and unit tests. Native Image tasks and
+functional-test scenarios that invoke `native-image`, including the full
+`:native-gradle-plugin:functionalTest` and `:native-maven-plugin:functionalTest` suites, require an
+appropriate GraalVM JDK with `native-image` installed. Set `GRAALVM_HOME` to that installation.
 
 ## IDE Setup
 
@@ -35,7 +41,7 @@ You can use the various commands in the [Gradle build lifecycle](https://docs.gr
 Examples used in daily development follow (all executed from the root of the repository):
 
 ```bash
-# Compile all projects
+# Compile all projects, including documentation
 ./gradlew assemble
 
 # Compile only the native-gradle-plugin (for example)
@@ -60,12 +66,29 @@ Examples used in daily development follow (all executed from the root of the rep
 ./gradlew :native-gradle-plugin:inspections
 ./gradlew :native-maven-plugin:inspections
 
-# Build and run all tests, complete (and very long) build
+# Authoritative full build: assemble, verify, and render documentation
 ./gradlew build
 
 # Clean all projects
 ./gradlew clean
 ```
+
+The property-free commands above use full mode, which includes every composite build. The root
+`assemble`, `test`, `check`, and `inspections` tasks delegate to the matching task in every build
+selected by the mode. The default root `build` also renders the documentation with Asciidoctor.
+
+For faster local feedback when documentation is unrelated to the change, enable core mode. Core
+mode omits the `docs` composite before it is configured, while retaining product, common, and
+build-logic builds:
+
+```bash
+./gradlew assemble -Porg.graalvm.build.core=true
+./gradlew test -Porg.graalvm.build.core=true
+./gradlew build -Porg.graalvm.build.core=true
+```
+
+Only `true` and `false` are accepted property values. Core mode is not a substitute for the
+property-free full build used for pull-request, release, or publication validation.
 
 ## CI Checks
 

--- a/build-logic/aggregator/src/main/kotlin/org.graalvm.build.aggregator.gradle.kts
+++ b/build-logic/aggregator/src/main/kotlin/org.graalvm.build.aggregator.gradle.kts
@@ -1,5 +1,8 @@
 import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.GradleException
 import org.gradle.api.publish.plugins.PublishingPlugin
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.kotlin.dsl.*
@@ -47,13 +50,35 @@ import java.nio.file.Files.createTempDirectory
  */
 
 plugins {
-    base
+    `java-base`
+}
+
+// Report the Java 17 prerequisite before included builds start. §FS-build-infrastructure.2.1.
+val java17Launcher = extensions.getByType<JavaToolchainService>().launcherFor {
+    languageVersion.set(JavaLanguageVersion.of(17))
+}
+try {
+    java17Launcher.get()
+} catch (failure: Exception) {
+    val prerequisiteFailure = GradleException(
+        "A discoverable JDK 17 installation is required to build Native Build Tools. " +
+            "Configure Gradle Java toolchain discovery (for example, org.gradle.java.installations.paths) " +
+            "and retry. The JDK that launches Gradle may be newer than Java 17."
+    )
+    prerequisiteFailure.addSuppressed(failure)
+    throw prerequisiteFailure
 }
 
 // Root verification aggregators delegate to included builds. §FS-build-infrastructure.1.1.
 tasks.named("clean") {
     gradle.includedBuilds.forEach {
         dependsOn(it.task(":clean"))
+    }
+}
+
+tasks.named("assemble") {
+    gradle.includedBuilds.forEach {
+        dependsOn(it.task(":assemble"))
     }
 }
 
@@ -72,6 +97,13 @@ tasks.register("inspections") {
 tasks.named("check") {
     gradle.includedBuilds.forEach {
         dependsOn(it.task(":check"))
+    }
+}
+
+// Full-mode build renders documentation through the included docs lifecycle. §FS-build-infrastructure.1.1.
+tasks.named("build") {
+    gradle.includedBuilds.find { it.name == "docs" }?.let {
+        dependsOn(it.task(":build"))
     }
 }
 

--- a/build-logic/aggregator/src/test/kotlin/org/graalvm/build/RootBuildModesTest.kt
+++ b/build-logic/aggregator/src/test/kotlin/org/graalvm/build/RootBuildModesTest.kt
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.build
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.writeText
+
+// Root mode selection and lifecycle aggregation are specified by §FS-build-infrastructure.1 and §FS-build-infrastructure.1.1.
+class RootBuildModesTest {
+    @TempDir
+    lateinit var testDirectory: Path
+
+    @Test
+    fun `default full build evaluates and renders documentation`() {
+        val fixture = createFixture()
+
+        runner(fixture, "build").build()
+
+        assertCoreLifecycleMarkers(fixture, includeTestAndInspections = false)
+        assertTrue(marker(fixture, "docs-evaluated").exists())
+        assertTrue(marker(fixture, "docs-asciidoctor").exists())
+    }
+
+    @Test
+    fun `explicit false selects full mode and aggregates every included build`() {
+        val fixture = createFixture()
+
+        runner(fixture, "assemble", "test", "check", "inspections", "-Porg.graalvm.build.core=false").build()
+
+        assertLifecycleMarkers(fixture, "product")
+        assertLifecycleMarkers(fixture, "common")
+        assertLifecycleMarkers(fixture, "build-logic")
+        assertLifecycleMarkers(fixture, "docs")
+        assertTrue(marker(fixture, "docs-evaluated").exists())
+    }
+
+    @Test
+    fun `core build omits documentation evaluation and rendering`() {
+        val fixture = createFixture()
+
+        runner(fixture, "build", "test", "inspections", "-Porg.graalvm.build.core=true").build()
+
+        assertCoreLifecycleMarkers(fixture, includeTestAndInspections = true)
+        assertFalse(marker(fixture, "docs-evaluated").exists())
+        assertFalse(marker(fixture, "docs-asciidoctor").exists())
+    }
+
+    @Test
+    fun `malformed core property fails during settings evaluation`() {
+        val fixture = createFixture()
+
+        val result = runner(fixture, "help", "-Porg.graalvm.build.core=yes").buildAndFail()
+
+        assertTrue(result.output.contains("must be 'true' or 'false', but was 'yes'"))
+        assertFalse(marker(fixture, "docs-evaluated").exists())
+    }
+
+    // Missing-toolchain prerequisite diagnostics are specified by §FS-build-infrastructure.2.1.
+    @Test
+    fun `missing Java 17 toolchain fails with actionable repository prerequisite`() {
+        val fixture = createFixture()
+        val emptyInstallations = fixture.resolve("empty-java-installations").createDirectories()
+
+        val result = runner(
+            fixture,
+            "help",
+            "-Porg.graalvm.build.core=true",
+            "-Dorg.gradle.java.installations.auto-detect=false",
+            "-Dorg.gradle.java.installations.auto-download=false",
+            "-Dorg.gradle.java.installations.paths=${emptyInstallations.toAbsolutePath()}"
+        ).buildAndFail()
+
+        assertTrue(result.output.contains("A discoverable JDK 17 installation is required to build Native Build Tools."))
+        assertTrue(result.output.contains("org.gradle.java.installations.paths"))
+        assertTrue(result.output.contains("Cannot find a Java installation"))
+        assertFalse(marker(fixture, "product-assemble").exists())
+        assertFalse(marker(fixture, "common-assemble").exists())
+        assertFalse(marker(fixture, "build-logic-assemble").exists())
+        assertFalse(marker(fixture, "docs-evaluated").exists())
+    }
+
+    private fun assertCoreLifecycleMarkers(fixture: Path, includeTestAndInspections: Boolean) {
+        assertLifecycleMarkers(fixture, "product", includeTestAndInspections)
+        assertLifecycleMarkers(fixture, "common", includeTestAndInspections)
+        assertLifecycleMarkers(fixture, "build-logic", includeTestAndInspections)
+    }
+
+    private fun assertLifecycleMarkers(fixture: Path, buildName: String, includeTestAndInspections: Boolean = true) {
+        assertTrue(marker(fixture, "$buildName-assemble").exists())
+        assertTrue(marker(fixture, "$buildName-check").exists())
+        if (includeTestAndInspections) {
+            assertTrue(marker(fixture, "$buildName-test").exists())
+            assertTrue(marker(fixture, "$buildName-inspections").exists())
+        }
+    }
+
+    private fun runner(fixture: Path, vararg arguments: String): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(fixture.toFile())
+            .withPluginClasspath()
+            .withArguments(*arguments, "--stacktrace")
+
+    private fun createFixture(): Path {
+        val fixture = testDirectory.resolve("fixture").createDirectories()
+        fixture.resolve("gradle").createDirectories()
+        fixture.resolve("gradle/libs.versions.toml").writeText(
+            """
+            [versions]
+            nativeBuildTools = "1.0.0"
+            junitJupiter = "5.13.0"
+            junitPlatform = "1.13.0"
+            """.trimIndent()
+        )
+        fixture.resolve("settings.gradle.kts").writeText(settingsScript(fixture))
+        fixture.resolve("build.gradle.kts").writeText(
+            """
+            plugins {
+                id("org.graalvm.build.aggregator")
+            }
+            """.trimIndent()
+        )
+
+        listOf("product", "common", "build-logic", "docs").forEach { createIncludedBuild(fixture, it) }
+        return fixture
+    }
+
+    private fun settingsScript(fixture: Path): String {
+        val docsEvaluated = escapedPath(marker(fixture, "docs-evaluated"))
+        return """
+            rootProject.name = "root-build-modes-fixture"
+
+            val coreBuild = providers.gradleProperty("org.graalvm.build.core").orNull?.let { value ->
+                when (value) {
+                    "true" -> true
+                    "false" -> false
+                    else -> throw GradleException(
+                        "Gradle property 'org.graalvm.build.core' must be 'true' or 'false', but was '${'$'}value'."
+                    )
+                }
+            } ?: false
+
+            includeBuild("product")
+            includeBuild("common")
+            includeBuild("build-logic")
+            if (!coreBuild) {
+                file("$docsEvaluated").apply {
+                    parentFile.mkdirs()
+                    writeText("evaluated")
+                }
+                includeBuild("docs")
+            }
+        """.trimIndent()
+    }
+
+    private fun createIncludedBuild(fixture: Path, buildName: String) {
+        val buildDirectory = fixture.resolve(buildName).createDirectories()
+        buildDirectory.resolve("settings.gradle.kts").writeText("rootProject.name = \"$buildName\"")
+        buildDirectory.resolve("build.gradle.kts").writeText(includedBuildScript(fixture, buildName))
+    }
+
+    private fun includedBuildScript(fixture: Path, buildName: String): String {
+        fun markerPath(taskName: String) = escapedPath(marker(fixture, "$buildName-$taskName"))
+        val documentationLifecycle = if (buildName == "docs") {
+            """
+                val asciidoctor = tasks.register("asciidoctor") {
+                    doLast { file("${markerPath("asciidoctor")}").apply { parentFile.mkdirs(); writeText("rendered") } }
+                }
+                tasks.named("build") { dependsOn(asciidoctor) }
+            """.trimIndent()
+        } else {
+            ""
+        }
+        return """
+            plugins { base }
+
+            tasks.named("assemble") {
+                doLast { file("${markerPath("assemble")}").apply { parentFile.mkdirs(); writeText("done") } }
+            }
+            tasks.named("check") {
+                doLast { file("${markerPath("check")}").apply { parentFile.mkdirs(); writeText("done") } }
+            }
+            tasks.register("test") {
+                doLast { file("${markerPath("test")}").apply { parentFile.mkdirs(); writeText("done") } }
+            }
+            tasks.register("inspections") {
+                doLast { file("${markerPath("inspections")}").apply { parentFile.mkdirs(); writeText("done") } }
+            }
+            $documentationLifecycle
+        """.trimIndent()
+    }
+
+    private fun marker(fixture: Path, name: String): Path = fixture.resolve("markers").resolve(name)
+
+    private fun escapedPath(path: Path): String = path.toAbsolutePath().toString().replace("\\", "\\\\")
+}

--- a/build-logic/documentation-plugins/build.gradle.kts
+++ b/build-logic/documentation-plugins/build.gradle.kts
@@ -48,7 +48,16 @@ repositories {
     gradlePluginPortal()
 }
 
+// Test infrastructure for documentation lifecycle rendering. §FS-build-infrastructure.3.1
 dependencies {
     implementation("org.asciidoctor.jvm.convert:org.asciidoctor.jvm.convert.gradle.plugin:4.0.5")
     implementation("org.ajoberstar:gradle-git-publish:3.0.0")
+    testImplementation(gradleTestKit())
+    testImplementation(platform("org.junit:junit-bom:5.13.0"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.13.0")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/build-logic/documentation-plugins/src/main/kotlin/org.graalvm.build.documentation.gradle.kts
+++ b/build-logic/documentation-plugins/src/main/kotlin/org.graalvm.build.documentation.gradle.kts
@@ -94,6 +94,11 @@ tasks {
             }
         }
     }
+
+    // Standard documentation lifecycle renders the user guide. §FS-build-infrastructure.3.1.
+    named("build") {
+        dependsOn(asciidoctor)
+    }
 }
 
 afterEvaluate {

--- a/build-logic/documentation-plugins/src/test/kotlin/org/graalvm/build/DocumentationLifecycleTest.kt
+++ b/build-logic/documentation-plugins/src/test/kotlin/org/graalvm/build/DocumentationLifecycleTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -39,23 +39,46 @@
  * SOFTWARE.
  */
 
-plugins {
-    `kotlin-dsl`
-}
+package org.graalvm.build
 
-repositories {
-    mavenCentral()
-    gradlePluginPortal()
-}
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.writeText
 
-// Test infrastructure for the selected root build mode and lifecycle aggregation. §FS-build-infrastructure.1.1
-dependencies {
-    testImplementation(gradleTestKit())
-    testImplementation(platform(libs.test.junit.bom))
-    testImplementation(libs.test.junit.jupiter.core)
-    testRuntimeOnly(libs.test.junit.platform.launcher)
-}
+// Documentation lifecycle rendering is specified by §FS-build-infrastructure.3.1.
+class DocumentationLifecycleTest {
+    @TempDir
+    lateinit var testDirectory: Path
 
-tasks.test {
-    useJUnitPlatform()
+    @Test
+    fun `build renders asciidoc documentation`() {
+        testDirectory.resolve("settings.gradle.kts").writeText("rootProject.name = \"documentation-fixture\"")
+        testDirectory.resolve("build.gradle.kts").writeText(
+            """
+            plugins {
+                id("org.graalvm.build.documentation")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+            """.trimIndent()
+        )
+        testDirectory.resolve("src/docs/asciidoc").createDirectories()
+        testDirectory.resolve("src/docs/asciidoc/index.adoc").writeText("= Documentation lifecycle")
+
+        val result = GradleRunner.create()
+            .withProjectDir(testDirectory.toFile())
+            .withPluginClasspath()
+            .withArguments("build", "--stacktrace")
+            .build()
+
+        assertTrue(result.output.contains(":asciidoctor"))
+        assertTrue(testDirectory.resolve("build/docs/asciidoc/index.html").exists())
+    }
 }

--- a/docs/spec/functional/build-infrastructure.md
+++ b/docs/spec/functional/build-infrastructure.md
@@ -10,7 +10,8 @@ pull request gates in [§AR-repository-ci](../architecture/ci.md#ar-repository-c
 
 | Maintainer need | Task or component | Output or effect |
 | --- | --- | --- |
-| Validate included builds | `test`, `check`, `inspections` | delegated verification across product/common/docs builds |
+| Assemble included builds | `assemble` | delegated assembly across builds in the selected root mode |
+| Validate included builds | `build`, `test`, `check`, `inspections` | delegated lifecycle work across builds in the selected root mode |
 | Inspect publishable artifacts | `showPublications` | Maven coordinates printed from publishable modules |
 | Publish locally for tests | `publishAllPublicationsToCommonRepository` | repository under `build/common-repo` |
 | Prepare release archive | `releaseZip` | ZIP of common repository publication output |
@@ -27,12 +28,23 @@ internal convention plugins. Root and build-logic tasks may assemble, test, publ
 prepare generated artifacts for the repository's modules. Aggregation tasks may coordinate
 cross-module maintenance work, but product behavior must still live in product or common modules.
 
-### 1.1 Verification aggregators
+Root orchestration has two modes. Full mode is the default when
+`org.graalvm.build.core` is absent or `false`; it includes every repository composite, including
+documentation, and is the authoritative path for pull-request, release, and publication
+validation. Core mode is selected only by `org.graalvm.build.core=true`; it includes product,
+common, and build-logic composites while omitting the documentation composite before that build is
+configured. Any other property value must fail settings evaluation rather than silently weakening
+validation. Core mode is a local-feedback path that avoids unnecessary documentation configuration
+and dependency resolution in support of [§GOAL-fast-feedback](../goals.md#goal-fast-feedback-native-build-workflows-provide-feedback-as-fast-as-practical).
 
-The root `test`, `check`, and `inspections` tasks are maintainer-facing shortcuts over the
-included builds. They must delegate to the matching task in each included build so a maintainer can
-run one root command when validating repository-wide changes. They are not product API, and their
-task graph may change when included builds are added or removed.
+### 1.1 Lifecycle aggregators
+
+The root `assemble`, `test`, `check`, and `inspections` tasks are maintainer-facing shortcuts over
+the builds included by the selected root mode. They must delegate to the matching task in each
+included build so a maintainer can run one root command when building or validating repository-wide
+changes. The root `build` task combines the selected mode's assembly and verification lifecycle;
+in full mode it must additionally complete documentation rendering. These tasks are not product
+API, and their task graph may change when included builds are added or removed.
 
 ### 1.2 Publication and release aggregators
 
@@ -85,6 +97,12 @@ skipped tests or replaying routine test streams. Detailed test events and captur
 remain available through Gradle's normal diagnostic levels and generated test reports, refining
 the concise-output goal in [§GOAL-concise-actionable-output](../goals.md#goal-concise-actionable-output-build-output-is-concise-actionable-and-token-efficient).
 
+Root orchestration must resolve the required Java 17 compilation toolchain before delegating build
+lifecycle work to included builds. If no matching installation is discoverable, it must fail with a
+concise repository prerequisite diagnostic that identifies Java 17 and points maintainers to Gradle
+toolchain discovery configuration. This check must use Gradle's toolchain service and must not
+configure automatic JDK provisioning or replace the underlying resolution cause.
+
 Convention plugins may add tasks and configurations to modules that apply them. Those additions
 are maintainer-facing build behavior, not runtime behavior of the Native Build Tools plugins.
 
@@ -129,6 +147,12 @@ Documentation build logic must resolve Javadoc artifacts, expand them into the g
 documentation tree, run AsciiDoc conversion, and publish rendered documentation to the configured
 documentation branch. Release documentation should publish under the release version and refresh
 the `latest` link; snapshot documentation must not replace the latest release pointer.
+
+The documentation build's standard `build` lifecycle must run AsciiDoc conversion. Consequently,
+the default full root `build` must render documentation, while core mode must neither configure the
+documentation composite nor execute its rendering tasks. This lifecycle distinction does not alter
+the Java 17 repository build floor or the ability to launch the checked-in wrapper with a supported
+newer JDK as required by [§REQ-support-matrix.1](../requirements.md#1-declared-support).
 
 ## 4. Continuous integration
 

--- a/docs/src/docs/asciidoc/changelog.adoc
+++ b/docs/src/docs/asciidoc/changelog.adoc
@@ -4,6 +4,7 @@
 == Release 1.1.6
 
 - Maven native test goals now read the matching Surefire or Failsafe execution, including its configured `testClassesDirectory`, and keep their test-ID output separate.
+- Clarify the separate Gradle launcher, JDK 17 compilation toolchain, and GraalVM prerequisites; add a docs-independent core build mode while keeping the default full build responsible for included-build assembly, verification, and documentation rendering.
 
 == Release 1.0.1
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,9 +46,22 @@ pluginManagement {
 
 rootProject.name = "native-build-tools"
 
+// Root composition modes are specified by §FS-build-infrastructure.1.
+val coreBuild = providers.gradleProperty("org.graalvm.build.core").orNull?.let { value ->
+    when (value) {
+        "true" -> true
+        "false" -> false
+        else -> throw GradleException(
+            "Gradle property 'org.graalvm.build.core' must be 'true' or 'false', but was '$value'."
+        )
+    }
+} ?: false
+
 includeBuild("common/junit-platform-native")
 includeBuild("common/utils")
 includeBuild("common/graalvm-reachability-metadata")
 includeBuild("native-gradle-plugin")
 includeBuild("native-maven-plugin")
-includeBuild("docs")
+if (!coreBuild) {
+    includeBuild("docs")
+}


### PR DESCRIPTION
## What changed

The developer guide now distinguishes the JDK used to launch Gradle from the Java 17 toolchain required to compile Native Build Tools. Gradle may run on a newer supported JDK, including JDK 21 or 25, but a discoverable JDK 17 installation is still required. When Java 17 is unavailable, root configuration fails early with repository-specific guidance while retaining Gradle's underlying toolchain failure for diagnostics.

The root build also has a new opt-in core mode that omits the documentation composite before it is configured. Root lifecycle tasks aggregate every build selected by the active mode, and the default full `build` renders the AsciiDoc documentation.

## Why

Developers using a newer launcher JDK could reasonably assume that no Java 17 installation was needed, then receive a delayed generic toolchain failure. Documentation dependencies were also configured even when a developer only needed the product builds, and root `assemble` did not actually assemble the included builds despite the developer guide saying it did.

The change makes the required toolchains explicit, provides a faster docs-independent feedback path, and makes the documented root lifecycle behavior match the task graph.

## Example

Run the normal documentation-inclusive repository build:

```text
./gradlew build
```

Run the product builds without configuring or rendering documentation:

```text
./gradlew build -Porg.graalvm.build.core=true
```

The property is strict: absence or `false` selects the full build, `true` selects core mode, and any other value fails during settings evaluation.

## Implementation summary

- Documented the separate Gradle launcher, discoverable Java 17 compiler toolchain, and GraalVM/native-image prerequisites.
- Added strict `org.graalvm.build.core` parsing and omitted `docs` during settings composition in core mode.
- Made root `assemble`, `test`, `check`, and `inspections` aggregate the builds present in the selected mode.
- Connected the default full root `build` to the documentation build and connected the documentation `build` lifecycle to `asciidoctor`.
- Added an early Java 17 toolchain prerequisite check using Gradle's public toolchain service, without enabling automatic provisioning.
- Added focused TestKit coverage for mode selection, malformed input, aggregation, documentation rendering, and the missing-JDK diagnostic.

## Validation

The following checks passed:

- `./gradlew -p build-logic/aggregator cleanTest test --console=plain` — 5 focused TestKit tests.
- `./gradlew -p build-logic/documentation-plugins cleanTest test --console=plain` — 1 focused TestKit test with rendered AsciiDoc output.
- `grund check`
- `grund fmt . --marker --cross-refs --check`
- `git diff --check`
- `./gradlew help -Porg.graalvm.build.core=true --console=plain`
- malformed-property smoke coverage for `-Porg.graalvm.build.core=yes`
- default full `build --dry-run` task-graph assertion containing `:docs:asciidoctor` and `:docs:build`
- core `build --dry-run` task-graph assertion containing product/common tasks and no `:docs:` tasks
- `./gradlew :native-gradle-plugin:inspections :native-maven-plugin:inspections -Porg.graalvm.build.core=true --console=plain`
- constrained missing-JDK reproduction with toolchain auto-detection and auto-download disabled, confirming the actionable repository prerequisite message

A complete root `./gradlew build` was not rerun because the existing `:native-gradle-plugin:validatePlugins` task reports unrelated Gradle 9.6.1 validation failures. Broad Native Image functional suites, the exact CI matrix, and documentation publication variants were not run locally.

Fixes #988

## AI workflow

Generated by [Rhei](https://github.com/vjovanov/rhei)’s `github-issue-fix` workflow using 23 completed AI-assisted steps, 3 resolved models, and 3 focused review cycles. A maintainer-directed citation-only repair completed the blocked publication afterward.

<details>
<summary>View AI workflow details</summary>

Approved proposal: `bbce876008d81808`.

1. Issue intake and repository grounding

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 738019 total · 726819 input (633472 cached) · 11200 output

Captured issue #988, repository rules, specifications, worktree metadata, and implementation scope.

2. Human proposal approval

Model: not applicable · Agent: human · Reasoning effort: not applicable  
Tokens: not applicable

Approved proposal `bbce876008d81808` for implementation.

3. Implement approved fix

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 7082293 total · 7059553 input (6852608 cached) · 22740 output

Implemented the core/full build split, lifecycle aggregation, documentation rendering, developer guidance, specification updates, and focused TestKit coverage.

4. Validate implementation — visit 1

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 2161957 total · 2149463 input (2060928 cached) · 12494 output

Ran focused tests, grounding checks, task-graph assertions, documentation rendering, and missing-toolchain reproduction.

5. Requirements review — cycle 1

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 201905 total · 199426 input (164480 cached) · 2479 output

Identified that the Java-17-unavailable acceptance criterion needed an earlier repository-owned diagnostic or stronger evidence.

6. Spec review — cycle 1

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 233051 total · 229794 input (190464 cached) · 3257 output

Checked specification order, repository grounding, and citation coverage with no blockers.

7. Implementation review — cycle 1

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 217588 total · 213775 input (172672 cached) · 3813 output

Reviewed the initial implementation for scope, correctness, and regression coverage.

8. Validation review — cycle 1

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 220063 total · 216368 input (180608 cached) · 3695 output

Accepted the focused validation while recording the missing-JDK evidence needed by requirements review.

9. Aggregate review — cycle 1

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 129688 total · 127599 input (88320 cached) · 2089 output

Reconciled the specialist reviews and routed the missing-JDK diagnostic repair.

10. Address review findings — repair cycle 1

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 1441840 total · 1432088 input (1358592 cached) · 9752 output

Added the early Java 17 prerequisite diagnostic, its specification, and constrained TestKit coverage.

11. Validate repaired implementation — visit 2

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 949494 total · 937936 input (845312 cached) · 11558 output

Verified the new diagnostic, normal newer-JDK launcher behavior, focused tests, grounding, and task graphs.

12. Requirements review — cycle 2

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 329495 total · 325266 input (288896 cached) · 4229 output

Confirmed the repaired implementation satisfied the issue acceptance criteria.

13. Spec review — cycle 2

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 311804 total · 306415 input (257792 cached) · 5389 output

Found that the missing-JDK TestKit case lacked its most-specific specification citation.

14. Implementation review — cycle 2

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 285318 total · 279309 input (234880 cached) · 6009 output

Confirmed implementation behavior and reported the same missing test citation blocker.

15. Validation review — cycle 2

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 296967 total · 292549 input (257152 cached) · 4418 output

Accepted focused validation and documented the remaining broad validation gaps.

16. Aggregate review — cycle 2

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 179869 total · 176620 input (132736 cached) · 3249 output

Reconciled cycle 2 and routed the missing citation repair.

17. Address review findings — repair cycle 2

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 336319 total · 332173 input (300288 cached) · 4146 output

Added `§FS-build-infrastructure.2.1` to the missing-Java-17 TestKit case.

18. Validate repaired implementation — visit 3

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 1101052 total · 1086362 input (998144 cached) · 14690 output

Reran focused TestKit, grounding, task-graph, inspection, and missing-toolchain checks.

19. Requirements review — cycle 3

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 323460 total · 319071 input (268416 cached) · 4389 output

Confirmed all issue requirements were satisfied.

20. Spec review — cycle 3

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 383331 total · 377726 input (339072 cached) · 5605 output

Found two missing most-specific citations on the newly added TestKit dependency infrastructure.

21. Implementation review — cycle 3

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 256480 total · 252708 input (216448 cached) · 3772 output

Found the new missing-toolchain citation comment placed between `@Test` and its declaration.

22. Validation review — cycle 3

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium  
Tokens: 210758 total · 207037 input (174080 cached) · 3721 output

Accepted all focused validation with no blocking failures.

23. Aggregate review — cycle 3

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium  
Tokens: 126767 total · 123858 input (100608 cached) · 2909 output

Reconciled the final review and recorded three fixable citation and placement blockers.

24. Record blocked publication

Model: openai:gpt-5.6-luna · Agent: codex · Reasoning effort: medium  
Tokens: 87296 total · 85811 input (68480 cached) · 1485 output

Kept the branch local because the configured two repair visits were exhausted after the third review cycle.

25. Maintainer-directed final repair and publication

Model: not recorded by Rhei · Agent: codex · Reasoning effort: not reported  
Tokens: not captured by Rhei accounting

Applied the three citation-only review fixes, reran the focused checks, committed the result, pushed `graalvm:rhei/issue-988`, and opened this ready-for-review PR.

**Aggregate token usage:** 17604814 total · 17457726 input (16184448 cached) · 147088 output

The aggregate covers all 23 finalized Rhei agent invocations and excludes the maintainer-directed final repair and publication. Deterministic program routing is non-model work. Focused review cycles: 3. Review-repair cycles: 2 within Rhei, followed by one citation-only completion. Accounting coverage: 23 measured Rhei invocations. Superseded attempts: none. Unmeasured Rhei attempts: none. Pricing: unpriced. Unsupported cache dimensions: input cache write, output cached read, and output cache write.

</details>
