### PR TITLE
Enable toolchain detection by default in the Gradle plugin

### DIFF
--- a/docs/src/docs/asciidoc/changelog.adoc
+++ b/docs/src/docs/asciidoc/changelog.adoc
@@ -3,6 +3,10 @@
 
 == Release 1.1.12
 
+- Enabled Gradle toolchain detection by default. The plugin now automatically uses a Java
+  toolchain when it supplies `native-image`, transparently falling back to `GRAALVM_HOME`,
+  `JAVA_HOME`, or the Gradle JVM otherwise. Set `graalvmNative.toolchainDetection` to `false`
+  to restore the previous behavior.
 - Gradle Native Image executable discovery now distinguishes explicitly configured launchers from
   convention-selected toolchains. Toolchains without `native-image` fall back to `GRAALVM_HOME`,
   `JAVA_HOME`, or the Gradle JVM, while explicit launchers fail with an actionable diagnostic.

--- a/native-gradle-plugin/docs/functional/native-image-invocation.md
+++ b/native-gradle-plugin/docs/functional/native-image-invocation.md
@@ -5,7 +5,9 @@ process execution.
 
 ## 1. Executable discovery
 
-Compile and metadata tasks must find the `native-image` executable by probing, in order:
+Compile and metadata tasks must find the `native-image` executable by probing, in order.
+Toolchain detection is enabled by default, so users must set
+`graalvmNative.toolchainDetection` to `false` to disable it.
 
 ### 1.1. Explicit java launcher
 

--- a/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
+++ b/native-gradle-plugin/src/functionalTest/groovy/org/graalvm/buildtools/gradle/NativeImageOptionsTest.groovy
@@ -12,6 +12,31 @@ class NativeImageOptionsTest extends Specification {
     @TempDir
     Path testDirectory
 
+    @Issue("https://github.com/graalvm/native-build-tools/issues/1039")
+    def "toolchain detection is enabled by default"() {
+        when:
+        def runner = GradleRunner.create()
+                .forwardStdOutput(new PrintWriter(System.out))
+                .forwardStdError(new PrintWriter(System.err))
+                .withPluginClasspath()
+                .withProjectDir(testDirectory.toFile())
+
+        def buildFile = testDirectory.resolve("build.gradle")
+        buildFile.text = """
+            plugins {
+                id 'java'
+                id 'org.graalvm.buildtools.native'
+            }
+            
+            assert graalvmNative.toolchainDetection.get()
+        """
+
+        runner.build()
+
+        then:
+        noExceptionThrown()
+    }
+
     @Issue("https://github.com/graalvm/native-build-tools/issues/109")
     def "toolchain defaults to the current Java version"() {
         when:

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/dsl/GraalVMExtension.java
@@ -122,7 +122,7 @@ public interface GraalVMExtension {
 
     /**
      * Property driving the detection of toolchains which support building native images.
-     * The default is false.
+     * The default is true.
      *
      * @return is toolchain detection on
      */

--- a/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
+++ b/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/internal/DefaultGraalVmExtension.java
@@ -79,7 +79,7 @@ public abstract class DefaultGraalVmExtension implements GraalVMExtension {
         this.plugin = plugin;
         this.project = project;
         this.defaultJavaLauncher = project.getObjects().property(JavaLauncher.class);
-        getToolchainDetection().convention(false);
+        getToolchainDetection().convention(true);
         // Restore the public javaLauncher convention on every binary: the property resolves
         // from the default (toolchain-selected) launcher, with provenance tracked so the
         // plugin can tell convention-sourced values apart from explicit assignments.


### PR DESCRIPTION
## Summary

Sets `graalvmNative.toolchainDetection` to `true` by default in the Gradle plugin, so that a typical GraalVM setup works out of the box without requiring users to know about or explicitly enable the flag. This is safe to do now because PR #845 made toolchain discovery predictable: the plugin only uses a toolchain that actually supplies `bin/native-image` and transparently falls back to the environment chain otherwise.

## Problem

After PR #845 was merged, toolchain detection is safe and predictable. It currently still defaults to `false`, forcing users to explicitly enable it or configure `javaLauncher`. This adds unnecessary complexity for the common case where automatic detection would work correctly.

## Solution

Flip the default of `graalvmNative.toolchainDetection` from `false` to `true`. The existing discovery behavior (from PR #845) already provides the required safety guarantees:

- An explicitly configured `graalvmNative.binaries.<name>.javaLauncher` remains authoritative. If it lacks `bin/native-image`, the build fails immediately with a clear diagnostic.
- A convention-selected launcher (from toolchain detection or the Gradle JVM) is used only when it actually contains `bin/native-image`. Otherwise the plugin falls back to the environment chain (`GRAALVM_HOME` → `JAVA_HOME` → the Gradle JVM `java-home`).
- `gu install native-image` runs only on the environment-fallback path, never against a user-configured or toolchain installation.

With the default flipped to `true`, a typical GraalVM setup builds out of the box while explicit `javaLauncher` configuration and environment variables remain authoritative fallbacks.

## Test coverage

- Added a functional test `toolchain detection is enabled by default` asserting that `graalvmNative.toolchainDetection` resolves to `true` with no configuration.
- Existing `toolchain defaults to the current Java version` test continues to pass.
- The `NativeImageExecutableLocatorTest` unit tests (7 tests) covering the explicit/convention fallback contract all pass.

### Validation

Tested with GraalVM CE 25.0.2 and an actual `native-image` build. `can build a native image for a simple application` passes with the default `toolchainDetection` now enabled, along with the rest of the `JavaApplicationFunctionalTest` suite (`9` passed, `1` skipped). The only failing case, `can build a native image with PGO instrumentation`, fails with `--pgo-instrument is not a valid mainclass`; this is a pre-existing issue that reproduces identically on the unmodified `master` base and is unrelated to this change (it was verified in a clean worktree against `graalvm/native-build-tools` `master`).

Closes #1039