### PR TITLE
Make embedded Maven output concise and reproducible

### DIFF
--- a/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/GeneratePluginDescriptor.java
+++ b/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/GeneratePluginDescriptor.java
@@ -18,11 +18,16 @@ package org.graalvm.build.maven;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.LocalState;
 import org.gradle.process.JavaExecSpec;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.List;
 
+/**
+ * Generates the plugin descriptor with a task-local Maven repository. §E2E-functional-tests.4
+ */
 @CacheableTask
 public abstract class GeneratePluginDescriptor extends MavenTask {
 
@@ -32,14 +37,26 @@ public abstract class GeneratePluginDescriptor extends MavenTask {
     @Internal
     public abstract DirectoryProperty getLocalRepository();
 
+    @LocalState
+    public abstract DirectoryProperty getMavenLocalRepository();
+
     public GeneratePluginDescriptor() {
         getArguments().set(Arrays.asList("-q", "org.apache.maven.plugins:maven-plugin-plugin:3.6.1:descriptor"));
+        getMavenLocalRepository().convention(getProject().getLayout().getBuildDirectory().dir("maven-local/" + getName()));
     }
 
     @Override
     protected void prepareSpec(JavaExecSpec spec) {
         spec.systemProperty("common.repo.uri", getCommonRepository().getAsFile().get().toURI().toString());
         spec.systemProperty("seed.repo.uri", getLocalRepository().get().getAsFile().toURI().toASCIIString());
+    }
+
+    @Override
+    protected void prepareArguments(List<String> arguments) {
+        File repository = getMavenLocalRepository().getAsFile().get();
+        getFileSystemOperations().delete(spec -> spec.delete(
+                getProject().fileTree(repository, files -> files.include("**/*.lastUpdated"))));
+        arguments.add("-Dmaven.repo.local=" + repository.getAbsolutePath());
     }
 
     @Override

--- a/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/MavenOutput.java
+++ b/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/MavenOutput.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and in any patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and the
+ * Larger Work(s), and to make, use, sell, offer for sale, import, export, have
+ * made, and have sold the Software and the Larger Work(s), and to sublicense the
+ * foregoing rights on either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.build.maven;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Bounds embedded Maven output and renders one safe actionable failure. §E2E-functional-tests.4
+ */
+final class MavenOutput extends OutputStream {
+    private static final int MAXIMUM_BYTES = 4 * 1024 * 1024;
+    private static final Pattern ANSI_ESCAPE = Pattern.compile("\\x1B(?:\\[[0-?]*[ -/]*[@-~]|\\][^\\x07]*(?:\\x07|\\x1B\\\\))");
+    private static final Pattern RESOLUTION_FAILURE = Pattern.compile(
+            "Could not (?:transfer|find) artifact ([^\\s]+) (?:from/to|in) ([^\\s(]+) \\(([^)]+)\\)",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern CACHED_NOT_FOUND = Pattern.compile(
+            "([^\\s]+) was not found in ([^\\s]+) during a previous attempt",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern SLF4J_ERROR = Pattern.compile("^\\[[^]]+]\\s+ERROR\\s+\\S+\\s+-\\s*(.*)$");
+    private static final Pattern URL = Pattern.compile("[a-zA-Z][a-zA-Z0-9+.-]*://[^\\s)]+(?:\\)[^\\s]*)?");
+    private static final String DIAGNOSTIC_HINT = "Rerun with --info or --debug for Maven diagnostics.";
+
+    private final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    private boolean truncated;
+
+    @Override
+    public synchronized void write(int value) {
+        if (bytes.size() < MAXIMUM_BYTES) {
+            bytes.write(value);
+        } else {
+            truncated = true;
+        }
+    }
+
+    @Override
+    public synchronized void write(byte[] data, int offset, int length) {
+        int remaining = MAXIMUM_BYTES - bytes.size();
+        if (remaining > 0) {
+            bytes.write(data, offset, Math.min(length, remaining));
+        }
+        if (length > remaining) {
+            truncated = true;
+        }
+    }
+
+    synchronized String contents() {
+        String output = bytes.toString(StandardCharsets.UTF_8);
+        if (truncated) {
+            return output + System.lineSeparator() + "[embedded Maven output truncated]";
+        }
+        return output;
+    }
+
+    static String failureMessage(String diagnostics) {
+        String plainOutput = ANSI_ESCAPE.matcher(diagnostics).replaceAll("");
+        Matcher resolution = RESOLUTION_FAILURE.matcher(plainOutput);
+        if (resolution.find()) {
+            String artifact = resolution.group(1);
+            String repository = resolution.group(2);
+            String url = sanitizeUrl(resolution.group(3));
+            String location = url == null ? repository : repository + " (" + url + ")";
+            return "Embedded Maven could not resolve artifact " + artifact + " from repository " + location + ". " + DIAGNOSTIC_HINT;
+        }
+        Matcher cachedNotFound = CACHED_NOT_FOUND.matcher(plainOutput);
+        if (cachedNotFound.find()) {
+            String artifact = cachedNotFound.group(1);
+            String repository = sanitizeUrl(cachedNotFound.group(2));
+            String location = repository == null ? "[repository URL omitted]" : repository;
+            return "Embedded Maven could not resolve artifact " + artifact + " from repository " + location + ". " + DIAGNOSTIC_HINT;
+        }
+        String detail = finalMeaningfulError(plainOutput);
+        return "Embedded Maven failed: " + detail + ". " + DIAGNOSTIC_HINT;
+    }
+
+    private static String finalMeaningfulError(String output) {
+        String[] lines = output.split("\\R");
+        for (int index = lines.length - 1; index >= 0; index--) {
+            String detail = errorDetail(lines[index].trim());
+            if (detail == null) {
+                continue;
+            }
+            if (!detail.isEmpty() && !detail.startsWith("-> [Help ") && !detail.startsWith("[Help ")
+                    && !detail.startsWith("For more information")) {
+                return stripTrailingPeriod(sanitizeUrls(detail));
+            }
+        }
+        return "Maven exited with a non-zero status";
+    }
+
+    private static String errorDetail(String line) {
+        if (line.startsWith("[ERROR]")) {
+            return line.substring("[ERROR]".length()).trim();
+        }
+        Matcher matcher = SLF4J_ERROR.matcher(line);
+        return matcher.matches() ? matcher.group(1).trim() : null;
+    }
+
+    private static String sanitizeUrls(String text) {
+        Matcher matcher = URL.matcher(text);
+        StringBuffer sanitized = new StringBuffer();
+        while (matcher.find()) {
+            String replacement = sanitizeUrl(matcher.group());
+            matcher.appendReplacement(sanitized, Matcher.quoteReplacement(replacement == null ? "[repository URL omitted]" : replacement));
+        }
+        matcher.appendTail(sanitized);
+        return sanitized.toString();
+    }
+
+    private static String sanitizeUrl(String value) {
+        try {
+            URI uri = new URI(value);
+            if (uri.getScheme() == null) {
+                return null;
+            }
+            if (uri.isOpaque()) {
+                return uri.getScheme() + ":";
+            }
+            return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(), null, null).toASCIIString();
+        } catch (URISyntaxException ex) {
+            return null;
+        }
+    }
+
+    private static String stripTrailingPeriod(String value) {
+        return value.endsWith(".") ? value.substring(0, value.length() - 1) : value;
+    }
+}

--- a/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/MavenTask.java
+++ b/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/MavenTask.java
@@ -16,6 +16,7 @@
 package org.graalvm.build.maven;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
@@ -28,11 +29,14 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.ExecOperations;
+import org.gradle.process.ExecResult;
 import org.gradle.process.JavaExecSpec;
 
 import javax.inject.Inject;
@@ -42,7 +46,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Runs embedded Maven with explicit offline and snapshot-update policy. §E2E-functional-tests.4
+ * Runs embedded Maven with concise diagnostics and an explicit supported launcher. §E2E-functional-tests.4
  */
 @CacheableTask
 public abstract class MavenTask extends DefaultTask {
@@ -74,15 +78,14 @@ public abstract class MavenTask extends DefaultTask {
     @Input
     public abstract Property<Boolean> getOffline();
 
-    @Input
-    public abstract Property<Boolean> getUpdateSnapshots();
+    @Nested
+    public abstract Property<JavaLauncher> getJavaLauncher();
 
     @OutputDirectory
     public abstract DirectoryProperty getOutputDirectory();
 
     public MavenTask() {
         getOffline().convention(false);
-        getUpdateSnapshots().convention(false);
     }
 
     protected void extractOutput(File tmpDir, File outputDirectory) {
@@ -101,16 +104,23 @@ public abstract class MavenTask extends DefaultTask {
         File settingsFile = getSettingsFile().getAsFile().get();
         File outputDirectory = getOutputDirectory().getAsFile().get();
         File projectdir = getProjectDirectory().getAsFile().get();
-        getExecOperations().javaexec(spec -> {
+        MavenOutput output = new MavenOutput();
+        ExecResult result = getExecOperations().javaexec(spec -> {
             spec.setClasspath(getMavenEmbedderClasspath());
             spec.getMainClass().set("org.apache.maven.cli.MavenCli");
+            spec.setExecutable(getJavaLauncher().get().getExecutablePath().getAsFile());
             spec.systemProperty("maven.multiModuleProjectDirectory", projectdir.getAbsolutePath());
             spec.systemProperty("org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener", "warn");
+            spec.setStandardOutput(output);
+            spec.setErrorOutput(output);
+            spec.setIgnoreExitValue(true);
             prepareSpec(spec);
             List<String> arguments = new ArrayList<>();
-            arguments.add("--errors");
-            if (getUpdateSnapshots().get()) {
-                arguments.add("-U");
+            if (getLogger().isInfoEnabled()) {
+                arguments.add("--errors");
+            }
+            if (getLogger().isDebugEnabled()) {
+                arguments.add("--debug");
             }
             if (getOffline().get()) {
                 arguments.add("--offline");
@@ -122,8 +132,15 @@ public abstract class MavenTask extends DefaultTask {
             arguments.addAll(getArguments().get());
             prepareArguments(arguments);
             spec.args(arguments);
-            getLogger().lifecycle("Invoking Maven with arguments " + arguments);
+            getLogger().info("Invoking Maven with arguments {}", arguments);
         });
+        String diagnostics = output.contents();
+        if (getLogger().isInfoEnabled() && !diagnostics.isBlank()) {
+            getLogger().info("Embedded Maven output:\n{}", diagnostics);
+        }
+        if (result.getExitValue() != 0) {
+            throw new GradleException(MavenOutput.failureMessage(diagnostics));
+        }
         extractOutput(projectdir, outputDirectory);
     }
 

--- a/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/SeedMavenRepository.java
+++ b/native-maven-plugin/build-plugins/src/main/java/org/graalvm/build/maven/SeedMavenRepository.java
@@ -91,7 +91,9 @@ public abstract class SeedMavenRepository extends MavenTask {
         Map<String, String> values = new LinkedHashMap<>(getSeedProperties().get());
         values.put("arguments", String.join("\n", getArguments().get()));
         values.put("offline", getOffline().get().toString());
-        values.put("updateSnapshots", getUpdateSnapshots().get().toString());
+        values.put("javaLauncher.languageVersion", getJavaLauncher().get().getMetadata().getLanguageVersion().toString());
+        values.put("javaLauncher.runtimeVersion", getJavaLauncher().get().getMetadata().getJavaRuntimeVersion());
+        values.put("javaLauncher.vendor", getJavaLauncher().get().getMetadata().getVendor());
         Map<String, Path> files = new LinkedHashMap<>();
         files.put("projectDirectory", getProjectDirectory().getAsFile().get().toPath());
         files.put("settingsFile", getSettingsFile().getAsFile().get().toPath());

--- a/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-embedder.gradle.kts
+++ b/native-maven-plugin/build-plugins/src/main/kotlin/org.graalvm.build.maven-embedder.gradle.kts
@@ -39,8 +39,23 @@
  * SOFTWARE.
  */
 
+import org.graalvm.build.maven.MavenTask
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.withType
+
 // Shared maintainer-facing build configurations are convention-plugin behavior. §root/FS-build-infrastructure.2.1
 val mavenEmbedder = configurations.create("mavenEmbedder")
 val testFixturesImplementation = configurations.getByName("testFixturesImplementation")
 
 testFixturesImplementation.extendsFrom(mavenEmbedder)
+
+// Repository-internal Maven runs on the supported Java floor independently of the Gradle daemon. §E2E-functional-tests.4
+val embeddedMavenLauncher = extensions.getByType<JavaToolchainService>().launcherFor {
+    languageVersion.set(JavaLanguageVersion.of(17))
+}
+
+tasks.withType<MavenTask>().configureEach {
+    javaLauncher.set(embeddedMavenLauncher)
+}

--- a/native-maven-plugin/build-plugins/src/test/java/org/graalvm/build/maven/MavenOutputTest.java
+++ b/native-maven-plugin/build-plugins/src/test/java/org/graalvm/build/maven/MavenOutputTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and in any patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and the
+ * Larger Work(s), and to make, use, sell, offer for sale, import, export, have
+ * made, and have sold the Software and the Larger Work(s), and to sublicense the
+ * foregoing rights on either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.build.maven;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Protects concise, sanitized embedded Maven failure classification. §E2E-functional-tests.4
+ */
+class MavenOutputTest {
+    @Test
+    void classifiesTransferAndNotFoundDiagnostics() {
+        assertEquals(
+                "Embedded Maven could not resolve artifact example:missing:pom:1.0 from repository private "
+                        + "(https://repo.example.test:8443/releases). Rerun with --info or --debug for Maven diagnostics.",
+                MavenOutput.failureMessage("[ERROR] Could not transfer artifact example:missing:pom:1.0 from/to private "
+                        + "(https://user:secret@repo.example.test:8443/releases?token=hidden#fragment): timeout"));
+        assertEquals(
+                "Embedded Maven could not resolve artifact example:absent:jar:2.0 from repository central "
+                        + "(https://repo.example.test/maven2). Rerun with --info or --debug for Maven diagnostics.",
+                MavenOutput.failureMessage("[ERROR] Could not find artifact example:absent:jar:2.0 in central "
+                        + "(https://repo.example.test/maven2)"));
+        assertEquals(
+                "Embedded Maven could not resolve artifact example:cached:jar:3.0 from repository "
+                        + "https://repo.example.test/releases. Rerun with --info or --debug for Maven diagnostics.",
+                MavenOutput.failureMessage("[main] ERROR org.apache.maven.cli.MavenCli - "
+                        + "example:cached:jar:3.0 was not found in "
+                        + "https://user:secret@repo.example.test/releases?token=hidden#fragment during a previous attempt"));
+    }
+
+    @Test
+    void sanitizesUrlsInFallbackErrors() {
+        String message = MavenOutput.failureMessage("""
+                [ERROR] Earlier error
+                [ERROR] Request to https://user:secret@repo.example.test/path?token=hidden#fragment failed.
+                [ERROR] -> [Help 1]
+                """);
+
+        assertTrue(message.contains("https://repo.example.test/path"));
+        assertFalse(message.contains("user:secret"));
+        assertFalse(message.contains("token=hidden"));
+    }
+
+    @Test
+    void recognizesSlf4jPrefixedFallbackErrors() {
+        String message = MavenOutput.failureMessage("""
+                [main] ERROR org.apache.maven.cli.MavenCli - Earlier error
+                [main] ERROR org.apache.maven.cli.MavenCli - Build configuration is invalid.
+                [main] ERROR org.apache.maven.cli.MavenCli - -> [Help 1]
+                [main] ERROR org.apache.maven.cli.MavenCli - [Help 1] https://example.test/help
+                """);
+
+        assertTrue(message.contains("Embedded Maven failed: Build configuration is invalid."));
+        assertFalse(message.contains("Earlier error"));
+    }
+}

--- a/native-maven-plugin/build-plugins/src/test/java/org/graalvm/build/maven/MavenPluginConventionTest.java
+++ b/native-maven-plugin/build-plugins/src/test/java/org/graalvm/build/maven/MavenPluginConventionTest.java
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Protects the unit-test class-directory and assembly descriptor boundaries. §AR-maven-plugin.6
+ * Protects descriptor assembly boundaries and its embedded Maven launcher. §AR-maven-plugin.6, §E2E-functional-tests.4
  */
 class MavenPluginConventionTest {
     @TempDir
@@ -88,6 +88,15 @@ class MavenPluginConventionTest {
         assertFalse(test.getOutput().contains(":plugin:generatePluginDescriptor SKIPPED"));
     }
 
+    @Test
+    void descriptorGenerationUsesTheEmbeddedMavenJava17Launcher() throws IOException {
+        writeFixture(projectDirectory);
+
+        BuildResult result = runner("printEmbeddedMavenLauncher").build();
+
+        assertTrue(result.getOutput().contains("EMBEDDED_MAVEN_JAVA=17"));
+    }
+
     private GradleRunner runner(String... arguments) {
         return GradleRunner.create()
                 .withProjectDir(projectDirectory.toFile())
@@ -115,6 +124,14 @@ class MavenPluginConventionTest {
                         create<MavenPublication>("mavenPlugin") {
                             from(components["java"])
                         }
+                    }
+                }
+
+                tasks.register("printEmbeddedMavenLauncher") {
+                    doLast {
+                        val descriptor = tasks.named("generatePluginDescriptor").get()
+                                as org.graalvm.build.maven.GeneratePluginDescriptor
+                        println("EMBEDDED_MAVEN_JAVA=" + descriptor.javaLauncher.get().metadata.languageVersion)
                     }
                 }
                 """);

--- a/native-maven-plugin/build-plugins/src/test/java/org/graalvm/build/maven/MavenRepositorySeedTaskTest.java
+++ b/native-maven-plugin/build-plugins/src/test/java/org/graalvm/build/maven/MavenRepositorySeedTaskTest.java
@@ -79,6 +79,8 @@ class MavenRepositorySeedTaskTest {
                     id 'org.graalvm.build.maven-embedder'
                 }
 
+                java.toolchain.languageVersion = JavaLanguageVersion.of(17)
+
                 def seed = tasks.register('seed', SeedMavenRepository) {
                     dependsOn(tasks.classes)
                     projectDirectory.set(layout.projectDirectory.dir('seed-project'))
@@ -87,7 +89,16 @@ class MavenRepositorySeedTaskTest {
                     mavenEmbedderClasspath.from(sourceSets.main.output)
                     outputDirectory.set(layout.buildDirectory.dir('seed'))
                     seedProperties.put('key', providers.gradleProperty('key').orElse('current'))
-                    arguments.set(providers.gradleProperty('fail').map { ['-Dfail=true'] }.orElse([]))
+                    arguments.set(providers.gradleProperty('failure').map { ['-Dfailure=' + it] }.orElse([]))
+                }
+
+                def embeddedJavaVersion = providers.gradleProperty('embeddedJavaVersion')
+                if (embeddedJavaVersion.present) {
+                    seed.configure {
+                        javaLauncher.set(javaToolchains.launcherFor {
+                            languageVersion.set(JavaLanguageVersion.of(embeddedJavaVersion.get().toInteger()))
+                        })
+                    }
                 }
 
                 tasks.register('validateSeed', ValidateMavenRepositorySeed, seed.get())
@@ -103,19 +114,36 @@ class MavenRepositorySeedTaskTest {
 
                 import java.nio.file.Files;
                 import java.nio.file.Path;
+                import java.util.Arrays;
 
                 public class MavenCli {
                     public static void main(String[] args) throws Exception {
+                        Path repository = null;
                         for (String argument : args) {
-                            if ("-Dfail=true".equals(argument)) {
-                                System.exit(1);
-                            }
                             if (argument.startsWith("-Dmaven.repo.local=")) {
-                                Path repository = Path.of(argument.substring("-Dmaven.repo.local=".length()));
+                                repository = Path.of(argument.substring("-Dmaven.repo.local=".length()));
                                 Files.createDirectories(repository);
-                                Files.writeString(repository.resolve("artifact.jar"), "complete");
                             }
                         }
+                        System.err.println("ARGUMENTS=" + Arrays.toString(args));
+                        System.err.println("FAKE_JAVA_VERSION=" + System.getProperty("java.version"));
+                        if (Arrays.asList(args).contains("-Dfailure=resolution")) {
+                            for (int index = 0; index < 2; index++) {
+                                System.err.println("[ERROR] Could not transfer artifact com.example:missing:pom:1.0 from/to private-repo (https://user:secret@example.test:8443/maven/releases?token=hidden#fragment): Connect timed out");
+                                System.err.println("resolver-stack-line");
+                                System.err.println("WARNING: sun.misc.Unsafe support is unavailable");
+                            }
+                            System.exit(1);
+                        }
+                        if (Arrays.asList(args).contains("-Dfailure=generic")) {
+                            System.err.println("[ERROR] Earlier failure detail");
+                            System.err.println("[ERROR] Build configuration is invalid.");
+                            System.err.println("[ERROR] -> [Help 1]");
+                            System.exit(1);
+                        }
+                        Files.writeString(repository.resolve("artifact.jar"), "complete");
+                        Files.writeString(repository.resolve("arguments.txt"), String.join("\\n", args));
+                        Files.writeString(repository.resolve("java-version.txt"), System.getProperty("java.version"));
                     }
                 }
                 """);
@@ -129,7 +157,7 @@ class MavenRepositorySeedTaskTest {
         byte[] artifactBefore = Files.readAllBytes(artifact);
         byte[] manifestBefore = Files.readAllBytes(manifest);
 
-        runner("seed", "-Pfail=true", "--rerun-tasks").buildAndFail();
+        runner("seed", "-Pfailure=generic", "--rerun-tasks").buildAndFail();
 
         assertArrayEquals(artifactBefore, Files.readAllBytes(artifact));
         assertArrayEquals(manifestBefore, Files.readAllBytes(manifest));
@@ -166,6 +194,77 @@ class MavenRepositorySeedTaskTest {
         BuildResult missing = runner("validateSeed").buildAndFail();
         assertTrue(missing.getOutput().contains(MavenRepositorySeedState.INVALID_SEED_MESSAGE));
         assertFalse(Files.exists(repository));
+    }
+
+    @Test
+    void normalExecutionUsesJava17WithoutVerboseMavenFlags() throws IOException {
+        BuildResult result = runner("seed").build();
+
+        String arguments = Files.readString(repository.resolve("arguments.txt"));
+        assertFalse(arguments.contains("--errors"));
+        assertFalse(arguments.contains("--debug"));
+        assertFalse(arguments.contains("-U"));
+        assertTrue(Files.readString(repository.resolve("java-version.txt")).startsWith("17"));
+        assertFalse(result.getOutput().contains("FAKE_JAVA_VERSION"));
+    }
+
+    @Test
+    void normalResolutionFailureIsSummarizedOnceAndSanitized() {
+        BuildResult result = runner("seed", "-Pfailure=resolution").buildAndFail();
+
+        String output = result.getOutput();
+        String summary = "Embedded Maven could not resolve artifact com.example:missing:pom:1.0 from repository "
+                + "private-repo (https://example.test:8443/maven/releases).";
+        assertEquals(1, occurrences(output, summary));
+        assertFalse(output.contains("user:secret"));
+        assertFalse(output.contains("token=hidden"));
+        assertFalse(output.contains("resolver-stack-line"));
+        assertFalse(output.contains("sun.misc.Unsafe"));
+    }
+
+    @Test
+    void infoAndDebugReplayMavenOutputAndEnableTheirDetailFlags() {
+        BuildResult info = runner("seed", "-Pfailure=generic", "--info").buildAndFail();
+        assertTrue(info.getOutput().contains("ARGUMENTS=[--errors,"));
+        assertFalse(info.getOutput().contains("ARGUMENTS=[--errors, --debug,"));
+        assertTrue(info.getOutput().contains("Earlier failure detail"));
+
+        BuildResult debug = runner("seed", "-Pfailure=generic", "--debug").buildAndFail();
+        assertTrue(debug.getOutput().contains("ARGUMENTS=[--errors, --debug,"));
+        assertTrue(debug.getOutput().contains("Earlier failure detail"));
+    }
+
+    @Test
+    void unrelatedFailureUsesTheFinalMeaningfulMavenError() {
+        BuildResult result = runner("seed", "-Pfailure=generic").buildAndFail();
+
+        assertTrue(result.getOutput().contains("Embedded Maven failed: Build configuration is invalid."));
+        assertFalse(result.getOutput().contains("Earlier failure detail"));
+        assertFalse(result.getOutput().contains("[Help 1]"));
+    }
+
+    @Test
+    void launcherMetadataParticipatesInSeedValidity() throws IOException {
+        runner("seed").build();
+        byte[] manifestForJava17 = Files.readAllBytes(repository.resolve(MavenRepositorySeedState.MANIFEST_NAME));
+
+        BuildResult refreshed = runner("seed", "-PembeddedJavaVersion=25").build();
+
+        assertEquals(TaskOutcome.SUCCESS, refreshed.task(":seed").getOutcome());
+        assertTrue(Files.readString(repository.resolve("java-version.txt")).startsWith("25"));
+        assertFalse(java.util.Arrays.equals(
+                manifestForJava17,
+                Files.readAllBytes(repository.resolve(MavenRepositorySeedState.MANIFEST_NAME))));
+    }
+
+    private static int occurrences(String text, String expected) {
+        int count = 0;
+        int offset = 0;
+        while ((offset = text.indexOf(expected, offset)) >= 0) {
+            count++;
+            offset += expected.length();
+        }
+        return count;
     }
 
     private GradleRunner runner(String... arguments) {

--- a/native-maven-plugin/build.gradle.kts
+++ b/native-maven-plugin/build.gradle.kts
@@ -129,7 +129,6 @@ val prepareMavenLocalRepo = tasks.register<SeedMavenRepository>("prepareMavenLoc
     pomFile.set(seedingDir.map { it.file("pom.xml") })
     mavenEmbedderClasspath.from(configurations.mavenEmbedder)
     outputDirectory.set(localRepositoryDir)
-    updateSnapshots.set(true)
     seedProperties.put("junit.jupiter.version", libs.versions.junitJupiter)
     seedProperties.put("native.maven.plugin.version", libs.versions.nativeBuildTools)
     seedProperties.put("junit.platform.native.version", libs.versions.nativeBuildTools)

--- a/native-maven-plugin/docs/e2e.md
+++ b/native-maven-plugin/docs/e2e.md
@@ -96,9 +96,22 @@ sample project would, rather than reaching into compiled classes directly.
 
 Online `prepareMavenLocalRepo` builds a replacement seed in staging and publishes it only after
 Maven succeeds. Its seed-state manifest keys the prepared seeding project, Maven settings,
-embedder classpath, goals, flags, supplied version/system-property values, and seed schema. The
-manifest inventories every stable repository file by relative path and content hash; transient
-locks, temporary downloads, and resolver-status files are excluded.
+embedder classpath, goals, flags, supplied version/system-property values, the explicit Java 17
+launcher, and seed schema. The fresh staging repository follows Maven's normal remote snapshot
+policy rather than requesting unconditional snapshot updates. The manifest inventories every
+stable repository file by relative path and content hash; transient locks, temporary downloads,
+and resolver-status files are excluded.
+
+Repository-internal Maven executions use the Gradle toolchain-provided Java 17 launcher regardless
+of the runtime that launched Gradle or the separately selected functional-test JVM. Ordinary
+execution captures Maven's routine streams, omits Maven error stacks, and reports one actionable
+Gradle failure. A dependency-resolution failure identifies the first unresolved artifact and
+repository, sanitizing repository URLs by removing credentials, query values, and fragments; an
+unclassified failure reports the final meaningful Maven error. Gradle `--info` replays the captured
+Maven output and enables Maven error detail, while Gradle `--debug` additionally enables Maven debug
+output. Descriptor generation uses an isolated task-local Maven repository and clears failed-transfer
+markers before execution so stale negative cache entries cannot require snapshot refreshes. These
+launcher and effective argument inputs participate in seed validity.
 
 Offline descriptor and functional-test prerequisites validate that manifest without invoking
 Maven or modifying the repository. Validation requires the current input key and the complete


### PR DESCRIPTION
## What changed

Embedded Maven runs used by descriptor generation and Maven repository seeding now use a reproducible Java 17 launcher and concise default diagnostics. Routine runs no longer force Maven error stacks or snapshot updates, and dependency failures are reduced to one actionable summary instead of replaying repeated resolver output.

## Why

This keeps normal Gradle output readable and prevents embedded Maven behavior from changing with the JDK that launched Gradle. Maintainers can still obtain the complete Maven diagnostics through Gradle `--info` and `--debug` when investigating a failure.

## Example

At the default log level, an unavailable dependency is reported once with its coordinates and sanitized repository identity, followed by guidance to rerun with `--info` or `--debug`. With `--info`, the captured Maven output is replayed and Maven error details are enabled; with `--debug`, Maven debug output is enabled as well.

## Implementation summary

- Added bounded Maven output capture, resolver classification, URL sanitization, and concise fallback rendering.
- Configured all repository-internal `MavenTask` executions with the Gradle toolchain's Java 17 launcher.
- Removed unconditional `--errors` and `-U`, and included launcher metadata in seed validity inputs.
- Preserved staged/atomic seed behavior, including failed-refresh preservation, and added focused regression coverage for output, launcher wiring, and seed validity.

## Validation

- `grund check`
- `grund fmt . --marker --cross-refs --check`
- `git diff --check`
- `./gradlew -p native-maven-plugin/build-plugins test --tests org.graalvm.build.maven.MavenOutputTest --tests org.graalvm.build.maven.MavenRepositorySeedTaskTest --tests org.graalvm.build.maven.MavenPluginConventionTest --rerun-tasks` — 15 tests passed
- `./gradlew :native-maven-plugin:generatePluginDescriptor :native-maven-plugin:prepareMavenLocalRepo --rerun-tasks`
- `./gradlew :native-maven-plugin:validateMavenLocalRepo --offline`
- `./gradlew -p native-maven-plugin/build-plugins check --rerun-tasks`
- `./gradlew :native-maven-plugin:test :native-maven-plugin:inspections`

The full native functional suite, repository-wide `./gradlew build`, exact Maven CI matrix, and documentation rendering were not rerun. Real dependency-resolution failure behavior used controlled fixtures because no deterministic network-failure reproducer is available.

Fixes #986

## AI workflow

Generated by [Rhei](https://github.com/vjovanov/rhei)’s `github-issue-fix` workflow using 8 completed AI-assisted steps, 3 resolved models, and 1 focused review cycle.

<details>
<summary>View AI workflow details</summary>

Approved proposal: `38c2224cc58e013d`

1. Issue intake — reviewed issue 986, repository rules, specifications, and routing to establish the accepted scope.

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium
Tokens: 944375 total · 930457 input (850816 cached) · 13918 output

2. Implementation — implemented concise embedded Maven diagnostics, Java 17 launcher wiring, seed-input tracking, and regression coverage.

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium
Tokens: 11502723 total · 11487780 input (11290368 cached) · 14943 output

3. Validation — ran focused build-logic, descriptor, seed, plugin, Maven module, grounding, and formatting checks and recorded validation gaps.

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium
Tokens: 2102495 total · 2088725 input (1984000 cached) · 13770 output

4. Requirements review (cycle 1) — checked the implementation against issue acceptance criteria and found no requirements blockers.

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium
Tokens: 206456 total · 203763 input (165504 cached) · 2693 output

5. Spec review (cycle 1) — checked the changed specifications and citations against repository grounding rules and found no spec blockers.

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium
Tokens: 347229 total · 343070 input (291584 cached) · 4159 output

6. Implementation review (cycle 1) — reviewed the diff and behavior against the approved proposal and found no implementation blockers.

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium
Tokens: 419086 total · 414416 input (375296 cached) · 4670 output

7. Validation review (cycle 1) — independently checked validation evidence and confirmed there were no validation blockers.

Model: openai:gpt-5.6-terra · Agent: codex · Reasoning effort: medium
Tokens: 183364 total · 179956 input (145024 cached) · 3408 output

8. Aggregate review (cycle 1) — consolidated requirements, specification, implementation, and validation results and marked the change ready to publish.

Model: openai:gpt-5.6-sol · Agent: codex · Reasoning effort: medium
Tokens: 103066 total · 101617 input (79744 cached) · 1449 output

9. PR publication — committed the approved implementation, pushed `rhei/issue-986` to `graalvm`, and opened or updated the ready-for-review pull request.

Model: openai:gpt-5.6-luna · Agent: codex · Reasoning effort: medium
Tokens: not finalized at PR creation

**Aggregate token usage:** 15808794 total · 15749784 input (15182336 cached) · 59010 output

The aggregate excludes the current unfinalized publication step. Focused review cycles: 1. Review-repair cycles: 0. Accounting coverage: 8 measured completed invocations. Superseded attempts: 0. Unmeasured attempts: 0. Unsupported cache dimensions: output cached-read and output cache-write.

</details>
