### PR TITLE
Layers DSL follow-up: configuration-cache and test cleanup

### DIFF
--- a/native-gradle-plugin/docs/e2e.md
+++ b/native-gradle-plugin/docs/e2e.md
@@ -95,6 +95,8 @@ or Native Image invocation, add or update a functional test in the closest scena
 Configuration-cache functional tests validate that Gradle-specific task and provider wiring works
 with Gradle's configuration-cache model. They protect [§REQ-gradle-model](requirements.md#req-gradle-model-the-gradle-plugin-preserves-gradle-model-compatibility)
 and the architecture boundaries in [§AR-gradle-plugin.2](architecture.md#2-extension-and-option-model) and [§AR-gradle-plugin.3](architecture.md#3-task-graph-architecture).
+They cover both named-layer consumers and ordinary native tasks with no declared layers so the
+layer DSL cannot leak project model objects into otherwise unrelated task state. [§FS-plugin-model.2](functional/plugin-model.md#2-extension-surface).
 
 Run the configuration-cache suite with the task exposed by the Gradle functional-testing
 convention, or let CI run the generated matrix from [§root/AR-repository-ci.1.3](../../docs/spec/architecture/ci.md#13-gradle-plugin-pr-workflow).

--- a/native-gradle-plugin/docs/functional/plugin-model.md
+++ b/native-gradle-plugin/docs/functional/plugin-model.md
@@ -69,7 +69,9 @@ name to the same selection set. A consuming binary may select each logical name 
 plugin resolves provider-backed names lazily and fails duplicate-name validation before any
 selected producer task executes. This layer model must not introduce avoidable project or task
 container serialization; general configuration-cache compatibility remains governed by the
-plugin's existing configuration-cache baseline.
+plugin's existing configuration-cache baseline. Binaries that select no named layers retain no
+reference to the layer container, its callbacks, or the project model; selected layers reach tasks
+only through normalized names, output-file providers, and file collections.
 
 `fromConfiguration(...)` and `all` include resolved external and project dependencies. Dependency
 selectors also accept Gradle providers, including version-catalog accessors.

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -46,6 +46,7 @@ import org.graalvm.buildtools.gradle.fixtures.GraalVMSupport
 import org.graalvm.buildtools.utils.NativeImageUtils
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
+import spock.lang.Issue
 import spock.lang.Requires
 import spock.util.concurrent.PollingConditions
 
@@ -77,6 +78,7 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
         outputContains "Builds the dependencies Native Image layer."
     }
 
+    @Issue("https://github.com/graalvm/native-build-tools/issues/1027")
     def "native tasks without layers reuse the configuration cache"() {
         given:
         withSample("java-application")
@@ -131,6 +133,7 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
         errorOutputContains "Layer 'empty' has no contents"
     }
 
+    @Issue("https://github.com/graalvm/native-build-tools/issues/1033")
     def "rejects duplicate provider layer selections before the producer runs"() {
         given:
         withSample("layered-java-application")

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -134,8 +134,9 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
     def "rejects duplicate provider layer selections before the producer runs"() {
         given:
         withSample("layered-java-application")
+        buildFile.text = buildFile.text.replace('\r\n', '\n').replace('\n', '\r\n')
         // Replace the sample's happy-path consumer so this test isolates direct/provider duplicates. §FS-plugin-model.2.
-        buildFile.text = buildFile.text.replace('''        main {
+        replaceBuildFile('''        main {
             usesLayer('dependencies')
         }
 ''', '''        main {
@@ -310,7 +311,7 @@ public class Application {
                 implementation("org.slf4j:slf4j-api:2.0.17")
             }
         '''.stripIndent()
-        buildFile.text = buildFile.text.replace('''                modules("java.base")
+        replaceBuildFile('''                modules("java.base")
 ''', '''                packages("org.slf4j")
 ''')
         buildFile << '''
@@ -340,7 +341,7 @@ public class Application {
 
         given:
         withSample("layered-java-application")
-        buildFile.text = buildFile.text.replace('''                modules("java.base")
+        replaceBuildFile('''                modules("java.base")
 ''', '''                all = true
 ''')
         buildFile << '''
@@ -374,7 +375,7 @@ public class Application {
                 implementation("org.apache.commons:commons-lang3:3.17.0")
             }
         '''.stripIndent()
-        buildFile.text = buildFile.text.replace('''                modules("java.base")
+        replaceBuildFile('''                modules("java.base")
 ''', '''                modules("java.base")
                 from(configurations.runtimeClasspath)
 ''')
@@ -624,5 +625,11 @@ public class Application {
                 }
             }
         }
+    }
+
+    private void replaceBuildFile(String expected, String replacement) {
+        String normalized = buildFile.text.replace('\r\n', '\n')
+        assert normalized.contains(expected): "Expected layered application fixture text was not found:\n${expected}"
+        buildFile.text = normalized.replace(expected, replacement)
     }
 }

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/LayeredApplicationFunctionalTest.groovy
@@ -77,6 +77,46 @@ class LayeredApplicationFunctionalTest extends AbstractFunctionalTest {
         outputContains "Builds the dependencies Native Image layer."
     }
 
+    def "native tasks without layers reuse the configuration cache"() {
+        given:
+        withSample("java-application")
+        buildFile << '''
+            // Keep the compile task in the graph without invoking Native Image. §FS-plugin-model.2.
+            tasks.named("nativeCompile") {
+                enabled = false
+            }
+        '''.stripIndent()
+
+        when:
+        runAndReloadConfigurationCache 'nativeCompile', 'generateResourcesConfigFile'
+        if (hasConfigurationCache) {
+            // TestKit creates its exploded plugin classpath during the first pair of builds.
+            // Run once more after that input stabilizes to verify an actual cache reuse.
+            runAndReloadConfigurationCache 'nativeCompile', 'generateResourcesConfigFile'
+        }
+
+        then:
+        if (hasConfigurationCache) {
+            configurationCacheStoreTasks {
+                upToDate ':generateResourcesConfigFile'
+                skipped ':nativeCompile'
+                doesNotContain ':nativeDependenciesLayer'
+            }
+            tasks {
+                upToDate ':generateResourcesConfigFile'
+                skipped ':nativeCompile'
+                doesNotContain ':nativeDependenciesLayer'
+            }
+            outputContains 'Reusing configuration cache.'
+        } else {
+            tasks {
+                succeeded ':generateResourcesConfigFile'
+                skipped ':nativeCompile'
+                doesNotContain ':nativeDependenciesLayer'
+            }
+        }
+    }
+
     def "rejects an empty named layer before invoking Native Image"() {
         given:
         withSample("layered-java-application")

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java
@@ -57,6 +57,7 @@ import org.graalvm.buildtools.gradle.internal.GraalVMLogger;
 import org.graalvm.buildtools.gradle.internal.GraalVMReachabilityMetadataService;
 import org.graalvm.buildtools.gradle.internal.GradleUtils;
 import org.graalvm.buildtools.gradle.internal.NativeImageExecutableLocator;
+import org.graalvm.buildtools.gradle.internal.NativeImageLayerRegistry;
 import org.graalvm.buildtools.gradle.internal.agent.AgentConfigurationFactory;
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask;
 import org.graalvm.buildtools.gradle.tasks.CollectReachabilityMetadata;
@@ -200,6 +201,7 @@ public class NativeImagePlugin implements Plugin<Project> {
     private static final String NATIVE_IMAGE_OPTIONS_ENV = "NATIVE_IMAGE_OPTIONS";
 
     private GraalVMLogger logger;
+    private transient NativeImageLayerRegistry layerRegistry;
 
     // Exposed detection provider for test binaries (to be used by follow-up tasks)
     private Provider<Boolean> compatModeEnabled;
@@ -580,7 +582,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                 project.getObjects(),
                 project.getProviders(),
                 project.getExtensions().findByType(JavaToolchainService.class),
-                graalExtension.getLayers(),
+                layerRegistry,
                 "lib" + layer.getName()
             );
             CreateLayerOptions create = project.getObjects().newInstance(CreateLayerOptions.class);
@@ -910,10 +912,14 @@ public class NativeImagePlugin implements Plugin<Project> {
     }
 
     private GraalVMExtension registerGraalVMExtension(Project project) {
+        layerRegistry = new NativeImageLayerRegistry(project.getObjects());
         NamedDomainObjectContainer<NativeImageLayer> layers = project.getObjects()
             .domainObjectContainer(NativeImageLayer.class, name -> {
                 NativeImageLayerArguments.validateLayerName(name);
-                return project.getObjects().newInstance(NativeImageLayer.class, name, project.getObjects(), project);
+                NativeImageLayer layer = project.getObjects().newInstance(
+                    NativeImageLayer.class, name, project.getObjects(), project, layerRegistry);
+                layerRegistry.register(layer);
+                return layer;
             });
         NamedDomainObjectContainer<NativeImageOptions> nativeImages = project.getObjects()
             .domainObjectContainer(NativeImageOptions.class, name ->
@@ -922,7 +928,7 @@ public class NativeImagePlugin implements Plugin<Project> {
                     project.getObjects(),
                     project.getProviders(),
                     project.getExtensions().findByType(JavaToolchainService.class),
-                    layers,
+                    layerRegistry,
                     project.getName())
             );
         GraalVMExtension graalvmNative = project.getExtensions().create(GraalVMExtension.class, "graalvmNative",

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageLayer.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/NativeImageLayer.java
@@ -48,10 +48,10 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
+import org.graalvm.buildtools.gradle.internal.NativeImageLayerRegistry;
 import org.graalvm.buildtools.utils.NativeImageLayerArguments;
 
 import javax.inject.Inject;
@@ -64,17 +64,17 @@ import java.util.Set;
 public abstract class NativeImageLayer implements Named {
     private final String name;
     private final LayerContents contents;
-    private final Project project;
+    private final transient NativeImageLayerRegistry layerRegistry;
     private final ConfigurableFileCollection layerFiles;
     private final ConfigurableFileCollection inheritedCompatibilityClasspath;
     private final ConfigurableFileCollection compatibilityClasspath;
     private final Set<String> configuredLayerNames = new HashSet<>();
 
     @Inject
-    public NativeImageLayer(String name, ObjectFactory objects, Project project) {
+    public NativeImageLayer(String name, ObjectFactory objects, Project project, NativeImageLayerRegistry layerRegistry) {
         this.name = name;
         this.contents = objects.newInstance(LayerContents.class, project);
-        this.project = project;
+        this.layerRegistry = layerRegistry;
         this.layerFiles = project.files();
         this.inheritedCompatibilityClasspath = project.files();
         this.compatibilityClasspath = project.files();
@@ -114,12 +114,9 @@ public abstract class NativeImageLayer implements Named {
             throw new IllegalArgumentException("Layer '" + name + "' is selected more than once");
         }
         getUseLayerNames().add(name);
-        Provider<NativeImageLayer> layer = project.provider(() -> project.getExtensions()
-            .getByType(GraalVMExtension.class)
-            .getLayers()
-            .getByName(name));
-        layerFiles.from(layer.flatMap(NativeImageLayer::getOutputFile));
-        inheritedCompatibilityClasspath.from(layer.map(NativeImageLayer::getCompatibilityClasspath));
+        NativeImageLayerRegistry.LayerReference reference = layerRegistry.reference(name);
+        layerFiles.from(reference.getOutputFile());
+        inheritedCompatibilityClasspath.from(reference.getCompatibilityClasspath());
     }
 
     @Internal

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/BaseNativeImageOptions.java
@@ -53,7 +53,6 @@ import org.graalvm.buildtools.utils.SharedConstants;
 import org.graalvm.buildtools.utils.NativeImageLayerArguments;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
-import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.ProjectLayout;
@@ -94,13 +93,13 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
     private static final GraalVMLogger LOGGER = GraalVMLogger.of(Logging.getLogger(BaseNativeImageOptions.class));
     private final DomainObjectSet<LayerOptions> layers;
     private final ConfigurableFileCollection layerCompatibilityClasspath;
-    private NativeImageLayer assignedLayer;
+    private transient NativeImageLayer assignedLayer;
 
     private final String name;
     private final transient TaskContainer tasks;
     private final ObjectFactory objects;
     private final ProviderFactory providers;
-    private final NamedDomainObjectContainer<NativeImageLayer> namedLayers;
+    private final transient NativeImageLayerRegistry layerRegistry;
 
     @Override
     @Internal
@@ -267,7 +266,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
                                   ProviderFactory providers,
                                   JavaToolchainService toolchains,
                                   TaskContainer tasks,
-                                  NamedDomainObjectContainer<NativeImageLayer> namedLayers,
+                                  NativeImageLayerRegistry layerRegistry,
                                   String defaultImageName) {
         this.name = name;
         getDebug().convention(false);
@@ -295,7 +294,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         this.tasks = tasks;
         this.objects = objectFactory;
         this.providers = providers;
-        this.namedLayers = namedLayers;
+        this.layerRegistry = layerRegistry;
     }
 
     private static Provider<Boolean> property(ProviderFactory providers, String name) {
@@ -458,8 +457,7 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
     public void useLayer(NativeImageLayer layer) {
         // Typed layer consumption records the producing layer output on the binary. §FS-plugin-model.2.
         addLayerName(layer.getName());
-        getLayerFiles().from(layer.getOutputFile());
-        layerCompatibilityClasspath.from(layer.getCompatibilityClasspath());
+        addLayerReference(layerRegistry.reference(layer.getName()));
     }
 
     @Override
@@ -472,12 +470,10 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
 
     @Override
     public void usesLayer(String name) {
-        // Resolve the container only when Gradle queries the binary, allowing layers to be declared later. §FS-plugin-model.2.
+        // Resolve normalized properties without retaining the layer container in task state. §FS-plugin-model.2.
         NativeImageLayerArguments.validateLayerName(name);
-        Provider<NativeImageLayer> layer = providers.provider(() -> namedLayers.getByName(name));
         addLayerName(name);
-        getLayerFiles().from(layer.flatMap(NativeImageLayer::getOutputFile));
-        layerCompatibilityClasspath.from(layer.map(NativeImageLayer::getCompatibilityClasspath));
+        addLayerReference(layerRegistry.reference(name));
     }
 
     @Override
@@ -490,8 +486,14 @@ public abstract class BaseNativeImageOptions implements NativeImageOptions {
         // Singular property assignment replaces any prior layer selection. §FS-plugin-model.2.
         assignedLayer = layer;
         getLayerNames().set(List.of(layer.getName()));
-        getLayerFiles().setFrom(layer.getOutputFile());
-        layerCompatibilityClasspath.setFrom(layer.getCompatibilityClasspath());
+        NativeImageLayerRegistry.LayerReference reference = layerRegistry.reference(layer.getName());
+        getLayerFiles().setFrom(reference.getOutputFile());
+        layerCompatibilityClasspath.setFrom(reference.getCompatibilityClasspath());
+    }
+
+    private void addLayerReference(NativeImageLayerRegistry.LayerReference reference) {
+        getLayerFiles().from(reference.getOutputFile());
+        layerCompatibilityClasspath.from(reference.getCompatibilityClasspath());
     }
 
     private void addLayerName(String layerName) {

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageLayerRegistry.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/NativeImageLayerRegistry.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.buildtools.gradle.internal;
+
+import org.graalvm.buildtools.gradle.dsl.NativeImageLayer;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration-time registry that normalizes named layers into task-safe properties.
+ * §FS-plugin-model.2.
+ */
+public final class NativeImageLayerRegistry {
+    private final ObjectFactory objects;
+    private final Map<String, LayerReference> references = new HashMap<>();
+
+    public NativeImageLayerRegistry(ObjectFactory objects) {
+        this.objects = objects;
+    }
+
+    public LayerReference reference(String name) {
+        return references.computeIfAbsent(name, ignored -> new LayerReference(objects));
+    }
+
+    public void register(NativeImageLayer layer) {
+        LayerReference reference = reference(layer.getName());
+        reference.getOutputFile().convention(layer.getOutputFile());
+        reference.getCompatibilityClasspath().from(layer.getCompatibilityClasspath());
+    }
+
+    public static final class LayerReference {
+        private final RegularFileProperty outputFile;
+        private final ConfigurableFileCollection compatibilityClasspath;
+
+        private LayerReference(ObjectFactory objects) {
+            this.outputFile = objects.fileProperty();
+            this.compatibilityClasspath = objects.fileCollection();
+        }
+
+        public RegularFileProperty getOutputFile() {
+            return outputFile;
+        }
+
+        public ConfigurableFileCollection getCompatibilityClasspath() {
+            return compatibilityClasspath;
+        }
+    }
+}

--- a/native-maven-plugin/docs/functional/configuration-model.md
+++ b/native-maven-plugin/docs/functional/configuration-model.md
@@ -59,13 +59,16 @@ specialized skip controls and behavior.
 
 A `layer-create` execution accepts one layer definition with a required name and neutral contents:
 `all`, module names, package names, explicit files, and selected `groupId:artifactId[:version]`
-dependencies with configurable transitivity. `includeDependencies`, when present, accepts only
-`all`; other values fail configuration instead of being ignored. Layer names accept only letters,
-digits, dots, underscores, and hyphens. Version-qualified selections must match the resolved
-root dependency exactly before including its transitive dependency trail. Normal compile goals
-accept `useLayers` entries that select project dependencies of type `nil` by coordinates. Missing,
-ambiguous, and duplicate selections fail before Native Image is invoked. Loading the plugin with
-`<extensions>true</extensions>` registers `nil` as a Maven artifact type early and is recommended
-for consistent reactor and repository resolution, although Maven builds that already preserve the
-explicit `nil` type may resolve without it.
+dependencies with configurable transitivity. The shared Maven plugin descriptor marks the layer
+parameter optional so unrelated goals and IDE plugin validation do not require `<layer>`; an
+explicit `layer-create` execution without a configured, non-blank layer name still fails.
+`includeDependencies`, when present, accepts only `all`; other values fail configuration instead
+of being ignored. Layer names accept only letters, digits, dots, underscores, and hyphens.
+Version-qualified selections must match the resolved root dependency exactly before including its
+transitive dependency trail. Normal compile goals accept `useLayers` entries that select project
+dependencies of type `nil` by coordinates. Missing, ambiguous, and duplicate selections fail
+before Native Image is invoked. Loading the plugin with `<extensions>true</extensions>` registers
+`nil` as a Maven artifact type early and is recommended for consistent reactor and repository
+resolution, although Maven builds that already preserve the explicit `nil` type may resolve
+without it.
 [§root/REQ-backwards-compatibility.2](../../../docs/spec/requirements.md#2-configuration-compatibility).

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -56,6 +56,21 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         !NativeImageUtils.isGraalVMVersionAtLeast(GraalVMSupport.getGraalVMHomeVersionString(), 25, 1)
     }
 
+    def "layer is optional in the shared Maven plugin descriptor"() {
+        given:
+        withSample("layered-maven-application")
+
+        when:
+        mvn 'help:describe',
+            "-Dplugin=org.graalvm.buildtools:native-maven-plugin:${System.getProperty('native.maven.plugin.version')}",
+            '-Dgoal=layer-create', '-Ddetail'
+
+        then:
+        buildSucceeded
+        def help = result.stdOut.replaceAll(/\u001B\[[;\d]*m/, '').replace('\r\n', '\n')
+        help =~ /(?s)\n\s+layer\s*\n\s+\(no description available\)\s*\n\s*\n\s+mainClass\s*\n/
+    }
+
     def "loads the nil artifact handler and reactor model"() {
         given:
         withSample("layered-maven-application")

--- a/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
+++ b/native-maven-plugin/src/functionalTest/groovy/org/graalvm/buildtools/maven/LayeredApplicationFunctionalTest.groovy
@@ -44,6 +44,7 @@ import org.graalvm.buildtools.utils.NativeImageUtils
 import org.graalvm.buildtools.utils.NativeImageLayerRuntime
 import spock.lang.Ignore
 import spock.lang.IgnoreIf
+import spock.lang.Issue
 import spock.lang.Requires
 
 import java.util.zip.ZipFile
@@ -56,6 +57,7 @@ class LayeredApplicationFunctionalTest extends AbstractGraalVMMavenFunctionalTes
         !NativeImageUtils.isGraalVMVersionAtLeast(GraalVMSupport.getGraalVMHomeVersionString(), 25, 1)
     }
 
+    @Issue("https://github.com/graalvm/native-build-tools/issues/1031")
     def "layer is optional in the shared Maven plugin descriptor"() {
         given:
         withSample("layered-maven-application")

--- a/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
+++ b/native-maven-plugin/src/main/java/org/graalvm/buildtools/maven/LayerCreateMojo.java
@@ -70,7 +70,8 @@ import java.util.Set;
         requiresDependencyResolution = ResolutionScope.RUNTIME,
         requiresDependencyCollection = ResolutionScope.RUNTIME)
 public class LayerCreateMojo extends AbstractNativeImageMojo {
-    @Parameter(required = true)
+    // Optional in the shared descriptor; explicit layer-create execution validates it below. §FS-config-model.7.
+    @Parameter(required = false)
     private LayerConfiguration layer;
 
     @Component

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/LayerConfigurationTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/LayerConfigurationTest.groovy
@@ -25,6 +25,18 @@ import spock.lang.Specification
 
 // Verifies Maven XML mapping for layer selection. §FS-config-model.7.
 class LayerConfigurationTest extends Specification {
+    def "layer-create still requires a configured layer"() {
+        given:
+        def mojo = new TestLayerCreateMojo()
+
+        when:
+        mojo.runExecute()
+
+        then:
+        def e = thrown(MojoExecutionException)
+        e.message == "The layer-create goal requires a non-blank layer name"
+    }
+
     def "includeDependencies all maps to the neutral all selector"() {
         given:
         def configuration = new LayerConfiguration()

--- a/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/LayerConfigurationTest.groovy
+++ b/native-maven-plugin/src/test/groovy/org/graalvm/buildtools/maven/LayerConfigurationTest.groovy
@@ -21,10 +21,12 @@ import org.apache.maven.artifact.handler.DefaultArtifactHandler
 import org.graalvm.buildtools.maven.config.LayerConfiguration
 import org.graalvm.buildtools.maven.config.LayerDependencyConfiguration
 import org.apache.maven.plugin.MojoExecutionException
+import spock.lang.Issue
 import spock.lang.Specification
 
 // Verifies Maven XML mapping for layer selection. §FS-config-model.7.
 class LayerConfigurationTest extends Specification {
+    @Issue("https://github.com/graalvm/native-build-tools/issues/1031")
     def "layer-create still requires a configured layer"() {
         given:
         def mojo = new TestLayerCreateMojo()


### PR DESCRIPTION
## Summary

- isolate named-layer lookup behind normalized Gradle properties so binaries that do not use layers retain no layer container, project, task container, or layer callbacks
- add configuration-cache coverage proving no-layer `nativeCompile` and `generateResourcesConfigFile` graphs do not see layer producer tasks
- make layered functional-test fixture replacements line-ending independent and exercise the CRLF path on every platform
- make the Maven `<layer>` parameter optional in the shared plugin descriptor while retaining the explicit `layer-create` validation failure

Fixes #1027.
Fixes #1033.
Fixes #1031.

## Follow-up from #1032

This carries forward only the accepted annotation change from #1032 (`@Parameter(required = false)`). It intentionally does not include that PR’s early return: explicitly invoking `layer-create` without a configured, non-blank layer name still fails instead of silently succeeding.

## Validation

- `grund check`
- `grund fmt . --marker --cross-refs --check`
- Gradle and Maven plugin Checkstyle
- Gradle plugin unit tests and focused layer configuration-cache functional tests
- no-layer configuration-cache regression test on Gradle 9.6.1
- CRLF fixture regression test on Gradle 9.6.1
- full layered native-image functional test with GraalVM 25.0.3, including configuration-cache reuse after changing the application
- generated Maven plugin descriptor reports `layer` as optional
- Maven unit test confirms `layer-create` without a configured layer still fails
- Maven `help:describe` functional test confirms the published descriptor does not mark `layer` required.