### PR TITLE
Optional LayerConfiguration

### DIFF
--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
@@ -70,7 +70,7 @@ import java.util.Set;
         requiresDependencyResolution = ResolutionScope.RUNTIME,
         requiresDependencyCollection = ResolutionScope.RUNTIME)
 public class LayerCreateMojo extends AbstractNativeImageMojo {
-    @Parameter(required = true)
+    @Parameter(required = false)
     private LayerConfiguration layer;
 
     @Component

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
@@ -92,7 +92,12 @@ public class LayerCreateMojo extends AbstractNativeImageMojo {
 
     @Override
     protected void executeInternal() throws MojoExecutionException {
-        if (layer == null || layer.getName() == null || layer.getName().isBlank()) {
+        // Skip if no layers are defined
+        if(layer == null){
+            return;
+        }
+        
+        if (layer.getName() == null || layer.getName().isBlank()) {
             throw new MojoExecutionException("The layer-create goal requires a non-blank layer name");
         }
         try {


### PR DESCRIPTION
Fixes: https://github.com/graalvm/native-build-tools/issues/1031

(This is only a suggested change, please cherry-pick and push / close this PR if it is ok)

I saw that there is only an exception when the layer goal is executed, so maybe revert the changes in `executeInternal`